### PR TITLE
fix(themes: highcontrast): define closebutton size explicitly

### DIFF
--- a/webextensions/sidebar/styles/square/highcontrast.css
+++ b/webextensions/sidebar/styles/square/highcontrast.css
@@ -71,6 +71,8 @@
 .tab .closebox {
   margin-top: -10px;
   padding: 3px;
+  height: 22px;
+  width: 22px;
 }
 
 .tab .closebox:hover {


### PR DESCRIPTION
sorry for spamming you :)
but i've just noticed what in some condition close button box turns from a square into a not-even rectangle, this rule should fix that