### PR TITLE
Decrease top margin of audio-overlay icon

### DIFF
--- a/skin/classic/treestyletab/ui-base.css
+++ b/skin/classic/treestyletab/ui-base.css
@@ -359,7 +359,7 @@ tabbrowser[treestyletab-tabbar-position="bottom"]
 /* overlay icon */
 .tabbrowser-tabs[treestyletab-mode="vertical"]
   .tab-content[pinned="true"] > image.tab-icon-overlay {
-  margin-top: -14px !important;
+  margin-top: -8px !important;
   -moz-margin-start: -8px !important;
 }
 


### PR DESCRIPTION
This allows the audio-overlay icon for pinned tabs to appear underneath
the Firefox bookmarks/ address bars and within the bounds of a pinned
tab.

Changes were made to make it look better on Mac OS X.  It's kinda hard 
to get right for all the themes, but I found this to appear nicer overall for
issue #945.

See the following screenshots for a comparison:
-14px overlay: 
![-14px overlay](https://cloud.githubusercontent.com/assets/1098725/10263226/11ea6012-69b4-11e5-9c6a-14eacdd2405b.png)

-8px overlay:
<img width="37" alt="screen shot 2015-10-24 at 7 13 31 am" src="https://cloud.githubusercontent.com/assets/1098725/10710422/476b0dec-7a1f-11e5-9c52-1893cef3d64b.png">
<img width="39" alt="screen shot 2015-10-24 at 7 13 59 am" src="https://cloud.githubusercontent.com/assets/1098725/10710420/476a03c0-7a1f-11e5-9975-3a13a90b6381.png">
<img width="32" alt="screen shot 2015-10-24 at 7 14 09 am" src="https://cloud.githubusercontent.com/assets/1098725/10710423/476bce8a-7a1f-11e5-9de1-4b4929a8e8e0.png">
<img width="38" alt="screen shot 2015-10-24 at 7 14 25 am" src="https://cloud.githubusercontent.com/assets/1098725/10710421/476a7148-7a1f-11e5-9457-c8dc0c598a20.png">
