### PR TITLE
Don't show Australis tab curves with vertical tabs

### DIFF
--- a/skin/classic/treestyletab/base.css
+++ b/skin/classic/treestyletab/base.css
@@ -80,3 +80,26 @@
   .tabbrowser-arrowscrollbox .tabs-newtab-button {
 	border-style: none !important;
 }
+
+/* Don't show the tab curve with vertical tabs */
+
+.tabbrowser-tabs[treestyletab-mode="vertical"] .tab-background-end[selected=true]::after,
+.tabbrowser-tabs[treestyletab-mode="vertical"] .tab-background-end[selected=true]::before,
+.tabbrowser-tabs[treestyletab-mode="vertical"] .tab-background-start[selected=true]::after,
+.tabbrowser-tabs[treestyletab-mode="vertical"] .tab-background-start[selected=true]::before {
+  content: none;
+}
+
+.tabbrowser-tabs[treestyletab-mode="vertical"] .tabbrowser-tab:hover > .tab-stack > .tab-background:not([selected=true]) {
+  background-image: none;
+}
+
+.tabbrowser-tabs[treestyletab-mode="vertical"] .tabbrowser-tab {
+  pointer-events: auto;
+}
+
+.tabbrowser-tabs[treestyletab-mode="vertical"] .tab-background-middle {
+  -moz-border-start: none;
+  -moz-border-end: none;
+}
+


### PR DESCRIPTION
I'm not sure if this is the preferred stylesheet to make this change but this is a start to improve the UX related to the tab curve changes with Australis.
