### PR TITLE
`wiew` should be `view`.

### DIFF
--- a/modules/base.js
+++ b/modules/base.js
@@ -567,7 +567,7 @@ var TreeStyleTabBase = inherit(TreeStyleTabConstants, {
 		var parent = aNode.parentNode;
 		var doc = aNode.ownerDocument || aNode;
 		var view = doc.defaultView;
-		while (parent && parent instanceof wiew.Element)
+		while (parent && parent instanceof view.Element)
 		{
 			let position = view.getComputedStyle(parent, null).getPropertyValue('position');
 			if (position != 'static')


### PR DESCRIPTION
This typo causes TST unable to reshow the tabs after FF exiting full-screen mode.
It may also be the cause of #789 ?
