### PR TITLE
Change TreeStyleTabUtils.prefs to simple getter

### DIFF
--- a/modules/utils.js
+++ b/modules/utils.js
@@ -57,8 +57,7 @@ const TST_PREF_PREFIX = 'extensions.treestyletab.';
 let TreeStyleTabUtils = {
 
 	get prefs () {
-		delete this.prefs;
-		return this.prefs = prefs;
+		return prefs;
 	},
 
 /* Save/Load Prefs */


### PR DESCRIPTION
I think this need not be lazy getter because this returns simple `window['piro.sakura.ne.jp'].prefs` and its doesn't rely on any context.
If we need to access `window['piro.sakura.ne.jp'].prefs` in modules, we can load it as js code module.
