### PR TITLE
Fix incorrect tab tracking

### DIFF
--- a/webextensions/common/tree/handlers.js
+++ b/webextensions/common/tree/handlers.js
@@ -225,17 +225,14 @@ async function onNewTabTracked(aTab) {
 
   var newTab = buildTab(aTab, { inRemote: !!gTargetWindow });
   newTab.classList.add(kTAB_STATE_OPENING);
-  // append to DOM tree to detect duplication
-  container.appendChild(newTab);
+
+  var nextTab = getAllTabs(container)[aTab.index];
+  container.insertBefore(newTab, nextTab);
 
   gCreatingTabs[aTab.id] = newTab.uniqueId;
   var uniqueId = await newTab.uniqueId;
   if (gCreatingTabs[aTab.id] === newTab.uniqueId)
     delete gCreatingTabs[aTab.id];
-
-  // move to correct position after tabs.onRemoved is processed
-  var nextTab = getAllTabs(container)[aTab.index];
-  container.insertBefore(newTab, nextTab);
 
   updateTab(newTab, aTab, {
     tab:        aTab,


### PR DESCRIPTION
Since created tabs are positioned after an await the tab order can be broken if the order is manipulated during the await time. This merge request moves the positioning code to before all awaits. This seems to fix #1709.

The [test script in #1709](https://github.com/piroor/treestyletab/issues/1709#issuecomment-358880326) doesn't break the tab order after this fix but does before. This means that the `Always open in [Container]` option in the popup for [Firefox Multi-Account Containers by Mozilla](https://addons.mozilla.org/firefox/addon/multi-account-containers/) doesn't break the tab order after this fix.

