### PR TITLE
Share the ESLint configuration for ES Module 

### DIFF
--- a/webextensions/.eslintrc.js
+++ b/webextensions/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
   },
 
   'env': {
+    'browser': true,
     'webextensions': true,
   },
 

--- a/webextensions/background/module/.eslintrc.js
+++ b/webextensions/background/module/.eslintrc.js
@@ -4,13 +4,7 @@
 'use strict';
 
 module.exports = {
-  'parserOptions': {
-    'sourceType': 'module',
-  },
-
-  'rules': {
-    'no-undef': ['error', {
-      'typeof': true,
-    }],
-  },
+  'extends': [
+    '../../tools/eslint/for-module.js',
+  ],
 };

--- a/webextensions/background/module/.eslintrc.js
+++ b/webextensions/background/module/.eslintrc.js
@@ -8,10 +8,6 @@ module.exports = {
     'sourceType': 'module',
   },
 
-  'env': {
-    'browser': true,
-  },
-
   'rules': {
     'no-undef': ['error', {
       'typeof': true,

--- a/webextensions/common/module/.eslintrc.js
+++ b/webextensions/common/module/.eslintrc.js
@@ -4,13 +4,7 @@
 'use strict';
 
 module.exports = {
-  'parserOptions': {
-    'sourceType': 'module',
-  },
-
-  'rules': {
-    'no-undef': ['error', {
-      'typeof': true,
-    }],
-  },
+  'extends': [
+    '../../tools/eslint/for-module.js',
+  ],
 };

--- a/webextensions/common/module/.eslintrc.js
+++ b/webextensions/common/module/.eslintrc.js
@@ -8,10 +8,6 @@ module.exports = {
     'sourceType': 'module',
   },
 
-  'env': {
-    'browser': true,
-  },
-
   'rules': {
     'no-undef': ['error', {
       'typeof': true,

--- a/webextensions/options/module/.eslintrc.js
+++ b/webextensions/options/module/.eslintrc.js
@@ -4,13 +4,7 @@
 'use strict';
 
 module.exports = {
-  'parserOptions': {
-    'sourceType': 'module',
-  },
-
-  'rules': {
-    'no-undef': ['error', {
-      'typeof': true,
-    }],
-  },
+  'extends': [
+    '../../tools/eslint/for-module.js',
+  ],
 };

--- a/webextensions/options/module/.eslintrc.js
+++ b/webextensions/options/module/.eslintrc.js
@@ -8,10 +8,6 @@ module.exports = {
     'sourceType': 'module',
   },
 
-  'env': {
-    'browser': true,
-  },
-
   'rules': {
     'no-undef': ['error', {
       'typeof': true,

--- a/webextensions/resources/module/.eslintrc.js
+++ b/webextensions/resources/module/.eslintrc.js
@@ -4,13 +4,7 @@
 'use strict';
 
 module.exports = {
-  'parserOptions': {
-    'sourceType': 'module',
-  },
-
-  'rules': {
-    'no-undef': ['error', {
-      'typeof': true,
-    }],
-  },
+  'extends': [
+    '../../tools/eslint/for-module.js',
+  ],
 };

--- a/webextensions/resources/module/.eslintrc.js
+++ b/webextensions/resources/module/.eslintrc.js
@@ -8,10 +8,6 @@ module.exports = {
     'sourceType': 'module',
   },
 
-  'env': {
-    'browser': true,
-  },
-
   'rules': {
     'no-undef': ['error', {
       'typeof': true,

--- a/webextensions/sidebar/module/.eslintrc.js
+++ b/webextensions/sidebar/module/.eslintrc.js
@@ -4,13 +4,7 @@
 'use strict';
 
 module.exports = {
-  'parserOptions': {
-    'sourceType': 'module',
-  },
-
-  'rules': {
-    'no-undef': ['error', {
-      'typeof': true,
-    }],
-  },
+  'extends': [
+    '../../tools/eslint/for-module.js',
+  ],
 };

--- a/webextensions/sidebar/module/.eslintrc.js
+++ b/webextensions/sidebar/module/.eslintrc.js
@@ -8,10 +8,6 @@ module.exports = {
     'sourceType': 'module',
   },
 
-  'env': {
-    'browser': true,
-  },
-
   'rules': {
     'no-undef': ['error', {
       'typeof': true,

--- a/webextensions/tools/eslint/for-module.js
+++ b/webextensions/tools/eslint/for-module.js
@@ -1,0 +1,16 @@
+/*eslint-env commonjs*/
+/*eslint quote-props: ['error', "always"] */
+
+'use strict';
+
+module.exports = {
+  'parserOptions': {
+    'sourceType': 'module',
+  },
+
+  'rules': {
+    'no-undef': ['error', {
+      'typeof': true,
+    }],
+  },
+};


### PR DESCRIPTION
For the future, if we add a new rule applying only for ES Module, we should modify only `tools/eslint/for-module.js` by this change.