### PR TITLE
Remove TreeStyleTabUtils.ObserverService.

### DIFF
--- a/modules/browser.js
+++ b/modules/browser.js
@@ -38,6 +38,10 @@ const EXPORTED_SYMBOLS = ['TreeStyleTabBrowser'];
 const Cc = Components.classes;
 const Ci = Components.interfaces;
 
+Components.utils.import('resource://gre/modules/XPCOMUtils.jsm');
+
+XPCOMUtils.defineLazyModuleGetter(this, "Services", "resource://gre/modules/Services.jsm");
+
 Components.utils.import('resource://treestyletab-modules/window.js');
  
 function TreeStyleTabBrowser(aWindowService, aTabBrowser) 
@@ -687,11 +691,11 @@ TreeStyleTabBrowser.prototype = {
 		this.onPrefChange('extensions.treestyletab.tabbar.narrowScrollbar');
 		this.onPrefChange('extensions.treestyletab.animation.enabled');
 
-		this.ObserverService.addObserver(this, this.kTOPIC_INDENT_MODIFIED, false);
-		this.ObserverService.addObserver(this, this.kTOPIC_COLLAPSE_EXPAND_ALL, false);
-		this.ObserverService.addObserver(this, this.kTOPIC_CHANGE_TREEVIEW_AVAILABILITY, false);
-		this.ObserverService.addObserver(this, 'private-browsing-change-granted', false);
-		this.ObserverService.addObserver(this, 'lightweight-theme-styling-update', false);
+		Services.obs.addObserver(this, this.kTOPIC_INDENT_MODIFIED, false);
+		Services.obs.addObserver(this, this.kTOPIC_COLLAPSE_EXPAND_ALL, false);
+		Services.obs.addObserver(this, this.kTOPIC_CHANGE_TREEVIEW_AVAILABILITY, false);
+		Services.obs.addObserver(this, 'private-browsing-change-granted', false);
+		Services.obs.addObserver(this, 'lightweight-theme-styling-update', false);
 		this.addPrefListener(this);
 
 		// Don't init these ovservers on this point to avoid needless initializations.
@@ -2014,11 +2018,11 @@ TreeStyleTabBrowser.prototype = {
 			this.tabbarCanvas = null;
 		}
 
-		this.ObserverService.removeObserver(this, this.kTOPIC_INDENT_MODIFIED);
-		this.ObserverService.removeObserver(this, this.kTOPIC_COLLAPSE_EXPAND_ALL);
-		this.ObserverService.removeObserver(this, this.kTOPIC_CHANGE_TREEVIEW_AVAILABILITY);
-		this.ObserverService.removeObserver(this, 'private-browsing-change-granted');
-		this.ObserverService.removeObserver(this, 'lightweight-theme-styling-update');
+		Services.obs.removeObserver(this, this.kTOPIC_INDENT_MODIFIED);
+		Services.obs.removeObserver(this, this.kTOPIC_COLLAPSE_EXPAND_ALL);
+		Services.obs.removeObserver(this, this.kTOPIC_CHANGE_TREEVIEW_AVAILABILITY);
+		Services.obs.removeObserver(this, 'private-browsing-change-granted');
+		Services.obs.removeObserver(this, 'lightweight-theme-styling-update');
 		this.removePrefListener(this);
 
 		delete this.windowService;

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -276,14 +276,6 @@ var TreeStyleTabUtils = {
 	},
 	_SessionStore : null,
 
-	get ObserverService() {
-		if (!this._ObserverService) {
-			this._ObserverService = Services.obs;
-		}
-		return this._ObserverService;
-	},
-	_ObserverService : null,
-
 	get IOService() {
 		if (!this._IOService) {
 			this._IOService = Services.io;
@@ -2075,7 +2067,7 @@ var TreeStyleTabUtils = {
 	set treeViewEnabled(aValue)
 	{
 		this._treeViewEnabled = !!aValue;
-		this.ObserverService.notifyObservers(
+		Services.obs.notifyObservers(
 			window,
 			this.kTOPIC_CHANGE_TREEVIEW_AVAILABILITY,
 			this._treeViewEnabled
@@ -2705,11 +2697,11 @@ var TreeStyleTabUtils = {
 		{
 			case 'extensions.treestyletab.indent.vertical':
 				this.baseIndentVertical = value;
-				this.ObserverService.notifyObservers(null, this.kTOPIC_INDENT_MODIFIED, value);
+				Services.obs.notifyObservers(null, this.kTOPIC_INDENT_MODIFIED, value);
 				return;
 			case 'extensions.treestyletab.indent.horizontal':
 				this.baseIndentHorizontal = value;
-				this.ObserverService.notifyObservers(null, this.kTOPIC_INDENT_MODIFIED, value);
+				Services.obs.notifyObservers(null, this.kTOPIC_INDENT_MODIFIED, value);
 				return;
 
 			case 'extensions.treestyletab.tabbar.width':

--- a/modules/window.js
+++ b/modules/window.js
@@ -40,6 +40,8 @@ const Ci = Components.interfaces;
 
 Components.utils.import('resource://gre/modules/XPCOMUtils.jsm');
 
+XPCOMUtils.defineLazyModuleGetter(this, "Services", "resource://gre/modules/Services.jsm");
+
 Components.utils.import('resource://treestyletab-modules/utils.js');
 XPCOMUtils.defineLazyGetter(this, 'TreeStyleTabBrowser', function() {
 	var ns = {};
@@ -1480,7 +1482,7 @@ TreeStyleTabWindow.prototype = {
   
 	collapseExpandAllSubtree : function TSTWindow_collapseExpandAllSubtree(aCollapse) 
 	{
-		this.ObserverService.notifyObservers(
+		Services.obs.notifyObservers(
 			this.window,
 			this.kTOPIC_COLLAPSE_EXPAND_ALL,
 			(aCollapse ? 'collapse' : 'open' )


### PR DESCRIPTION
I think that this property can be replaced by calling directly `Service.obs`.
