### PR TITLE
Add defer attribute to script elements

### DIFF
--- a/webextensions/background/background.html
+++ b/webextensions/background/background.html
@@ -5,31 +5,31 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script type="application/javascript" src="/common/tree/constants.js"></script>
-    <script type="application/javascript" src="/common/fake-context-menu/constants.js"></script>
-    <script type="application/javascript" src="/common/fake-context-menu/background.js"></script>
-    <script type="application/javascript" src="/common/Configs.js"></script>
-    <script type="application/javascript" src="/common/common.js"></script>
-    <script type="application/javascript" src="/common/xpath.js"></script>
-    <script type="application/javascript" src="/common/TabIdFixer.js"></script>
-    <script type="application/javascript" src="/common/TabFavIconHelper.js"></script>
-    <script type="application/javascript" src="/common/MetricsData.js"></script>
-    <script type="application/javascript" src="/common/permissions.js"></script>
-    <script type="application/javascript" src="/common/RichConfirm.js"></script>
-    <script type="application/javascript" src="/common/tree/base.js"></script>
-    <script type="application/javascript" src="/common/tree/api-tabs.js"></script>
-    <script type="application/javascript" src="/common/tree/get-tabs.js"></script>
-    <script type="application/javascript" src="/common/tree/tab-information.js"></script>
-    <script type="application/javascript" src="/common/tree/tree-operations.js"></script>
-    <script type="application/javascript" src="/common/tree/cache.js"></script>
-    <script type="application/javascript" src="/common/tree/contextual-identities.js"></script>
-    <script type="application/javascript" src="/common/tree/handlers.js"></script>
-    <script type="application/javascript" src="/common/commands.js"></script>
-    <script type="application/javascript" src="/background/background.js"></script>
-    <script type="application/javascript" src="/background/cache.js"></script>
-    <script type="application/javascript" src="/background/handlers.js"></script>
-    <script type="application/javascript" src="/background/context-menu.js"></script>
-    <script type="application/javascript" src="/background/migration.js"></script>
+    <script defer type="application/javascript" src="/common/tree/constants.js"></script>
+    <script defer type="application/javascript" src="/common/fake-context-menu/constants.js"></script>
+    <script defer type="application/javascript" src="/common/fake-context-menu/background.js"></script>
+    <script defer type="application/javascript" src="/common/Configs.js"></script>
+    <script defer type="application/javascript" src="/common/common.js"></script>
+    <script defer type="application/javascript" src="/common/xpath.js"></script>
+    <script defer type="application/javascript" src="/common/TabIdFixer.js"></script>
+    <script defer type="application/javascript" src="/common/TabFavIconHelper.js"></script>
+    <script defer type="application/javascript" src="/common/MetricsData.js"></script>
+    <script defer type="application/javascript" src="/common/permissions.js"></script>
+    <script defer type="application/javascript" src="/common/RichConfirm.js"></script>
+    <script defer type="application/javascript" src="/common/tree/base.js"></script>
+    <script defer type="application/javascript" src="/common/tree/api-tabs.js"></script>
+    <script defer type="application/javascript" src="/common/tree/get-tabs.js"></script>
+    <script defer type="application/javascript" src="/common/tree/tab-information.js"></script>
+    <script defer type="application/javascript" src="/common/tree/tree-operations.js"></script>
+    <script defer type="application/javascript" src="/common/tree/cache.js"></script>
+    <script defer type="application/javascript" src="/common/tree/contextual-identities.js"></script>
+    <script defer type="application/javascript" src="/common/tree/handlers.js"></script>
+    <script defer type="application/javascript" src="/common/commands.js"></script>
+    <script defer type="application/javascript" src="/background/background.js"></script>
+    <script defer type="application/javascript" src="/background/cache.js"></script>
+    <script defer type="application/javascript" src="/background/handlers.js"></script>
+    <script defer type="application/javascript" src="/background/context-menu.js"></script>
+    <script defer type="application/javascript" src="/background/migration.js"></script>
   </head>
   <body>
     <div id="all-tabs"></div>

