### PR TITLE
Option to not focus on moved tabs

### DIFF
--- a/webextensions/common/common.js
+++ b/webextensions/common/common.js
@@ -225,6 +225,8 @@ configs = new Configs({
   minimumIntervalToProcessDragoverEvent: 50,
   moveDroppedTabToNewWindowForUnhandledDragEvent: true, // see also: https://github.com/piroor/treestyletab/issues/1646
   autoDiscardTabForUnexpectedFocus: false,
+  focusOnMovedTabs: true,
+  focusOnMovedTabsBetweenWindows: true,
   knownExternalAddons: [
     'multipletab@piro.sakura.ne.jp'
   ],

--- a/webextensions/common/tree/tree-operations.js
+++ b/webextensions/common/tree/tree-operations.js
@@ -1475,8 +1475,14 @@ async function performTabsDragDrop(aParams = {}) {
   else
     log('=> already placed at expected position');
 
-  browser.tabs.update(draggedTabs[0].apiTab.id, { active: true })
-    .catch(handleMissingTabError);
+  if (
+    windowId !== destinationWindowId ?
+    configs.focusOnMovedTabsBetweenWindows :
+    configs.focusOnMovedTabs
+  ) {
+    browser.tabs.update(draggedTabs[0].apiTab.id, { active: true })
+      .catch(handleMissingTabError);
+  }
   var treeStructure = getTreeStructureFromTabs(draggedTabs);
 
   var newTabs;


### PR DESCRIPTION
I wanted to address #1803. I think the best solution is to use an extension to prevent the default action for the left mouse button if the tab is dragged. I made an extension that did this and I added the code bellow but this didn't work since Tree Style Tab always selects tabs when they are moved. So I made this merge request to add an option in TST to disable that behavior.

## Example extension

`background.js`:
```JavaScript
const kTST_ID = 'treestyletab@piro.sakura.ne.jp';

async function registerToTST() {
  try {
    await browser.runtime.sendMessage(kTST_ID, {
      type: 'register-self',
      name: browser.runtime.id,
      listeningTypes: ['tab-mousedown', 'tab-mouseup'],
    });
  } catch (error) { return false; }
  return true;
}

var lastResolve = null;
function resolveAs(value) {
  if (lastResolve && typeof lastResolve === 'function') {
    lastResolve(value);
  }
  lastResolve = null;
}

var lastMessage;
browser.runtime.onMessageExternal.addListener((aMessage, aSender) => {
  if (aSender.id !== kTST_ID) {
    return;
  }
  switch (aMessage.type) {
    case 'ready':
      registerToTST(); // passive registration for secondary (or after) startup
      break;
    case 'tab-mousedown':
      if (aMessage.button !== 0) {
        return false;
      }
      return new Promise((resolve, reject) => {
        resolveAs(true);
        lastResolve = resolve;
        lastMessage = aMessage;
      });
      break;
    case 'tab-mouseup':
      if (aMessage.button !== 0) {
        return false;
      }
      let releasedWithoutMove = lastMessage && aMessage.tab.id === lastMessage.tab.id;
      resolveAs(!releasedWithoutMove);
      break;
  }
});
registerToTST(); // aggressive registration on initial installation
```

`manifest.json`:
```JSON
{
  "manifest_version": 2,
  "name": "Move unloaded tabs for Tree Style Tab",
  "version": "1.0",
  "applications": {
    "gecko": {
      "strict_min_version": "57.0"
    }
  },
  "background": {
    "scripts": [
      "background.js"
    ]
  }
}
```