### PR TITLE
Readme update - Add extension to the list of related addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Some addons provide extended behavior to TST's sidebar panel:
  * [Tree Style Tab in Separate Window](https://addons.mozilla.org/firefox/addon/tst-in-separate-window/) allows you to open the Tree Style Tab sidebar page in a new window.
  * [Auto Tab Discard](https://addons.mozilla.org/firefox/addon/auto-tab-discard/) supports the fake context menu in the Tree Style Tab sidebar.
  * [UnloadTabs](https://addons.mozilla.org/firefox/addon/unload-tabs/) supports the fake context menu in the Tree Style Tab sidebar.
+ * [Bookmark Tree for Tree Style Tab](https://addons.mozilla.org/firefox/addon/bookmark-tree-for-tst/) allows you to bookmark and restore trees.
 
 ## Similar projects
 


### PR DESCRIPTION
I made an extension to bookmark and restore trees to fix #1756. Would be nice to include it in the readme.