### PR TITLE
Replace mozRequestAnimationFrame with requestAnimationFrame. Fixes #915

### DIFF
--- a/modules/lib/animationManager.js
+++ b/modules/lib/animationManager.js
@@ -120,7 +120,7 @@ if (typeof window == 'undefined' ||
 					return;
 				this._animatingWindows.push(aWindow);
 				let self = this;
-				aWindow.mozRequestAnimationFrame(function() {
+				aWindow.requestAnimationFrame(function() {
 					self.processAnimationFrame(aWindow);
 				});
 			}, this);
@@ -168,7 +168,7 @@ if (typeof window == 'undefined' ||
 			this._cleanUpWindows();
 			if (this._animatingWindows.indexOf(aWindow) > -1) {
 				let self = this;
-				aWindow.mozRequestAnimationFrame(function() {
+				aWindow.requestAnimationFrame(function() {
 					self.processAnimationFrame(aWindow);
 				});
 			}


### PR DESCRIPTION
As #915 spotted, after bug 909154, `mozRequestAnimationFrame` no longer exists. Switching to the non-prefixed version fixes the problem.