### PR TITLE
Fix #788, use css variable

### DIFF
--- a/content/treestyletab/treestyletab.xul
+++ b/content/treestyletab/treestyletab.xul
@@ -3,6 +3,15 @@
 <?xml-stylesheet href="treestyletab.css" type="text/css"?>
 <?xml-stylesheet href="treestyletab-tmp.css" type="text/css"?><!-- hacks for Tab Mix Plus -->
 
+<?xml-stylesheet href="chrome://treestyletab/skin/base-colors.css" type="text/css"?>
+
+<?xml-stylesheet href="chrome://treestyletab/skin/base.css" type="text/css"?>
+<?xml-stylesheet href="chrome://treestyletab/skin/twisty/twisty.css" type="text/css"?>
+<?xml-stylesheet href="chrome://treestyletab/skin/ui.css" type="text/css"?>
+<?xml-stylesheet href="chrome://treestyletab/skin/tmp.css" type="text/css"?><!-- hacks for Tab Mix Plus -->
+<?xml-stylesheet href="chrome://treestyletab/skin/platform-base.css" type="text/css"?>
+<?xml-stylesheet href="chrome://treestyletab/skin/pseudo-tree.css" type="text/css"?>
+
 <!DOCTYPE overlay SYSTEM "chrome://treestyletab/locale/treestyletab.dtd">
 <overlay id="treestyletab-overlay"
          xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"

--- a/content/treestyletab/treestyletab.xul
+++ b/content/treestyletab/treestyletab.xul
@@ -3,13 +3,6 @@
 <?xml-stylesheet href="treestyletab.css" type="text/css"?>
 <?xml-stylesheet href="treestyletab-tmp.css" type="text/css"?><!-- hacks for Tab Mix Plus -->
 
-<?xml-stylesheet href="chrome://treestyletab/skin/base.css" type="text/css"?>
-<?xml-stylesheet href="chrome://treestyletab/skin/twisty/twisty.css" type="text/css"?>
-<?xml-stylesheet href="chrome://treestyletab/skin/ui.css" type="text/css"?>
-<?xml-stylesheet href="chrome://treestyletab/skin/tmp.css" type="text/css"?><!-- hacks for Tab Mix Plus -->
-<?xml-stylesheet href="chrome://treestyletab/skin/platform-base.css" type="text/css"?>
-<?xml-stylesheet href="chrome://treestyletab/skin/pseudo-tree.css" type="text/css"?>
-
 <!DOCTYPE overlay SYSTEM "chrome://treestyletab/locale/treestyletab.dtd">
 <overlay id="treestyletab-overlay"
          xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"

--- a/modules/themeManager.js
+++ b/modules/themeManager.js
@@ -64,6 +64,16 @@ TreeStyleTabThemeManager.prototype = {
 		this._lastStyles = null;
 
 		var styles = [];
+
+		styles.push(BASE+'base-colors.css');
+
+		styles.push('chrome://treestyletab/skin/base.css');
+		styles.push('chrome://treestyletab/skin/twisty/twisty.css');
+		styles.push('chrome://treestyletab/skin/ui.css');
+		styles.push('chrome://treestyletab/skin/tmp.css');
+		styles.push('chrome://treestyletab/skin/platform-base.css');
+		styles.push('chrome://treestyletab/skin/pseudo-tree.css');
+		
 		switch (aStyle)
 		{
 			default:

--- a/modules/themeManager.js
+++ b/modules/themeManager.js
@@ -65,15 +65,6 @@ TreeStyleTabThemeManager.prototype = {
 
 		var styles = [];
 
-		styles.push(BASE+'base-colors.css');
-
-		styles.push('chrome://treestyletab/skin/base.css');
-		styles.push('chrome://treestyletab/skin/twisty/twisty.css');
-		styles.push('chrome://treestyletab/skin/ui.css');
-		styles.push('chrome://treestyletab/skin/tmp.css');
-		styles.push('chrome://treestyletab/skin/platform-base.css');
-		styles.push('chrome://treestyletab/skin/pseudo-tree.css');
-		
 		switch (aStyle)
 		{
 			default:

--- a/skin/classic/treestyletab/base-colors.css
+++ b/skin/classic/treestyletab/base-colors.css
@@ -1,0 +1,9 @@
+:root[devtoolstheme="light"]{
+    --tabs-newtab-button-background:-moz-dialog;
+    --tabs-newtab-button-background-hover:ThreeDHighlight;
+}
+
+:root[devtoolstheme="dark"]{
+    --tabs-newtab-button-background:#39424D;
+    --tabs-newtab-button-background-hover:#49525D;
+}

--- a/skin/classic/treestyletab/base.css
+++ b/skin/classic/treestyletab/base.css
@@ -16,11 +16,11 @@
 	border-radius: 0;
 	-moz-border-radius: 0;
 	border-top: 1px solid ThreeDShadow !important;
-	background: -moz-dialog !important;
+	background: var(--tabs-newtab-button-background) !important;
 }
 .tabbrowser-tabs[treestyletab-mode="vertical"] .tabs-newtab-button:hover,
 .treestyletab-tabbar-toolbar[treestyletab-mode="vertical"] > toolbarbutton:hover {
-	background: ThreeDHighlight !important;
+	background: var(--tabs-newtab-button-background-hover) !important;
 }
 
 /* for Mac OS X */


### PR DESCRIPTION
base-colors.cssの中でdeveditonか通常かを分けているのでbase.cssより後ろをthemeManager.jsに書く必要がなくなっているのがポイントです。

お願いします。