### PR TITLE
Add browser toolbar icon configuration for dark themes

### DIFF
--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -36,7 +36,24 @@
       "20": "resources/20x20-light.svg",
       "24": "resources/24x24-light.svg"
     },
-    "browser_style": true
+    "browser_style": true,
+    "theme_icons": [
+      {
+      "light": "resources/16x16-dark.svg",
+      "dark":  "resources/16x16-light.svg",
+      "size": 16
+      },
+      {
+        "light": "resources/20x20-dark.svg",
+        "dark":  "resources/20x20-light.svg",
+        "size": 20
+      },
+      {
+        "light": "resources/24x24-dark.svg",
+        "dark":  "resources/24x24-light.svg",
+        "size": 24
+      }
+    ]
   },
   "sidebar_action": {
     "default_title": "__MSG_sidebarTitle__",


### PR DESCRIPTION
Addons can have separate icons in the browser toolbar for dark and light themes.

This pull request adds theme dependent icon configuration to the browser_action property in the `manifest.json` (See [documentation](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/browser_action)).

This PR works with the default config `svg.context-properties.content.enabled=false` (relates to pull request #1558). 

Until this [ Firefox Issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1377302) is fixed, this PR can make the improve the icon visibility for dark themes.

Here are screenshots demonstrating the icon looks across different themes:
(left: FF sidebar icon, right: TST icon)

Light theme;
![light-theme](https://user-images.githubusercontent.com/5747745/33231470-33b1a01e-d1f6-11e7-913e-80b70e9444ec.png)

Dark theme:
![dark-theme](https://user-images.githubusercontent.com/5747745/33231472-37ff8bb8-d1f6-11e7-8086-ca88fd66221e.png)

Currently not working, but will be fixed as soon as #1558 is merged and FF issue is fixed:
Dark system theme (Linux, GTK) with default Firefox theme:
![default-dark-gtk](https://user-images.githubusercontent.com/5747745/33231491-6ca3f2d2-d1f6-11e7-94b4-4dd4787c2579.png)





