### PR TITLE
Enable import/no-absolute-path to disallow using absolute path to import an ES Module

### DIFF
--- a/webextensions/tools/eslint/for-module.js
+++ b/webextensions/tools/eslint/for-module.js
@@ -41,6 +41,10 @@ module.exports = {
     'import/default': 'error',
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/namespace.md
     'import/namespace': 'error',
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-absolute-path.md
+    'import/no-absolute-path': ['warn', {
+      'esmodule': true,
+    }],
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md
     'import/no-duplicates': 'error',
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/export.md


### PR DESCRIPTION
This enables [import/no-absolute-path]( https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-absolute-path.md).

By this change, ESLint enforce us to use a relative path.

Now, we use a relative path to empower ESLint's static analysis without setting eslint-plugin-import's _resolver_. So I think we can enable this rule to ensure that ESLint can always empower us to development easily.