### PR TITLE
OS X window controls overlap the nav-bar when the tabs aren't on top

### DIFF
--- a/skin/classic/treestyletab/base.css
+++ b/skin/classic/treestyletab/base.css
@@ -38,6 +38,14 @@
 	padding: 0 !important;
 }
 
+#main-window:not([treestyletab-tabbar-position="top"]) #titlebar-buttonbox {
+  -moz-appearance: none;
+}
+
+#main-window:not([treestyletab-tabbar-position="top"]) #titlebar-fullscreen-button {
+  -moz-appearance: none;
+}
+
 /* Support customizable tab bar */
 .treestyletab-tabbar-toolbar[treestyletab-mode="vertical"] > toolbarpaletteitem > toolbarbutton {
 	box-flex: 1;


### PR DESCRIPTION
1aa4e0d reduces the overlap by putting them back to their original position. I'm not sure how you want to fix the whole issue but this is a start.
