### PR TITLE
Not setting '.override' pref when uninstall/diasble this addon

### DIFF
--- a/modules/base.js
+++ b/modules/base.js
@@ -498,8 +498,6 @@ var TreeStyleTabBase = {
 				let pref = restorePrefs[i];
 				let backup = prefs.getPref(pref+'.backup');
 				if (backup === null) continue;
-				// we have to set to ".override" pref, to avoid unexpectedly reset by the preference listener.
-				prefs.setPref(pref+'.override', backup);
 				// restore user preference.
 				prefs.setPref(pref, backup);
 				// clear backup pref.


### PR DESCRIPTION
After https://github.com/piroor/treestyletab/commit/c06a2d2e2aa62452b10bb2bfa3c69d06f44c2bd7,

Thinking from the comment, we need not set `*.override` pref when uninstall/disable the comment.
