### PR TITLE
Repair tearing off a tree of multiple tabs

### DIFF
--- a/content/treestyletab/windowHelper.js
+++ b/content/treestyletab/windowHelper.js
@@ -114,7 +114,7 @@ var TreeStyleTabWindowHelper = {
 		gBrowser.__treestyletab__swapBrowsersAndCloseOther = gBrowser.swapBrowsersAndCloseOther;
 		gBrowser.swapBrowsersAndCloseOther = function(...args) {
 			if (TreeStyleTabWindowHelper.runningDelayedStartup &&
-				TreeStyleTabService.tearOffSubtreeFromRemote())
+				TreeStyleTabService.tearOffSubtreeFromRemote(...args))
 				return;
 			return gBrowser.__treestyletab__swapBrowsersAndCloseOther.apply(this, args);
 		};

--- a/modules/window.js
+++ b/modules/window.js
@@ -1870,10 +1870,9 @@ TreeStyleTabWindow.prototype = inherit(TreeStyleTabBase, {
 	},
 	_tabFocusAllowance : [],
  
-	tearOffSubtreeFromRemote : function TSTWindow_tearOffSubtreeFromRemote() 
+	tearOffSubtreeFromRemote : function TSTWindow_tearOffSubtreeFromRemote(ourTab, remoteTab)
 	{
 		var w = this.window;
-		var remoteTab = w.arguments[0];
 		var remoteWindow  = remoteTab.ownerDocument.defaultView;
 		var remoteService = remoteWindow.TreeStyleTabService;
 		var remoteMultipleTabService = remoteWindow.MultipleTabService;


### PR DESCRIPTION
With Firefox 47 and this add-on built from f20f936a030c73b7af0981a2ce7ad2e19d654e03, the context menu item "Move to New Window" would fail for me. A new window would open, but it would only contain a blank new tab, and none of the tabs would move.

This appears to fix this issue in 47 (Nightly) for me. I also tested in 44 (Release), and it works there as well.