### PR TITLE
Enable ESLint rules detecting unused variables for ES Module files

### DIFF
--- a/webextensions/.eslintrc.js
+++ b/webextensions/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
   },
 
   'env': {
+    'browser': true,
     'webextensions': true,
   },
 

--- a/webextensions/background/module/.eslintrc.js
+++ b/webextensions/background/module/.eslintrc.js
@@ -4,13 +4,7 @@
 'use strict';
 
 module.exports = {
-  'parserOptions': {
-    'sourceType': 'module',
-  },
-
-  'rules': {
-    'no-undef': ['error', {
-      'typeof': true,
-    }],
-  },
+  'extends': [
+    '../../tools/eslint/for-module.js',
+  ],
 };

--- a/webextensions/background/module/.eslintrc.js
+++ b/webextensions/background/module/.eslintrc.js
@@ -8,10 +8,6 @@ module.exports = {
     'sourceType': 'module',
   },
 
-  'env': {
-    'browser': true,
-  },
-
   'rules': {
     'no-undef': ['error', {
       'typeof': true,

--- a/webextensions/background/module/context-menu.js
+++ b/webextensions/background/module/context-menu.js
@@ -75,7 +75,6 @@ export var contextMenuClickListener = (aInfo, aAPITab) => {
   log('context menu item clicked: ', aInfo, aAPITab);
 
   var contextTab = getTabById(aAPITab);
-  var container  = contextTab.parentNode;
 
   switch (aInfo.menuItemId) {
     case 'reloadTree':

--- a/webextensions/common/module/.eslintrc.js
+++ b/webextensions/common/module/.eslintrc.js
@@ -4,13 +4,7 @@
 'use strict';
 
 module.exports = {
-  'parserOptions': {
-    'sourceType': 'module',
-  },
-
-  'rules': {
-    'no-undef': ['error', {
-      'typeof': true,
-    }],
-  },
+  'extends': [
+    '../../tools/eslint/for-module.js',
+  ],
 };

--- a/webextensions/common/module/.eslintrc.js
+++ b/webextensions/common/module/.eslintrc.js
@@ -8,10 +8,6 @@ module.exports = {
     'sourceType': 'module',
   },
 
-  'env': {
-    'browser': true,
-  },
-
   'rules': {
     'no-undef': ['error', {
       'typeof': true,

--- a/webextensions/options/module/.eslintrc.js
+++ b/webextensions/options/module/.eslintrc.js
@@ -4,13 +4,7 @@
 'use strict';
 
 module.exports = {
-  'parserOptions': {
-    'sourceType': 'module',
-  },
-
-  'rules': {
-    'no-undef': ['error', {
-      'typeof': true,
-    }],
-  },
+  'extends': [
+    '../../tools/eslint/for-module.js',
+  ],
 };

--- a/webextensions/options/module/.eslintrc.js
+++ b/webextensions/options/module/.eslintrc.js
@@ -8,10 +8,6 @@ module.exports = {
     'sourceType': 'module',
   },
 
-  'env': {
-    'browser': true,
-  },
-
   'rules': {
     'no-undef': ['error', {
       'typeof': true,

--- a/webextensions/resources/module/.eslintrc.js
+++ b/webextensions/resources/module/.eslintrc.js
@@ -4,13 +4,7 @@
 'use strict';
 
 module.exports = {
-  'parserOptions': {
-    'sourceType': 'module',
-  },
-
-  'rules': {
-    'no-undef': ['error', {
-      'typeof': true,
-    }],
-  },
+  'extends': [
+    '../../tools/eslint/for-module.js',
+  ],
 };

--- a/webextensions/resources/module/.eslintrc.js
+++ b/webextensions/resources/module/.eslintrc.js
@@ -8,10 +8,6 @@ module.exports = {
     'sourceType': 'module',
   },
 
-  'env': {
-    'browser': true,
-  },
-
   'rules': {
     'no-undef': ['error', {
       'typeof': true,

--- a/webextensions/sidebar/module/.eslintrc.js
+++ b/webextensions/sidebar/module/.eslintrc.js
@@ -4,13 +4,7 @@
 'use strict';
 
 module.exports = {
-  'parserOptions': {
-    'sourceType': 'module',
-  },
-
-  'rules': {
-    'no-undef': ['error', {
-      'typeof': true,
-    }],
-  },
+  'extends': [
+    '../../tools/eslint/for-module.js',
+  ],
 };

--- a/webextensions/sidebar/module/.eslintrc.js
+++ b/webextensions/sidebar/module/.eslintrc.js
@@ -8,10 +8,6 @@ module.exports = {
     'sourceType': 'module',
   },
 
-  'env': {
-    'browser': true,
-  },
-
   'rules': {
     'no-undef': ['error', {
       'typeof': true,

--- a/webextensions/tools/eslint/for-module.js
+++ b/webextensions/tools/eslint/for-module.js
@@ -9,6 +9,8 @@ module.exports = {
   },
 
   'rules': {
+    'no-unused-expressions': 'error',
+
     'no-undef': ['error', {
       'typeof': true,
     }],

--- a/webextensions/tools/eslint/for-module.js
+++ b/webextensions/tools/eslint/for-module.js
@@ -1,0 +1,16 @@
+/*eslint-env commonjs*/
+/*eslint quote-props: ['error', "always"] */
+
+'use strict';
+
+module.exports = {
+  'parserOptions': {
+    'sourceType': 'module',
+  },
+
+  'rules': {
+    'no-undef': ['error', {
+      'typeof': true,
+    }],
+  },
+};

--- a/webextensions/tools/eslint/for-module.js
+++ b/webextensions/tools/eslint/for-module.js
@@ -15,5 +15,10 @@ module.exports = {
     'no-undef': ['error', {
       'typeof': true,
     }],
+
+    'no-use-before-define': ['error', { // the measure for Temporary Dead Zone
+      'functions': false, //  Function declarations are hoisted.
+      'classes': true, // Class declarations are not hoisted. We should warn it.
+    }],
   },
 };

--- a/webextensions/tools/eslint/for-module.js
+++ b/webextensions/tools/eslint/for-module.js
@@ -15,7 +15,13 @@ module.exports = {
     'no-undef': ['error', {
       'typeof': true,
     }],
-
+    'no-unused-vars': ['warn', { // Not make an error for debugging.
+      'vars': 'all',
+      'args': 'after-used',
+      'argsIgnorePattern': '^_',
+      'caughtErrors': 'all',
+      'caughtErrorsIgnorePattern': '^_', // Allow `catch (_e) {...}`
+    }],
     'no-use-before-define': ['error', { // the measure for Temporary Dead Zone
       'functions': false, //  Function declarations are hoisted.
       'classes': true, // Class declarations are not hoisted. We should warn it.

--- a/webextensions/tools/eslint/for-module.js
+++ b/webextensions/tools/eslint/for-module.js
@@ -10,6 +10,7 @@ module.exports = {
 
   'rules': {
     'no-unused-expressions': 'error',
+    'no-unused-labels': 'error',
 
     'no-undef': ['error', {
       'typeof': true,


### PR DESCRIPTION
* This depends on https://github.com/piroor/treestyletab/pull/1932
* By this change, we can detect unused variables.
   * Under ES Module, we should/can clarify where a variable defines. Introducing this is easier.