### PR TITLE
Convert background/context-menu.js into ES Module 

### DIFF
--- a/webextensions/background/background.html
+++ b/webextensions/background/background.html
@@ -29,7 +29,6 @@
     <script defer type="application/javascript" src="/background/background.js"></script>
     <script defer type="application/javascript" src="/background/cache.js"></script>
     <script defer type="application/javascript" src="/background/handlers.js"></script>
-    <script defer type="application/javascript" src="/background/context-menu.js"></script>
     <script defer type="application/javascript" src="/background/migration.js"></script>
   </head>
   <body>

--- a/webextensions/background/background.html
+++ b/webextensions/background/background.html
@@ -25,6 +25,7 @@
     <script defer type="application/javascript" src="/common/tree/contextual-identities.js"></script>
     <script defer type="application/javascript" src="/common/tree/handlers.js"></script>
     <script defer type="application/javascript" src="/common/commands.js"></script>
+    <script type="module" src="/background/module/index.js"></script>
     <script defer type="application/javascript" src="/background/background.js"></script>
     <script defer type="application/javascript" src="/background/cache.js"></script>
     <script defer type="application/javascript" src="/background/handlers.js"></script>

--- a/webextensions/background/background.js
+++ b/webextensions/background/background.js
@@ -14,7 +14,6 @@ var gExternalListenerAddons = null;
 var gMaybeTabSwitchingByShortcut = false;
 var gTabSwitchedByShortcut       = false;
 
-var gMetricsData = new MetricsData();
 gMetricsData.add('Loaded');
 
 window.addEventListener('DOMContentLoaded', init, { once: true });

--- a/webextensions/background/module/.eslintrc.js
+++ b/webextensions/background/module/.eslintrc.js
@@ -11,4 +11,10 @@ module.exports = {
   'env': {
     'browser': true,
   },
+
+  'rules': {
+    'no-undef': ['error', {
+      'typeof': true,
+    }],
+  },
 };

--- a/webextensions/background/module/.eslintrc.js
+++ b/webextensions/background/module/.eslintrc.js
@@ -1,0 +1,14 @@
+/*eslint-env commonjs*/
+/*eslint quote-props: ['error', "always"] */
+
+'use strict';
+
+module.exports = {
+  'parserOptions': {
+    'sourceType': 'module',
+  },
+
+  'env': {
+    'browser': true,
+  },
+};

--- a/webextensions/background/module/context-menu.js
+++ b/webextensions/background/module/context-menu.js
@@ -5,6 +5,18 @@
 */
 'use strict';
 
+// Defined in a classic script source, and we can read these as global variables. 
+/* global
+  tabContextMenu: false,
+  kTSTAPI_CONTEXT_MENU_REMOVE_ALL: false,
+  kTSTAPI_CONTEXT_MENU_CREATE: false,
+  getTabById: false,
+  log: false,
+  Commands: false,
+  configs: false,
+ */
+
+
 var gContextMenuItems = `
   reloadTree
   reloadDescendants
@@ -19,7 +31,7 @@ var gContextMenuItems = `
   bookmarkTree
 `.trim().split(/\s+/);
 
-async function refreshContextMenuItems() {
+export async function refreshContextMenuItems() {
   browser.contextMenus.removeAll();
   tabContextMenu.onExternalMessage({
     type: kTSTAPI_CONTEXT_MENU_REMOVE_ALL
@@ -59,7 +71,7 @@ async function refreshContextMenuItems() {
   }
 }
 
-var contextMenuClickListener = (aInfo, aAPITab) => {
+export var contextMenuClickListener = (aInfo, aAPITab) => {
   log('context menu item clicked: ', aInfo, aAPITab);
 
   var contextTab = getTabById(aAPITab);

--- a/webextensions/background/module/index.js
+++ b/webextensions/background/module/index.js
@@ -1,4 +1,10 @@
+import {
+  refreshContextMenuItems,
+  contextMenuClickListener,
+} from './context-menu.js';
 import { gMetricsData } from './metrics.js';
 
 // Set to the global to make compatibility with other classic sources.
 window.gMetricsData = gMetricsData;
+window.refreshContextMenuItems = refreshContextMenuItems;
+window.contextMenuClickListener = contextMenuClickListener;

--- a/webextensions/background/module/index.js
+++ b/webextensions/background/module/index.js
@@ -1,0 +1,4 @@
+import { gMetricsData } from './metrics.js';
+
+// Set to the global to make compatibility with other classic sources.
+window.gMetricsData = gMetricsData;

--- a/webextensions/background/module/metrics.js
+++ b/webextensions/background/module/metrics.js
@@ -1,0 +1,5 @@
+// Defined in a classic script source, and we can read these as global variables. 
+/* global
+  MetricsData: false,
+ */
+export const gMetricsData = new MetricsData();


### PR DESCRIPTION
This pull requests contains these changes:

1. Allow to add es module style file to background module.
2. Enable `no-undef` rule for them.
3. Try to split `gMetricsData` into own module.
4. Convert background/context-menu.js into ES Module.