### PR TITLE
Erase border that appears with TMP (#528)

### DIFF
--- a/skin/classic/treestyletab/tmp.css
+++ b/skin/classic/treestyletab/tmp.css
@@ -49,3 +49,8 @@
   .tabbrowser-tabs[treestyletab-mode="vertical"] .tab-progress {
 	margin-top: -2px;
 }
+
+:root[treestyletab-enable-compatibility-tmp="true"]
+  #tabbrowser-tabs .tabbrowser-tab:not([selected="true"]) {
+	background-image: none !important;
+}


### PR DESCRIPTION
I've checked conflict as much as possible, but I'm afraid my oversights.

note: This is due to tabmixplus/chrome/content/tab/tab.js, backgroundRule set linear-gradient to background-image.
note2: I use a rule 'not([selected="true"])', because treestyletab/skin/classic/treestyletab/sidebar/sidebar-base.css set
  background to '.tabbrowser-tab[selected="true"]'.
