### PR TITLE
Fixed 'Always resotre tabs' typo in localization

### DIFF
--- a/locale/da-DK/treestyletab/treestyletab.properties
+++ b/locale/da-DK/treestyletab/treestyletab.properties
@@ -28,7 +28,7 @@ bookmarkDroppedTabs.bookmarkOnlyParent=Bogmærk kun hovedfanen.
 
 undoCloseTabSetBehavior.label=This tab was closed together with other %S tab(s) in a tree. Do you want them to be restored along?
 undoCloseTabSetBehavior.restoreOnce=Restore tabs
-undoCloseTabSetBehavior.restoreForever=Always resotre tabs
+undoCloseTabSetBehavior.restoreForever=Always restore tabs
 undoCloseTabSetBehavior.ignoreForever=Never show this notification
 # undoCloseTabSetBehavior.label=Vil du også gendanne følgende %S fane(r)?
 # undoCloseTabSetBehavior.never=Spørg ikke igen

--- a/locale/de-DE/treestyletab/treestyletab.properties
+++ b/locale/de-DE/treestyletab/treestyletab.properties
@@ -28,7 +28,7 @@ bookmarkDroppedTabs.bookmarkOnlyParent=Nur das gezogene Tab als Lesezeichen spei
 
 undoCloseTabSetBehavior.label=This tab was closed together with other %S tab(s) in a tree. Do you want them to be restored along?
 undoCloseTabSetBehavior.restoreOnce=Restore tabs
-undoCloseTabSetBehavior.restoreForever=Always resotre tabs
+undoCloseTabSetBehavior.restoreForever=Always restore tabs
 undoCloseTabSetBehavior.ignoreForever=Never show this notification
 # #undoCloseTabSetBehavior.title=Möchten Sie andere geschlossene Tabs auch wieder herstellen?
 # #undoCloseTabSetBehavior.text=Dieses Tab wurde gemeinsam mit %S anderen geschlossen. Wie sollen diese behandelt werden?

--- a/locale/en-US/treestyletab/treestyletab.properties
+++ b/locale/en-US/treestyletab/treestyletab.properties
@@ -28,7 +28,7 @@ bookmarkDroppedTabs.bookmarkOnlyParent=Bookmark the Parent Tab Only.
 
 undoCloseTabSetBehavior.label=This tab was closed together with other %S tab(s) in a tree. Do you want them to be restored along?
 undoCloseTabSetBehavior.restoreOnce=Restore tabs
-undoCloseTabSetBehavior.restoreForever=Always resotre tabs
+undoCloseTabSetBehavior.restoreForever=Always restore tabs
 undoCloseTabSetBehavior.ignoreForever=Never show this notification
 
 openSelectedPlaces.bookmarks=from %2$S bookmarks, including "%1$S"

--- a/locale/en-US/treestyletab/treestyletab.properties
+++ b/locale/en-US/treestyletab/treestyletab.properties
@@ -48,7 +48,7 @@ compatibility_STM_warning_title=Super Tab Mode collides with Tree Style Tab
 compatibility_STM_warning_text=New tabs opened from links (or others) don't become child of the current tab, because the position of new tabs is controlled by Super Tab Mode. Which feature do you want to be enabled?\n(*You can change those settings manually by the configuration dialog of Super Tab Mode.)
 compatibility_STM_warning_use_TST=Make tabs children of the current tab
 compatibility_STM_warning_use_STM=Put tabs to the position specified by Super Tab Mode
-compatibility_STM_warning_never=Don't show this dialo anymore.
+compatibility_STM_warning_never=Don't show this dialog anymore.
 
 
 closeTabsToTheEnd_vertical_label=Close Tabs to the Bottom

--- a/locale/es-ES/treestyletab/treestyletab.properties
+++ b/locale/es-ES/treestyletab/treestyletab.properties
@@ -28,7 +28,7 @@ bookmarkDroppedTabs.bookmarkOnlyParent=Bookmark the Parent Tab Only.
 
 undoCloseTabSetBehavior.label=This tab was closed together with other %S tab(s) in a tree. Do you want them to be restored along?
 undoCloseTabSetBehavior.restoreOnce=Restore tabs