--- a/webextensions/options/options.html
+++ b/webextensions/options/options.html
@@ -5,15 +5,15 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script type="application/javascript" src="/common/tree/constants.js"></script>
-    <script type="application/javascript" src="/common/Configs.js"></script>
-    <script type="application/javascript" src="/common/common.js"></script>
-    <script type="application/javascript" src="/options/Options.js"></script>
-    <script type="application/javascript" src="/common/l10n.js"></script>
-    <script type="application/javascript" src="/options/ShortcutCustomizeUI.js"></script>
-    <script type="application/javascript" src="/common/permissions.js"></script>
-    <script type="application/javascript" src="/background/migration.js"></script>
-    <script type="application/javascript" src="/options/init.js"></script>
+    <script defer type="application/javascript" src="/common/tree/constants.js"></script>
+    <script defer type="application/javascript" src="/common/Configs.js"></script>
+    <script defer type="application/javascript" src="/common/common.js"></script>
+    <script defer type="application/javascript" src="/options/Options.js"></script>
+    <script defer type="application/javascript" src="/common/l10n.js"></script>
+    <script defer type="application/javascript" src="/options/ShortcutCustomizeUI.js"></script>
+    <script defer type="application/javascript" src="/common/permissions.js"></script>
+    <script defer type="application/javascript" src="/background/migration.js"></script>
+    <script defer type="application/javascript" src="/options/init.js"></script>
     <link rel="stylesheet" type="text/css" href="options.css"/>
   </head>
   <body>

--- a/webextensions/resources/group-tab.html
+++ b/webextensions/resources/group-tab.html
@@ -124,8 +124,8 @@
 <!--
   Don't load scripts dynamically, to prevent the tab is closed by Firefox.
   See also: https://github.com/piroor/treestyletab/issues/1670#issuecomment-350964087
-<script type="application/javascript" src="/common/l10n.js"></script>
-<script type="application/javascript" src="./group-tab.js"></script>
+<script defer type="application/javascript" src="/common/l10n.js"></script>
+<script defer type="application/javascript" src="./group-tab.js"></script>
 -->
 <main>
 <header>

--- a/webextensions/resources/startup.html
+++ b/webextensions/resources/startup.html
@@ -92,12 +92,12 @@
     font-weight: bold;
   }
 </style>
-<script type="application/javascript" src="./startup.js"></script>
-<script type="application/javascript" src="/common/l10n.js"></script>
-<script type="application/javascript" src="/common/tree/constants.js"></script>
-<script type="application/javascript" src="/common/permissions.js"></script>
-<script type="application/javascript" src="/common/Configs.js"></script>
-<script type="application/javascript" src="/common/common.js"></script>
+<script defer type="application/javascript" src="./startup.js"></script>
+<script defer type="application/javascript" src="/common/l10n.js"></script>
+<script defer type="application/javascript" src="/common/tree/constants.js"></script>
+<script defer type="application/javascript" src="/common/permissions.js"></script>
+<script defer type="application/javascript" src="/common/Configs.js"></script>
+<script defer type="application/javascript" src="/common/common.js"></script>
 
 <h1 id="title">__MSG_extensionName__</h1>
 <div><img id="icon" src="24x24-light.svg" alt=""></div>

--- a/webextensions/sidebar/sidebar.html
+++ b/webextensions/sidebar/sidebar.html
@@ -5,36 +5,36 @@
 <html class="left initializing">
   <head>
     <meta charset="UTF-8">
