### PR TITLE
Use checkLoadURIStrWithPrincipal() instead of checkLoadURIStr()

### DIFF
--- a/modules/tabbarDNDObserver.js
+++ b/modules/tabbarDNDObserver.js
@@ -1040,7 +1040,12 @@ catch(e) {
 			aEvent.stopPropagation();
 			throw 'Drop of ' + aURI + ' denied: no drag session.';
 		}
-		let normalizedURI = this.treeStyleTab.makeURIFromSpec(aURI);
+		let normalizedURI;
+		try {
+			normalizedURI = this.treeStyleTab.makeURIFromSpec(aURI);
+		}
+		catch(e) {
+		}
 		if (!normalizedURI)
 			return;
 		let sourceDoc = session.sourceDocument;


### PR DESCRIPTION
Because checkLoadURIStr() are missing in Nightly.
But I don't know, how test it...

Additionally sourceURI.substr(0, 9) should be a bit faster with very long URIs.
