### PR TITLE
Change the counter color which is black

### DIFF
--- a/webextensions/sidebar/styles/base.css
+++ b/webextensions/sidebar/styles/base.css
@@ -361,6 +361,14 @@ ul {
   content: ")";
 }
 
+/* change the counter color which is black */
+.tab.discarded .counter {
+  color: var(--tone-3)!important
+}
+.tab .counter {
+  color: var(--tone-1)!important
+}
+
 
 /* closebox */
 


### PR DESCRIPTION
The counter at the right of each tab label is in black, so it is difficult to read it.
I changed the counter color to be the same as the label.