### PR TITLE
Context menu item for Page Action to open settings page

### DIFF
--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -124,6 +124,7 @@
   "context_collapseAll_label": { "message": "Colla&pse All" },
   "context_expandAll_label": { "message": "E&xpand All" },
   "context_bookmarkTree_label": { "message": "&Bookmark this Tree…" },
+  "context_openSettings_label": { "message": "Tree Style Tab Settings" },
 
 
   "config_appearance_caption": { "message": "Appearance" },

--- a/webextensions/background/context-menu.js
+++ b/webextensions/background/context-menu.js
@@ -57,6 +57,12 @@ async function refreshContextMenuItems() {
       }
     }, browser.runtime);
   }
+
+  browser.contextMenus.create({
+    id: 'openSettings',
+    title: browser.i18n.getMessage(`context_openSettings_label`),
+    contexts: ['browser_action']
+  });
 }
 
 var contextMenuClickListener = (aInfo, aAPITab) => {
@@ -92,6 +98,10 @@ var contextMenuClickListener = (aInfo, aAPITab) => {
 
     case 'bookmarkTree':
       Commands.bookmarkTree(contextTab);
+      break;
+
+    case 'openSettings':
+      browser.runtime.openOptionsPage();
       break;
 
     default:


### PR DESCRIPTION
I saw that you could have context menu items for an extensions browser action. I think it would be nice to use this to provide rarely used context menu items such as one to open the extensions option page. 

This merge request adds the ability to quickly open the Tree Style Tab settings page by right clicking the extensions browser action (the button in the toolbar) and selecting the right context menu item.