### PR TITLE
Correctly update "list all tabs" menu if there is pinned tabs

### DIFF
--- a/modules/window.js
+++ b/modules/window.js
@@ -444,28 +444,10 @@ TreeStyleTabWindow.prototype = {
 		if (!utils.getTreePref('enableSubtreeIndent.allTabsPopup'))
 			return;
 
-		var items = Array.slice(aEvent.originalTarget.childNodes);
-		var firstItemIndex = 0;
-		// ignore menu items inserted by Weave (Firefox Sync), Tab Utilities, and others.
-		for (let i = 0, maxi = items.length; i < maxi; i++)
-		{
-			let item = items[i];
-			if (
-				item.getAttribute('anonid') ||
-				item.id ||
-				item.hidden ||
-				item.localName != 'menuitem'
-				)
-				firstItemIndex = i + 1;
-		}
-		items = items.slice(firstItemIndex);
-
-		var b = this.getTabBrowserFromChild(aEvent.originalTarget) || this.browser;
-		var tabs = this.getTabs(b);
-		for (let i = 0, maxi = tabs.length; i < maxi; i++)
-		{
-			items[i].style.marginLeft = tabs[i].getAttribute(this.kNEST)+'em';
-		}
+		Array.forEach(aEvent.originalTarget.childNodes, function(aItem) {
+			if (aItem.classList.contains('alltabs-item') && 'tab' in aItem)
+				aItem.style.marginLeft = aItem.tab.getAttribute(this.kNEST) + 'em';
+		}, this);
 	},
  
 	initUIShowHideObserver : function TSTWindow_initUIShowHideObserver() 


### PR DESCRIPTION
Also may be fixed using following way:

``` js
        var startPos = tabs.length - items.length; // Pinned tabs aren't displayed in menu
        for (let i = startPos, maxi = tabs.length; i < maxi; i++)
        {
            items[i - startPos].style.marginLeft = tabs[i].getAttribute(this.kNEST)+'em';
        }
```

But using of built-in `tab` property is better, I think.
