### PR TITLE
Remove the setting TreeStyleTabUtils.__proto__.

### DIFF
--- a/modules/utils.js
+++ b/modules/utils.js
@@ -65,7 +65,6 @@ const TST_PREF_VERSION = 9;
 
 
 let TreeStyleTabUtils = {
-	__proto__ : TreeStyleTabConstants,
 
 	get prefs () {
 		return prefs;
@@ -115,10 +114,10 @@ let TreeStyleTabUtils = {
 				if (this.getTreePref('loadDroppedLinkToNewChildTab') !== null) {
 					this.setTreePref('dropLinksOnTab.behavior',
 						this.getTreePref('loadDroppedLinkToNewChildTab.confirm') ?
-							this.kDROPLINK_ASK :
+							TreeStyleTabConstants.kDROPLINK_ASK :
 						this.getTreePref('loadDroppedLinkToNewChildTab') ?
-							this.kDROPLINK_NEWTAB :
-							this.kDROPLINK_LOAD
+							TreeStyleTabConstants.kDROPLINK_NEWTAB :
+							TreeStyleTabConstants.kDROPLINK_LOAD
 					);
 					this.clearTreePref('loadDroppedLinkToNewChildTab.confirm');
 					this.clearTreePref('loadDroppedLinkToNewChildTab');
@@ -126,21 +125,21 @@ let TreeStyleTabUtils = {
 				if (this.getTreePref('openGroupBookmarkAsTabSubTree') !== null) {
 					let behavior = 0;
 					if (this.getTreePref('openGroupBookmarkAsTabSubTree.underParent'))
-						behavior += this.kGROUP_BOOKMARK_USE_DUMMY;
+						behavior += TreeStyleTabConstants.kGROUP_BOOKMARK_USE_DUMMY;
 					if (!this.getTreePref('openGroupBookmarkBehavior.confirm')) {
 						behavior += (
 							this.getTreePref('openGroupBookmarkAsTabSubTree') ?
-								this.kGROUP_BOOKMARK_SUBTREE :
+								TreeStyleTabConstants.kGROUP_BOOKMARK_SUBTREE :
 							this.getTreePref('browser.tabs.loadFolderAndReplace') ?
-								this.kGROUP_BOOKMARK_REPLACE :
-								this.kGROUP_BOOKMARK_SEPARATE
+								TreeStyleTabConstants.kGROUP_BOOKMARK_REPLACE :
+								TreeStyleTabConstants.kGROUP_BOOKMARK_SEPARATE
 						);
 					}
 					this.setTreePref('openGroupBookmark.behavior', behavior);
 					this.clearTreePref('openGroupBookmarkBehavior.confirm');
 					this.clearTreePref('openGroupBookmarkAsTabSubTree');
 					this.clearTreePref('openGroupBookmarkAsTabSubTree.underParent');
-					prefs.setPref('browser.tabs.loadFolderAndReplace', !!(behavior & this.kGROUP_BOOKMARK_REPLACE));
+					prefs.setPref('browser.tabs.loadFolderAndReplace', !!(behavior & TreeStyleTabConstants.kGROUP_BOOKMARK_REPLACE));
 				}
 			case 4:
 				let (prefs = [


### PR DESCRIPTION
I think, `TreeStyleTabUtils` & `TreeStyleTabConstants` need not have parent-child relationship.

piro-san, how do you think?
