### PR TITLE
Fix for piroor/treestyletab#982 New Folder and Bookmark Properties

### DIFF
--- a/content/treestyletab/res/bookmarkMultipleTabs_bookmarkPropertiesOverlay.xul
+++ b/content/treestyletab/res/bookmarkMultipleTabs_bookmarkPropertiesOverlay.xul
@@ -25,7 +25,7 @@
 (function() {
 	if (!('BookmarkPropertiesPanel' in window) ||
 		!BookmarkPropertiesPanel._determineItemInfo ||
-		BookmarkPropertiesPanel._determineItemInfo.toSource().indexOf('__folderNameOverride') > -1)
+		BookmarkPropertiesPanel.__treestyletab__determineItemInfo)
 		return;
 
 	// Defined at http://mxr.mozilla.org/mozilla-central/source/browser/components/places/content/bookmarkProperties.js#73


### PR DESCRIPTION
Fix for piroor/treestyletab#982 and piroor/multipletab#101 as last commit did not fix the issue. Pull requests need to be applied to both repos for fix to work reliable.  Fixes issue where New Folder and Bookmark Properties dialogs appearing empty only both Tree Style Tabs and Multiple Tab Handler (and other extensions withbookmarkMultipleTabs_bookmarkPropertiesOverlay.xul) are enabled at the same time.
