### PR TITLE
CSS bug fix for the Sidebar skin

### DIFF
--- a/skin/classic/treestyletab/sidebar/sidebar.css
+++ b/skin/classic/treestyletab/sidebar/sidebar.css
@@ -118,7 +118,7 @@ tabbrowser[treestyletab-mode="vertical"]
 	-moz-box-align: stretch !important;
 	height: 21px !important;     /* height including border! */
 	margin: 0 !important;
-	padding: 1px 3px 2px 10px !important;
+	padding: 1px 3px 2px 0 !important;
 	text-align: left !important;
 	-moz-border-top-colors: none !important;
 	-moz-border-bottom-colors: none !important;


### PR DESCRIPTION
By default the CSS for the Sidebar skin gives a left padding of 10px to each tab.

This conflicts with the setting of `extensions.treestyletab.indent.property` = `padding`, which is needed in order to get a native look & feel.

Here is a screenshot that shows the 10px bug. You can see that a new tab (created at level 0) looks almost as if it was a level 1 tab, but not quite (it has the wrong padding of 10px, while level 0 tabs have 0px and level 1 have 12px):

![screen shot 2015-07-09 at 21 17 20](https://cloud.githubusercontent.com/assets/48756/8605133/698c4480-2683-11e5-808e-f120776ade98.png)
