### PR TITLE
Fix scrolling of tabs on Firefox 36

### DIFF
--- a/modules/browser.js
+++ b/modules/browser.js
@@ -165,8 +165,11 @@ TreeStyleTabBrowser.prototype = inherit(TreeStyleTabWindow.prototype, {
 		var node = this.scrollBox;
 		if (node._scrollbox)
 			node = node._scrollbox;
-		return (node.scrollBoxObject || node.boxObject)
-				.QueryInterface(Ci.nsIScrollBoxObject); // for Tab Mix Plus (ensure scrollbox-ed)
+		var boxObject = (node.scrollBoxObject || node.boxObject);
+                try {
+			boxObject = boxObject.QueryInterface(Ci.nsIScrollBoxObject); // for Tab Mix Plus (ensure scrollbox-ed)
+                } catch (ex) { /* May not implement this interface e.g. after bug 979835 */ }
+                return boxObject;
 	},
  
 	get splitter() 

--- a/modules/lib/autoScroll.js
+++ b/modules/lib/autoScroll.js
@@ -164,8 +164,11 @@ if (typeof window == 'undefined' ||
 		getScrollBoxObject : function(aTabBrowser) 
 		{
 			var box = this.getScrollBox(aTabBrowser);
-			return (box.scrollBoxObject || box.boxObject)
-					.QueryInterface(Ci.nsIScrollBoxObject); // Tab Mix Plus
+			var boxObject = (box.scrollBoxObject || box.boxObject);
+			try {
+				boxObject = boxObject.QueryInterface(Ci.nsIScrollBoxObject); // for Tab Mix Plus (ensure scrollbox-ed)
+			} catch (ex) { /* May not implement this interface e.g. after bug 979835 */ }
+			return boxObject;
 		},
 
 		getUpButton : function(aTabBrowser)


### PR DESCRIPTION
Bug 979835 broke scrolling of tabs on Firefox 36. I tested quickly with 33.0 and Tab Mix Plus installed and scrolling seemed to work still.
