### PR TITLE
Update click hook for Bug 1108555 changes

### DIFF
--- a/content/treestyletab/windowHelper.js
+++ b/content/treestyletab/windowHelper.js
@@ -200,8 +200,9 @@ var TreeStyleTabWindowHelper = {
 		TreeStyleTabUtils.doPatching(window.openLinkIn, 'window.openLinkIn', function(aName, aSource) {
 			// Bug 1050447 changed this line in Fx 34 to
 			// newTab = w.gBrowser.loadOneTab(
+			// Bug 1108555 removed newTab assignment
 			return eval(aName+' = '+aSource.replace(
-				/((b|newTab = w\.gB)rowser.loadOneTab\()/g,
+				/((b|(newTab = )?w\.gB)rowser.loadOneTab\()/g,
 				'TreeStyleTabService.onBeforeOpenLinkWithTab(gBrowser.selectedTab, aFromChrome); $1'
 			));
 		}, 'TreeStyleTab');


### PR DESCRIPTION
Commit that broke compatibility:
https://github.com/mozilla/gecko-dev/commit/3db60dbec7eda01090294f7526b7a7878abb5076#diff-1

Should be backwards compatible.