### PR TITLE
Fix nested tabs which were broken by Mozilla bug 1050447.

### DIFF
--- a/content/treestyletab/windowHelper.js
+++ b/content/treestyletab/windowHelper.js
@@ -209,7 +209,7 @@ var TreeStyleTabWindowHelper = {
 		if ('openLinkIn' in window) {
 			eval('window.openLinkIn = '+
 				window.openLinkIn.toSource().replace(
-					'browser.loadOneTab(',
+					'newTab = w.gBrowser.loadOneTab(',
 					'TreeStyleTabService.onBeforeOpenLinkWithParams(params); $&'
 				)
 			);


### PR DESCRIPTION
The signature of the code that opens new tabs changed, which
made the search / replace monkeypatch code break. This updates
treestyletabs to the new pattern.

Please see [bug 1057616](https://bugzilla.mozilla.org/show_bug.cgi?id=1057616) and [bug 1050447](https://bugzilla.mozilla.org/show_bug.cgi?id=1050447) for details.
