### PR TITLE
Don't show selected tab above other browser elements

### DIFF
--- a/skin/classic/treestyletab/metal/base.css
+++ b/skin/classic/treestyletab/metal/base.css
@@ -379,3 +379,9 @@ tabbrowser[treestyletab-tabbar-position="right"]
 	background: #e4e4e4 !important;
 	border-color: #666666 !important;
 }
+
+/* don't show tabs above other browser elements */
+.tabbrowser-tabs[treestyletab-mode="vertical"]
+  .tabbrowser-tab[selected="true"] {
+	z-index: auto;
+}

--- a/skin/classic/treestyletab/sidebar/sidebar.css
+++ b/skin/classic/treestyletab/sidebar/sidebar.css
@@ -482,3 +482,9 @@ tabbrowser[treestyletab-mode="vertical"]
   .tab-close-button {
 	visibility: visible !important;
 }
+
+/* don't show tabs above other browser elements */
+.tabbrowser-tabs[treestyletab-mode="vertical"]
+  .tabbrowser-tab[selected="true"] {
+	z-index: auto;
+}

--- a/skin/classic/treestyletab/square/base.css
+++ b/skin/classic/treestyletab/square/base.css
@@ -301,3 +301,9 @@ tabbrowser[treestyletab-style~="aero"]:not([treestyletab-tabbar-position="top"])
 	-moz-appearance: none !important;
 	background: transparent !important;
 }
+
+/* don't show tabs above other browser elements */
+.tabbrowser-tabs[treestyletab-mode="vertical"]
+  .tabbrowser-tab[selected="true"] {
+	z-index: auto;
+}


### PR DESCRIPTION
With certain skins/themes Tree Style tab has a tendency to be shown above other parts of Firefox when it should not:

![z-index error](https://camo.githubusercontent.com/d7ff0e40a859dc9af20372ac8643764a6f26ba37/68747470733a2f2f662e636c6f75642e6769746875622e636f6d2f6173736574732f3438353031322f313437373838372f33666533343139652d343636332d313165332d393132312d6361636332306639613661632e706e67)

(Thanks to @mjessome for screenshot).

One example is Vimperator. For more information see issue [#148@vimperator](https://github.com/vimperator/vimperator-labs/issues/148). In Vimperator's case it will only work as expected when 'mixed' or 'plain' is used due to this code from [`dropshadow.css#50`](https://github.com/piroor/treestyletab/blob/master/skin/classic/treestyletab/square/dropshadow.css):

	/* Transparent tabs are shown above solid tabs.
	We have to set z-index to show all tabs in the same layer. */
	.tabbrowser-tabs[treestyletab-mode="vertical"]
	.tabbrowser-tab,
	.tabbrowser-tabs[treestyletab-mode="vertical"]
	.tabbrowser-arrowscrollbox
	.tabs-newtab-button {
		position: relative;
		z-index: auto;
	}

This patch introduces the same logic to the other base skins (square/metal/sidebar), and aimes to fix #586 in Tree Style Tab. Tested on both Windows and Linux.

Note that I'm not sure if this is the best way to implement such a "fix". I tried to look through the CSS and the logic found in [`themeManager.js`](https://github.com/piroor/treestyletab/blob/master/modules/themeManager.js#L67), but it wasn't obvious how it should be resolved. 

