### PR TITLE
Fix missing aEvent in securityCheck()

### DIFF
--- a/modules/tabbarDNDObserver.js
+++ b/modules/tabbarDNDObserver.js
@@ -966,7 +966,7 @@ catch(e) {
 		var uris = this.retrieveURLsFromDataTransfer(aEvent.dataTransfer);
 		uris.forEach(function(aURI) {
 			if (aURI.indexOf(this.BOOKMARK_FOLDER) != 0)
-				this.securityCheck(aURI);
+				this.securityCheck(aURI, aEvent);
 		}, this);
 
 		var sv = this.treeStyleTab;
@@ -1029,7 +1029,7 @@ catch(e) {
 			}
 		}
 	},
-	securityCheck : function TabbarDND_securityCheck(aURI)
+	securityCheck : function TabbarDND_securityCheck(aURI, aEvent)
 	{
 		let session = this.treeStyleTab.currentDragSession;
 		let (sourceDoc = session ? session.sourceDocument : null) {


### PR DESCRIPTION
And this fix make visible another bug: securityCheck() throws for any link in Nightly:
TypeError: SecMan.checkLoadURIStr is not a function