-    <script type="application/javascript" src="/common/tree/constants.js"></script>
-    <script type="application/javascript" src="/common/MenuUI.js"></script>
-    <script type="application/javascript" src="/common/fake-context-menu/constants.js"></script>
-    <script type="application/javascript" src="/common/handle-accel-key.js"></script>
-    <script type="application/javascript" src="/common/Configs.js"></script>
-    <script type="application/javascript" src="/common/common.js"></script>
-    <script type="application/javascript" src="/common/l10n.js"></script>
-    <script type="application/javascript" src="/common/xpath.js"></script>
-    <script type="application/javascript" src="/common/TabIdFixer.js"></script>
-    <script type="application/javascript" src="/common/TabFavIconHelper.js"></script>
-    <script type="application/javascript" src="/common/permissions.js"></script>
-    <script type="application/javascript" src="/common/RichConfirm.js"></script>
-    <script type="application/javascript" src="/common/MetricsData.js"></script>
-    <script type="application/javascript" src="/common/tree/base.js"></script>
-    <script type="application/javascript" src="/common/tree/api-tabs.js"></script>
-    <script type="application/javascript" src="/common/tree/get-tabs.js"></script>
-    <script type="application/javascript" src="/common/tree/tab-information.js"></script>
-    <script type="application/javascript" src="/common/tree/tree-operations.js"></script>
-    <script type="application/javascript" src="/common/tree/cache.js"></script>
-    <script type="application/javascript" src="/common/tree/contextual-identities.js"></script>
-    <script type="application/javascript" src="/common/tree/handlers.js"></script>
-    <script type="application/javascript" src="/common/commands.js"></script>
-    <script type="application/javascript" src="/sidebar/color.js"></script>
-    <script type="application/javascript" src="/sidebar/cache.js"></script>
-    <script type="application/javascript" src="/sidebar/scroll.js"></script>
-    <script type="application/javascript" src="/sidebar/pinned-tabs.js"></script>
-    <script type="application/javascript" src="/sidebar/handlers.js"></script>
-    <script type="application/javascript" src="/sidebar/drag-and-drop.js"></script>
+    <script defer type="application/javascript" src="/common/tree/constants.js"></script>
+    <script defer type="application/javascript" src="/common/MenuUI.js"></script>
+    <script defer type="application/javascript" src="/common/fake-context-menu/constants.js"></script>
+    <script defer type="application/javascript" src="/common/handle-accel-key.js"></script>
+    <script defer type="application/javascript" src="/common/Configs.js"></script>
+    <script defer type="application/javascript" src="/common/common.js"></script>
+    <script defer type="application/javascript" src="/common/l10n.js"></script>
+    <script defer type="application/javascript" src="/common/xpath.js"></script>
+    <script defer type="application/javascript" src="/common/TabIdFixer.js"></script>
+    <script defer type="application/javascript" src="/common/TabFavIconHelper.js"></script>
+    <script defer type="application/javascript" src="/common/permissions.js"></script>
+    <script defer type="application/javascript" src="/common/RichConfirm.js"></script>
+    <script defer type="application/javascript" src="/common/MetricsData.js"></script>
+    <script defer type="application/javascript" src="/common/tree/base.js"></script>
+    <script defer type="application/javascript" src="/common/tree/api-tabs.js"></script>
+    <script defer type="application/javascript" src="/common/tree/get-tabs.js"></script>
+    <script defer type="application/javascript" src="/common/tree/tab-information.js"></script>
+    <script defer type="application/javascript" src="/common/tree/tree-operations.js"></script>
+    <script defer type="application/javascript" src="/common/tree/cache.js"></script>
+    <script defer type="application/javascript" src="/common/tree/contextual-identities.js"></script>
+    <script defer type="application/javascript" src="/common/tree/handlers.js"></script>
+    <script defer type="application/javascript" src="/common/commands.js"></script>
+    <script defer type="application/javascript" src="/sidebar/color.js"></script>
+    <script defer type="application/javascript" src="/sidebar/cache.js"></script>
+    <script defer type="application/javascript" src="/sidebar/scroll.js"></script>
+    <script defer type="application/javascript" src="/sidebar/pinned-tabs.js"></script>
+    <script defer type="application/javascript" src="/sidebar/handlers.js"></script>
+    <script defer type="application/javascript" src="/sidebar/drag-and-drop.js"></script>
     <link rel="stylesheet" type="text/css" href="/sidebar/sidebar.css"/>
-    <script type="application/javascript" src="/common/fake-context-menu/sidebar.js"></script>
+    <script defer type="application/javascript" src="/common/fake-context-menu/sidebar.js"></script>
     <link rel="stylesheet" type="text/css" href="/common/fake-context-menu/sidebar.css"/>
     <style id="size-definition" type="text/css"></style>
     <style id="contextual-identity-styling" type="text/css"></style>
@@ -135,6 +135,6 @@
       <li id="context_closeTab" class="require-context-tab"
           title="__MSG_tabContextMenu_close_label__">__MSG_tabContextMenu_close_label__</li>
     </ul>
-    <script type="application/javascript" src="/sidebar/sidebar.js"></script>
+    <script defer type="application/javascript" src="/sidebar/sidebar.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Motivation

`script[type="module"]` will be executed on when parsing html document is complete. This behavior is a similar to the one of `script[defer]`.

This means that `script[defer]` decreases a complexity to migrate to a module script from a classic script.

## See also

- [4.12.1 The script element - WHATWG HTML Standard](https://html.spec.whatwg.org/multipage/scripting.html#the-script-element)