### PR TITLE
Add a preferences menu item to the context menu

### DIFF
--- a/content/treestyletab/treestyletab.xul
+++ b/content/treestyletab/treestyletab.xul
@@ -142,6 +142,11 @@
 			type="checkbox"
 			autocheck="false"
 			oncommand="TreeStyleTabService.toggleFixed(TreeStyleTabService.getTabBrowserFromChild(this));"/>
+		<menuseparator id="context-separator-preferences"/>
+		<menuitem id="context-item-preferences"
+			label="&context.preferences.label;"
+			accesskey="&context.preferences.accesskey;"
+			oncommand="TreeStyleTabService.showPreferences();"/>
 	</menupopup>
 	<tooltip id="treestyletab-full-tree-tooltip"/>
 	<panel id="treestyletab-autohide-content-area-screen"

--- a/defaults/preferences/treestyletab.js
+++ b/defaults/preferences/treestyletab.js
@@ -359,6 +359,7 @@ pref("extensions.treestyletab.show.context-item-collapseAllSubtree", true);
 pref("extensions.treestyletab.show.context-item-expandAllSubtree", true);
 pref("extensions.treestyletab.show.context-item-toggleAutoHide", true);
 pref("extensions.treestyletab.show.context-item-toggleFixed", true);
+pref("extensions.treestyletab.show.context-item-preferences", true);
 pref("extensions.treestyletab.show.context-item-bookmarkTabSubtree", true);
 
 /**

--- a/locale/en-US/treestyletab/treestyletab.dtd
+++ b/locale/en-US/treestyletab/treestyletab.dtd
@@ -187,6 +187,8 @@
 <!ENTITY context.toggleFixed.accesskey          "f">
 <!ENTITY context.bookmarkTabSubtree.label       "Bookmark this Tree...">
 <!ENTITY context.bookmarkTabSubtree.accesskey   "t">
+<!ENTITY context.preferences.label              "Preferences...">
+<!ENTITY context.preferences.accesskey          "e">
 
 <!ENTITY group.default "New Group">
 <!ENTITY group.temporary "Temporary Group">

--- a/modules/browser.js
+++ b/modules/browser.js
@@ -123,6 +123,8 @@ TreeStyleTabBrowser.prototype = inherit(TreeStyleTabWindow.prototype, {
 	kMENUITEM_AUTOHIDE_SEPARATOR       : 'context-separator-toggleAutoHide',
 	kMENUITEM_AUTOHIDE                 : 'context-item-toggleAutoHide',
 	kMENUITEM_FIXED                    : 'context-item-toggleFixed',
+	kMENUITEM_PREFS_SEPARATOR          : 'context-separator-preferences',
+	kMENUITEM_PREFS                    : 'context-item-preferences',
 	kMENUITEM_BOOKMARKSUBTREE          : 'context-item-bookmarkTabSubtree',
 
 	kMENUITEM_CLOSE_TABS_TO_END        : 'context_closeTabsToTheEnd',
@@ -964,6 +966,8 @@ TreeStyleTabBrowser.prototype = inherit(TreeStyleTabWindow.prototype, {
 						aSelf.kMENUITEM_AUTOHIDE_SEPARATOR,
 						aSelf.kMENUITEM_AUTOHIDE,
 						aSelf.kMENUITEM_FIXED,
+						aSelf.kMENUITEM_PREFS_SEPARATOR,
+						aSelf.kMENUITEM_PREFS,
 						aSelf.kMENUITEM_BOOKMARKSUBTREE
 					];
 				for (let i = 0, maxi = ids.length; i < maxi; i++)
@@ -5243,6 +5247,7 @@ TreeStyleTabBrowser.prototype = inherit(TreeStyleTabWindow.prototype, {
 				this.kMENUITEM_EXPAND,
 				this.kMENUITEM_AUTOHIDE,
 				this.kMENUITEM_FIXED,
+				this.kMENUITEM_PREFS,
 				this.kMENUITEM_BOOKMARKSUBTREE
 			];
 		for (let i = 0, maxi = ids.length; i < maxi; i++)

--- a/modules/window.js
+++ b/modules/window.js
@@ -1562,6 +1562,17 @@ TreeStyleTabWindow.prototype = inherit(TreeStyleTabBase, {
 	{
 		this.autoHideWindow.toggleMode(aTabBrowser || this.browser);
 	},
+
+  showPreferences: function TSTWindow_showPreferences()
+  {
+		var window = this.window;
+		var instantApply = prefs.getPref("browser.preferences.instantApply");
+		window.openDialog(
+				'chrome://treestyletab/content/config.xul',
+				'____xyz',
+				'chrome,titlebar,toolbar,resizable,centerscreen'+ (instantApply ? ',dialog=no' : '')
+		);
+  },
  
 	toggleFixed : function TSTWindow_toggleFixed(aTabBrowser) /* PUBLIC API */ 
 	{


### PR DESCRIPTION
The context menu that shows up on left clicking the tree-style-tab bar
now has a preferences button to open preferences quickly