-undoCloseTabSetBehavior.restoreForever=Always resotre tabs
+undoCloseTabSetBehavior.restoreForever=Always restore tabs
 undoCloseTabSetBehavior.ignoreForever=Never show this notification
 # #undoCloseTabSetBehavior.title=Do you want other closed tabs to be restored too?
 # #undoCloseTabSetBehavior.text=This tab was closed with other %S tab(s) together. How treat them?

--- a/locale/es-ES/treestyletab/treestyletab.properties
+++ b/locale/es-ES/treestyletab/treestyletab.properties
@@ -57,7 +57,7 @@ compatibility_STM_warning_title=Super Tab Mode collides with Tree Style Tab
 compatibility_STM_warning_text=New tabs opened from links (or others) don't become child of the current tab, because the position of new tabs is controlled by Super Tab Mode. Which feature do you want to be enabled?\n(*You can change those settings manually by the configuration dialog of Super Tab Mode.)
 compatibility_STM_warning_use_TST=Make tabs children of the current tab
 compatibility_STM_warning_use_STM=Put tabs to the position specified by Super Tab Mode
-compatibility_STM_warning_never=Don't show this dialo anymore.
+compatibility_STM_warning_never=Don't show this dialog anymore.
 
 
 closeTabsToTheEnd_vertical_label=Close Tabs to the Bottom

--- a/locale/it-IT/treestyletab/treestyletab.properties
+++ b/locale/it-IT/treestyletab/treestyletab.properties
@@ -28,7 +28,7 @@ bookmarkDroppedTabs.bookmarkOnlyParent=Bookmark the Parent Tab Only.
 
 undoCloseTabSetBehavior.label=This tab was closed together with other %S tab(s) in a tree. Do you want them to be restored along?
 undoCloseTabSetBehavior.restoreOnce=Restore tabs
-undoCloseTabSetBehavior.restoreForever=Always resotre tabs
+undoCloseTabSetBehavior.restoreForever=Always restore tabs
 undoCloseTabSetBehavior.ignoreForever=Never show this notification
 # #undoCloseTabSetBehavior.title=Do you want other closed tabs to be restored too?
 # #undoCloseTabSetBehavior.text=This tab was closed with other %S tab(s) together. How treat them?

--- a/locale/it-IT/treestyletab/treestyletab.properties
+++ b/locale/it-IT/treestyletab/treestyletab.properties
@@ -57,7 +57,7 @@ compatibility_STM_warning_title=Super Tab Mode collides with Tree Style Tab
 compatibility_STM_warning_text=New tabs opened from links (or others) don't become child of the current tab, because the position of new tabs is controlled by Super Tab Mode. Which feature do you want to be enabled?\n(*You can change those settings manually by the configuration dialog of Super Tab Mode.)
 compatibility_STM_warning_use_TST=Make tabs children of the current tab
 compatibility_STM_warning_use_STM=Put tabs to the position specified by Super Tab Mode
-compatibility_STM_warning_never=Don't show this dialo anymore.
+compatibility_STM_warning_never=Don't show this dialog anymore.
 
 
 closeTabsToTheEnd_vertical_label=Close Tabs to the Bottom

--- a/locale/pl/treestyletab/treestyletab.properties
+++ b/locale/pl/treestyletab/treestyletab.properties
@@ -28,7 +28,7 @@ bookmarkDroppedTabs.bookmarkOnlyParent=Bookmark the Parent Tab Only.
 
 undoCloseTabSetBehavior.label=This tab was closed together with other %S tab(s) in a tree. Do you want them to be restored along?
 undoCloseTabSetBehavior.restoreOnce=Restore tabs
