### PR TITLE
fix(we: themes: systemcolors): remove unnecessary rule for excluding collapsed tabs

### DIFF
--- a/webextensions/sidebar/styles/square/systemcolors.css
+++ b/webextensions/sidebar/styles/square/systemcolors.css
@@ -31,7 +31,7 @@
     /*mix-blend-mode: multiply;*/
 }
 
-.tab:not(.collapsed),
+.tab,
 .newtab-button-box {
     border-style: solid;
 }


### PR DESCRIPTION
After some time appearance of the collapsed tabs get back to normal, so that workaround is making collapsed tab thinner than others