### PR TITLE
fix #788,add newtab-dark.css and so on.

### DIFF
--- a/modules/themeManager.js
+++ b/modules/themeManager.js
@@ -39,6 +39,9 @@ var EXPORTED_SYMBOLS = ['TreeStyleTabThemeManager'];
 const BASE = 'chrome://treestyletab/skin/';
 
 Components.utils.import('resource://treestyletab-modules/base.js');
+Components.utils.import('resource://gre/modules/XPCOMUtils.jsm');
+XPCOMUtils.defineLazyModuleGetter(this,
+  'TreeStyleTabUtils', 'resource://treestyletab-modules/utils.js');
 
 function TreeStyleTabThemeManager(aWindow)
 {
@@ -104,6 +107,9 @@ TreeStyleTabThemeManager.prototype = {
 				styles.push(BASE+'platform-styled.css');
 				break;
 		}
+
+		if(aStyle == '' && this.window.TreeStyleTabUtils.prefs.getPref('devtools.theme') == 'dark')
+			styles.push(BASE+'newtab-dark.css');
 
 		if (styles.length) {
 			this._lastStyles = styles.map(function(aStyle) {

--- a/skin/classic/treestyletab/base.css
+++ b/skin/classic/treestyletab/base.css
@@ -16,11 +16,11 @@
 	border-radius: 0;
 	-moz-border-radius: 0;
 	border-top: 1px solid ThreeDShadow !important;
-	background: -moz-dialog !important;
+	background: -moz-dialog;
 }
 .tabbrowser-tabs[treestyletab-mode="vertical"] .tabs-newtab-button:hover,
 .treestyletab-tabbar-toolbar[treestyletab-mode="vertical"] > toolbarbutton:hover {
-	background: ThreeDHighlight !important;
+	background: ThreeDHighlight ;
 }
 
 /* for Mac OS X */

--- a/skin/classic/treestyletab/newtab-dark.css
+++ b/skin/classic/treestyletab/newtab-dark.css
@@ -1,0 +1,6 @@
+.tabs-newtab-button{
+  background-color: #39424D !important
+}
+.tabs-newtab-button:hover{
+  background-color: #49427D !important
+}


### PR DESCRIPTION
新しいタブを黒っぽい色にするnewtab-dark.cssを追加し、themeManager.jsでdark themeかつskinがdisableな場合に適用するように設定しました。