-undoCloseTabSetBehavior.restoreForever=Always resotre tabs
+undoCloseTabSetBehavior.restoreForever=Always restore tabs
 undoCloseTabSetBehavior.ignoreForever=Never show this notification
 # #undoCloseTabSetBehavior.title=Czy chcesz przywrócić również inne zamknięte karty?
 # #undoCloseTabSetBehavior.text=Ta karta została zamknięta razem z innymi kartami: (&S). Jak je potraktować?

--- a/locale/pl/treestyletab/treestyletab.properties
+++ b/locale/pl/treestyletab/treestyletab.properties
@@ -57,7 +57,7 @@ compatibility_STM_warning_title=Super Tab Mode collides with Tree Style Tab
 compatibility_STM_warning_text=New tabs opened from links (or others) don't become child of the current tab, because the position of new tabs is controlled by Super Tab Mode. Which feature do you want to be enabled?\n(*You can change those settings manually by the configuration dialog of Super Tab Mode.)
 compatibility_STM_warning_use_TST=Make tabs children of the current tab
 compatibility_STM_warning_use_STM=Put tabs to the position specified by Super Tab Mode
-compatibility_STM_warning_never=Don't show this dialo anymore.
+compatibility_STM_warning_never=Don't show this dialog anymore.
 
 
 closeTabsToTheEnd_vertical_label=Close Tabs to the Bottom

--- a/locale/sv-SE/treestyletab/treestyletab.properties
+++ b/locale/sv-SE/treestyletab/treestyletab.properties
@@ -28,7 +28,7 @@ bookmarkDroppedTabs.bookmarkOnlyParent=Bokmärke endast för den överordnade fl
 
 undoCloseTabSetBehavior.label=This tab was closed together with other %S tab(s) in a tree. Do you want them to be restored along?
 undoCloseTabSetBehavior.restoreOnce=Restore tabs
-undoCloseTabSetBehavior.restoreForever=Always resotre tabs
+undoCloseTabSetBehavior.restoreForever=Always restore tabs
 undoCloseTabSetBehavior.ignoreForever=Never show this notification
 # undoCloseTabSetBehavior.label=Vill du att följande %S flik(ar) skall #å terställas?
 # undoCloseTabSetBehavior.never=Fråga mig inte igen

--- a/locale/zh-CN/treestyletab/treestyletab.properties
+++ b/locale/zh-CN/treestyletab/treestyletab.properties
@@ -28,7 +28,7 @@ bookmarkDroppedTabs.bookmarkOnlyParent=仅将该标签加入书签
 
 undoCloseTabSetBehavior.label=This tab was closed together with other %S tab(s) in a tree. Do you want them to be restored along?
 undoCloseTabSetBehavior.restoreOnce=Restore tabs
-undoCloseTabSetBehavior.restoreForever=Always resotre tabs
+undoCloseTabSetBehavior.restoreForever=Always restore tabs
 undoCloseTabSetBehavior.ignoreForever=Never show this notification
 # undoCloseTabSetBehavior.label=你要恢复的标签是跟其他 %S 个标签一起被关闭的，是否一并恢复？
 # undoCloseTabSetBehavior.never=以后都按此处理，不再提问

--- a/locale/zh-TW/treestyletab/treestyletab.properties
+++ b/locale/zh-TW/treestyletab/treestyletab.properties
@@ -28,7 +28,7 @@ bookmarkDroppedTabs.bookmarkOnlyParent=只加入父分頁
 
 undoCloseTabSetBehavior.label=This tab was closed together with other %S tab(s) in a tree. Do you want them to be restored along?
 undoCloseTabSetBehavior.restoreOnce=Restore tabs
-undoCloseTabSetBehavior.restoreForever=Always resotre tabs
+undoCloseTabSetBehavior.restoreForever=Always restore tabs
 undoCloseTabSetBehavior.ignoreForever=Never show this notification
 # undoCloseTabSetBehavior.label=您要一併復原以下 %S 個同時關閉的分頁嗎？
 # undoCloseTabSetBehavior.never=不要再問我，以後都照此辦理


### PR DESCRIPTION
Used find and sed to do a regex search and replace of text.

Corrects issue #839.