### PR TITLE
Tab close button class attribute changed with Australis causing a flood of namedNodes.close errors

### DIFF
--- a/modules/browser.js
+++ b/modules/browser.js
@@ -365,13 +365,7 @@ TreeStyleTabBrowser.prototype = {
  
 	getTabClosebox : function TSTBrowser_getTabClosebox(aTab) 
 	{
-		var d = this.document;
-		var close = ( // Tab Mix Plus
-						utils.getTreePref('compatibility.TMP') &&
-						d.getAnonymousElementByAttribute(aTab, 'class', 'tab-close-button always-right')
-					) ||
-					d.getAnonymousElementByAttribute(aTab, 'class', 'tab-close-button');
-		return close;
+		return this.document.getAnonymousElementByAttribute(aTab, 'anonid', 'close-button');
 	},
  
 	getTabTwisty : function TSTBrowser_getTabTwisty(aTab) 


### PR DESCRIPTION
We can switch to using the more stable `anonid` attribute which means we shouldn't need the TMP workaround either. This attribute isn't new with Australis so this will work in older versions.
