### PR TITLE
Modify PseudoTreeBuilder

### DIFF
--- a/modules/pseudoTreeBuilder.js
+++ b/modules/pseudoTreeBuilder.js
@@ -38,7 +38,9 @@ const EXPORTED_SYMBOLS = ['PseudoTreeBuilder'];
 const Cc = Components.classes;
 const Ci = Components.interfaces;
 
-Components.utils.import('resource://treestyletab-modules/utils.js');
+Components.utils.import('resource://gre/modules/XPCOMUtils.jsm');
+
+XPCOMUtils.defineLazyModuleGetter(this, 'TreeStyleTabUtils', 'resource://treestyletab-modules/utils.js');
 
 var PseudoTreeBuilder = {
 


### PR DESCRIPTION
I think following:
- It should not use `PseudoTreeBuilder.__proto__`.
  In this use case, we need not use `PseudoTreeBuilder.__proto__`. It can replace to calling `TreeStyleTabUtils`s methods directly. `__proto__` hack changes the code to not clearly.
