### PR TITLE
[help] chilerenTabが取れていない

### DIFF
--- a/modules/browser.js
+++ b/modules/browser.js
@@ -7355,9 +7355,6 @@ TreeStyleTabBrowser.prototype = inherit(TreeStyleTabWindow.prototype, {
 	registerTabFocusAllowance : function TSTBrowser_registerTabFocusAllowance(...aArgs) {
 		return this._callWindowServiceMethod('registerTabFocusAllowance', aArgs);
 	},
-	isPopupShown : function TSTBrowser_isPopupShown(...aArgs) {
-		return this._callWindowServiceMethod('isPopupShown', aArgs);
-	},
 	toggleAutoHide : function TSTBrowser_toggleAutoHide(...aArgs) {
 		return this._callWindowServiceMethod('toggleAutoHide', aArgs);
 	},


### PR DESCRIPTION
#1119 のバグなんですが、クリックイベントではclick handlerからcollapseExpandSubtreeに行くことがわかって関数を追加したのはいいんですが、`collapseExpandSubtree`の引数としてaTabがいるので
`var myseletab=this.browser.selectedTab;`でaTabっぽいのを探してきて引数に入れたのですが
`collapseExpandSubtree`の内部関数`getChildTabs`の中でうまく子タブが取れてないっぽいです。
arrayとしてちゃんと子タブのlistは入ってるのに・・・

ヘルプお願いします。