### PR TITLE
Rebase skin color #1145

### DIFF
--- a/modules/window.js
+++ b/modules/window.js
@@ -95,6 +95,13 @@ function TreeStyleTabWindow(aWindow)
 	aWindow.TreeStyleTabService = this;
 
 	XPCOMUtils.defineLazyModuleGetter(aWindow, 'TreeStyleTabBrowser', 'resource://treestyletab-modules/browser.js');
+
+	var DevEdition=this.window.AppConstants.MOZ_DEV_EDITION;
+	if (DevEdition) {
+		var rootelem=this.document.documentElement;
+		rootelem.setAttribute('treestyletab-devedition', true);
+	}
+
 }
 
 TreeStyleTabWindow.prototype = inherit(TreeStyleTabBase, {

--- a/modules/window.js
+++ b/modules/window.js
@@ -96,9 +96,9 @@ function TreeStyleTabWindow(aWindow)
 
 	XPCOMUtils.defineLazyModuleGetter(aWindow, 'TreeStyleTabBrowser', 'resource://treestyletab-modules/browser.js');
 
-	var DevEdition=this.window.AppConstants.MOZ_DEV_EDITION;
+	var DevEdition = this.window.AppConstants.MOZ_DEV_EDITION;
 	if (DevEdition) {
-		var rootelem=this.document.documentElement;
+		var rootelem = this.document.documentElement;
 		rootelem.setAttribute('treestyletab-devedition', true);
 	}
 

--- a/skin/classic/treestyletab/base-colors.css
+++ b/skin/classic/treestyletab/base-colors.css
@@ -44,7 +44,7 @@
 	--tst-tab-dropmarker: -moz-dialogtext;
 }
 
-:root[devtoolstheme="dark"] {
+:root[devtoolstheme="dark"][treestyletab-devedition="true"] {
 	--tst-tab-surface: #39424D;
 	--tst-tab-text: white;
 	--tst-tab-border: #5f6670;

--- a/skin/classic/treestyletab/square/base.css
+++ b/skin/classic/treestyletab/square/base.css
@@ -15,7 +15,7 @@
 	--tst-tabbar-bg: darkgray;
 }
 
-:root[devtoolstheme="dark"] {
+:root[devtoolstheme="dark"][treestyletab-devedition="true"] {
 	--tst-tab-highlighted-base: ThreeDHighlight;
 	--tst-tab-highlighted-highlight: Highlight;
 	--tst-tab-side-border: #39424D;


### PR DESCRIPTION
devtool.themeの色にとらわれず

```
今のTSTのスタイル指定で言う、普通のカラーセット(白)が使われる条件
    Developer Edition以外で、devtools.theme=lightである
    Developer Edition以外で、devtools.theme=darkである && Mixed/Plain/Sidebar/Metalである
    Developer Edition以外で、devtools.theme=darkである && Vertigo/Defaultである
    Developer Editionで、devtools.theme=lightである && Mixed/Plain/Sidebar/Metalである 
    Developer Editionで、devtools.theme=lightである && Vertigo/Defaultである 
今のTSTのスタイル指定で言う、darkテーマ用のカラーセットが使われる条件
    Developer Editionで、devtools.theme=darkである
```
という条件になるように修正しました。

regressionなどはfirefox developer edition(49.0a2)とFirefox：47.0.1(通常リリース)で確認済みです。
どちらも正常に動きます。

よろしくお願いします。