### PR TITLE
Fix stretched buttons on Metal theme on OS X

### DIFF
--- a/skin/classic/treestyletab/metal/Darwin.css
+++ b/skin/classic/treestyletab/metal/Darwin.css
@@ -9,6 +9,12 @@
 	padding-right: 0 !important;
 }
 
+.tabbrowser-tabs[treestyletab-mode="vertical"]
+  .tabs-newtab-button
+  .toolbarbutton-icon {
+	width: auto !important;
+}
+
 .tabbrowser-strip[treestyletab-mode="vertical"] {
 	border-bottom: 0 none !important;
 }

--- a/skin/classic/treestyletab/metal/Darwin.css
+++ b/skin/classic/treestyletab/metal/Darwin.css
@@ -5,8 +5,8 @@
 .tabbrowser-tabs[treestyletab-mode="vertical"]
   .tabbrowser-tab
   .tab-close-button {
-	padding-left: 0 !important;
-	padding-right: 0 !important;
+	padding: 0 !important;
+	margin-top: -1px !important;
 }
 
 .tabbrowser-tabs[treestyletab-mode="vertical"]


### PR DESCRIPTION
Before fix:
<img width="224" alt="screen shot 2016-09-13 at 11 18 08 am" src="https://cloud.githubusercontent.com/assets/87961/18485947/d6c7541c-79a3-11e6-81ae-5dd4d6caba56.png">

After fix:
<img width="220" alt="screen shot 2016-09-13 at 11 18 19 am" src="https://cloud.githubusercontent.com/assets/87961/18485951/dabf93a4-79a3-11e6-9b32-9a07b471ec00.png">

Affects OS X, not Ubuntu.

Verified fix on ESR 45.3.0, 48.0, 50.0a2, 51.0a1