### PR TITLE
Change TST content area overlay element background color to white

### DIFF
--- a/content/treestyletab/treestyletab.css
+++ b/content/treestyletab/treestyletab.css
@@ -162,7 +162,7 @@ tabbrowser[treestyletab-tabbar-autohide-mode="1"][treestyletab-tabbar-autohide="
 	 * Don't make this panel completely transparent, because
 	 * mousemove event never fire on 100% transparent panel.
 	 */
-	background: rgba(0, 0, 0, 0.01);
+	background: rgba(255, 255, 255, 0.01);
 	line-height: 0;
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
Changes background color of dummy almost-transparent element spread over
Firefox content area from black to white. The near transparent element may
change website tone with inverse color. Therefore white dummy element will
affect only black websites since this commit.

Fixes #710.
