### PR TITLE
Copy external libraries into external/ 

### DIFF
--- a/webextensions/.eslintignore
+++ b/webextensions/.eslintignore
@@ -10,3 +10,6 @@ options/ShortcutCustomizeUI.js
 
 # include as a lint target.
 !.eslintrc.js
+
+# The Makefile will copy external libraries into this directory
+external/

--- a/webextensions/.eslintignore
+++ b/webextensions/.eslintignore
@@ -1,13 +1,3 @@
-# from external
-common/TabIdFixer.js
-common/TabFavIconHelper.js
-common/Configs.js
-common/l10n.js
-common/RichConfirm.js
-common/MenuUI.js
-options/Options.js
-options/ShortcutCustomizeUI.js
-
 # include as a lint target.
 !.eslintrc.js
 

--- a/webextensions/.gitignore
+++ b/webextensions/.gitignore
@@ -1,12 +1,4 @@
 *.xpi
-**/TabIdFixer.js
-**/TabFavIconHelper.js
-**/Configs.js
-**/Options.js
-**/l10n.js
-**/MenuUI.js
-**/RichConfirm.js
-**/ShortcutCustomizeUI.js
 external/
 
 # node.js dependency

--- a/webextensions/.gitignore
+++ b/webextensions/.gitignore
@@ -7,6 +7,7 @@
 **/MenuUI.js
 **/RichConfirm.js
 **/ShortcutCustomizeUI.js
+external/
 
 # node.js dependency
 node_modules/

--- a/webextensions/Makefile
+++ b/webextensions/Makefile
@@ -1,6 +1,10 @@
 NPM_MOD_DIR := $(CURDIR)/node_modules
 NPM_BIN_DIR := $(NPM_MOD_DIR)/.bin
 
+EXTERNAL_LIB_DIR := $(CURDIR)/common
+EXTERNAL_OPTION_LIB_DIR := $(CURDIR)/options
+EXTERNAL_RESOURCES_LIB_DIR := $(CURDIR)/resources
+
 .PHONY: xpi install_dependency lint format install_extlib
 
 all: xpi
@@ -20,15 +24,15 @@ xpi: install_extlib lint ../extlib/webextensions-lib-tab-id-fixer/TabIdFixer.js 
 
 install_extlib:
 	cd .. && git submodule update
-	cp ../extlib/webextensions-lib-tab-id-fixer/TabIdFixer.js common/; echo 'export default TabIdFixer;' >> common/TabIdFixer.js
-	cp ../extlib/webextensions-lib-tab-favicon-helper/TabFavIconHelper.js common/; echo 'export default TabFavIconHelper;' >> common/TabFavIconHelper.js
-	cp ../extlib/webextensions-lib-rich-confirm/RichConfirm.js common/; echo 'export default RichConfirm;' >> common/RichConfirm.js
-	cp ../extlib/webextensions-lib-menu-ui/MenuUI.js common/; echo 'export default MenuUI;' >> common/MenuUI.js
-	cp ../extlib/webextensions-lib-configs/Configs.js common/; echo 'export default Configs;' >> common/Configs.js
-	cp ../extlib/webextensions-lib-options/Options.js options/; echo 'export default Options;' >> options/Options.js
-	cp ../extlib/webextensions-lib-l10n/l10n.js common/; echo 'export default l10n;' >> common/l10n.js
-	cp ../extlib/webextensions-lib-l10n/l10n.js resources/
-	cp ../extlib/webextensions-lib-shortcut-customize-ui/ShortcutCustomizeUI.js options/; echo 'export default ShortcutCustomizeUI;' >> options/ShortcutCustomizeUI.js
+	cp ../extlib/webextensions-lib-tab-id-fixer/TabIdFixer.js $(EXTERNAL_LIB_DIR)/; echo 'export default TabIdFixer;' >> $(EXTERNAL_LIB_DIR)/TabIdFixer.js
+	cp ../extlib/webextensions-lib-tab-favicon-helper/TabFavIconHelper.js $(EXTERNAL_LIB_DIR)/; echo 'export default TabFavIconHelper;' >> $(EXTERNAL_LIB_DIR)/TabFavIconHelper.js
+	cp ../extlib/webextensions-lib-rich-confirm/RichConfirm.js $(EXTERNAL_LIB_DIR)/; echo 'export default RichConfirm;' >> $(EXTERNAL_LIB_DIR)/RichConfirm.js
+	cp ../extlib/webextensions-lib-menu-ui/MenuUI.js $(EXTERNAL_LIB_DIR)/; echo 'export default MenuUI;' >> $(EXTERNAL_LIB_DIR)/MenuUI.js
+	cp ../extlib/webextensions-lib-configs/Configs.js $(EXTERNAL_LIB_DIR)/; echo 'export default Configs;' >> $(EXTERNAL_LIB_DIR)/Configs.js
+	cp ../extlib/webextensions-lib-options/Options.js $(EXTERNAL_OPTION_LIB_DIR)/; echo 'export default Options;' >> $(EXTERNAL_OPTION_LIB_DIR)/Options.js
+	cp ../extlib/webextensions-lib-l10n/l10n.js $(EXTERNAL_LIB_DIR)/; echo 'export default l10n;' >> $(EXTERNAL_LIB_DIR)/l10n.js
+	cp ../extlib/webextensions-lib-l10n/l10n.js $(EXTERNAL_RESOURCES_LIB_DIR)/
+	cp ../extlib/webextensions-lib-shortcut-customize-ui/ShortcutCustomizeUI.js $(EXTERNAL_OPTION_LIB_DIR)/; echo 'export default ShortcutCustomizeUI;' >> $(EXTERNAL_OPTION_LIB_DIR)/ShortcutCustomizeUI.js
 
 ../extlib/webextensions-lib-tab-id-fixer/TabIdFixer.js:
 	cd .. && git submodule update --init

--- a/webextensions/Makefile
+++ b/webextensions/Makefile
@@ -1,9 +1,7 @@
 NPM_MOD_DIR := $(CURDIR)/node_modules
 NPM_BIN_DIR := $(NPM_MOD_DIR)/.bin
 
-EXTERNAL_LIB_DIR := $(CURDIR)/common
-EXTERNAL_OPTION_LIB_DIR := $(CURDIR)/options
-EXTERNAL_RESOURCES_LIB_DIR := $(CURDIR)/resources
+EXTERNAL_LIB_DIR := $(CURDIR)/external
 
 .PHONY: xpi install_dependency lint format install_extlib
 
@@ -29,10 +27,10 @@ install_extlib:
 	cp ../extlib/webextensions-lib-rich-confirm/RichConfirm.js $(EXTERNAL_LIB_DIR)/; echo 'export default RichConfirm;' >> $(EXTERNAL_LIB_DIR)/RichConfirm.js
 	cp ../extlib/webextensions-lib-menu-ui/MenuUI.js $(EXTERNAL_LIB_DIR)/; echo 'export default MenuUI;' >> $(EXTERNAL_LIB_DIR)/MenuUI.js
 	cp ../extlib/webextensions-lib-configs/Configs.js $(EXTERNAL_LIB_DIR)/; echo 'export default Configs;' >> $(EXTERNAL_LIB_DIR)/Configs.js
-	cp ../extlib/webextensions-lib-options/Options.js $(EXTERNAL_OPTION_LIB_DIR)/; echo 'export default Options;' >> $(EXTERNAL_OPTION_LIB_DIR)/Options.js
+	cp ../extlib/webextensions-lib-options/Options.js $(EXTERNAL_LIB_DIR)/; echo 'export default Options;' >> $(EXTERNAL_LIB_DIR)/Options.js
 	cp ../extlib/webextensions-lib-l10n/l10n.js $(EXTERNAL_LIB_DIR)/; echo 'export default l10n;' >> $(EXTERNAL_LIB_DIR)/l10n.js
-	cp ../extlib/webextensions-lib-l10n/l10n.js $(EXTERNAL_RESOURCES_LIB_DIR)/
-	cp ../extlib/webextensions-lib-shortcut-customize-ui/ShortcutCustomizeUI.js $(EXTERNAL_OPTION_LIB_DIR)/; echo 'export default ShortcutCustomizeUI;' >> $(EXTERNAL_OPTION_LIB_DIR)/ShortcutCustomizeUI.js
+	cp ../extlib/webextensions-lib-l10n/l10n.js $(EXTERNAL_LIB_DIR)/l10n-classic.js
+	cp ../extlib/webextensions-lib-shortcut-customize-ui/ShortcutCustomizeUI.js $(EXTERNAL_LIB_DIR)/; echo 'export default ShortcutCustomizeUI;' >> $(EXTERNAL_LIB_DIR)/ShortcutCustomizeUI.js
 
 ../extlib/webextensions-lib-tab-id-fixer/TabIdFixer.js:
 	cd .. && git submodule update --init

--- a/webextensions/background/background.js
+++ b/webextensions/background/background.js
@@ -5,6 +5,9 @@
 */
 'use strict';
 
+import TabFavIconHelper from '../external/TabFavIconHelper.js';
+import RichConfirm from '../external/RichConfirm.js';
+
 import {
   log,
   dumpTab,
@@ -25,8 +28,6 @@ import * as TSTAPI from '../common/tst-api.js';
 import * as SidebarStatus from '../common/sidebar-status.js';
 import * as Commands from '../common/commands.js';
 import * as Migration from '../common/migration.js';
-import TabFavIconHelper from '../common/TabFavIconHelper.js';
-import RichConfirm from '../common/RichConfirm.js';
 import EventListenerManager from '../common/EventListenerManager.js';
 
 import * as TreeStructure from './tree-structure.js';
@@ -250,7 +251,7 @@ export async function tryInitGroupTab(aTab) {
     return;
   browser.tabs.executeScript(aTab.apiTab.id, Object.assign({}, scriptOptions, {
     //file:  '/common/l10n.js'
-    file:  '/resources/l10n.js' // ES module does not supported as a content script...
+    file:  '/external/l10n-classic.js' // ES module does not supported as a content script...
   }));
   browser.tabs.executeScript(aTab.apiTab.id, Object.assign({}, scriptOptions, {
     file:  '/resources/group-tab.js'

--- a/webextensions/background/index.js
+++ b/webextensions/background/index.js
@@ -3,6 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
+import '../external/TabIdFixer.js';
+
 import {
   log
 } from '../common/common.js';
@@ -14,7 +16,6 @@ import './listener.js';
 import './context-menu.js';
 
 import './tab-context-menu.js';
-import '../common/TabIdFixer.js';
 
 log.context = 'BG';
 

--- a/webextensions/common/api-tabs-listener.js
+++ b/webextensions/common/api-tabs-listener.js
@@ -38,6 +38,8 @@
  * ***** END LICENSE BLOCK ******/
 'use strict';
 
+import TabIdFixer from '../external/TabIdFixer.js';
+
 import {
   log,
   wait,
@@ -50,7 +52,6 @@ import * as Tabs from './tabs.js';
 import * as TabsContainer from './tabs-container.js';
 import * as TabsUpdate from './tabs-update.js';
 import * as TabsInternalOperation from './tabs-internal-operation.js';
-import TabIdFixer from './TabIdFixer.js';
 
 export function startListen() {
   browser.tabs.onActivated.addListener(onActivated);

--- a/webextensions/common/common.js
+++ b/webextensions/common/common.js
@@ -5,12 +5,13 @@
 */
 'use strict';
 
+import Configs from '../external/Configs.js';
+
 /* global
   uneval: false,
  */
 
 import * as Constants from './constants.js';
-import Configs from './Configs.js';
 
 export const configs = new Configs({
   optionsExpandedSections: ['section-appearance'],

--- a/webextensions/common/tabs-update.js
+++ b/webextensions/common/tabs-update.js
@@ -38,6 +38,8 @@
  * ***** END LICENSE BLOCK ******/
 'use strict';
 
+import TabFavIconHelper from '../external/TabFavIconHelper.js';
+
 import {
   log,
   wait,
@@ -48,7 +50,6 @@ import * as Constants from './constants.js';
 import * as ApiTabs from './api-tabs.js';
 import * as Tabs from './tabs.js';
 import * as ContextualIdentities from './contextual-identities.js';
-import TabFavIconHelper from './TabFavIconHelper.js';
 
 export function updateTab(aTab, aNewState = {}, aOptions = {}) {
   if ('url' in aNewState) {

--- a/webextensions/common/tree.js
+++ b/webextensions/common/tree.js
@@ -38,6 +38,8 @@
  * ***** END LICENSE BLOCK ******/
 'use strict';
 
+import TabIdFixer from '../external/TabIdFixer.js';
+
 import {
   log,
   wait,
@@ -57,7 +59,6 @@ import * as TSTAPI from './tst-api.js';
 import * as UserOperationBlocker from './user-operation-blocker.js';
 import * as MetricsData from './metrics-data.js';
 import EventListenerManager from './EventListenerManager.js';
-import TabIdFixer from './TabIdFixer.js';
 
 
 export const onAttached     = new EventListenerManager();

--- a/webextensions/common/tst-api.js
+++ b/webextensions/common/tst-api.js
@@ -38,12 +38,13 @@
  * ***** END LICENSE BLOCK ******/
 'use strict';
 
+import TabFavIconHelper from '../external/TabFavIconHelper.js';
+import TabIdFixer from '../external/TabIdFixer.js';
+
 import {
   configs
 } from './common.js';
 import * as Constants from './constants.js';
-import TabFavIconHelper from './TabFavIconHelper.js';
-import TabIdFixer from './TabIdFixer.js';
 import * as Tabs from './tabs.js';
 
 export const kREGISTER_SELF         = 'register-self';

--- a/webextensions/options/init.js
+++ b/webextensions/options/init.js
@@ -5,6 +5,10 @@
 */
 'use strict';
 
+import Options from '../external/Options.js';
+import ShortcutCustomizeUI from '../external/ShortcutCustomizeUI.js';
+import '../external/l10n.js';
+
 import {
   log,
   configs
@@ -12,10 +16,6 @@ import {
 
 import * as Permissions from '../common/permissions.js';
 import * as Migration from '../common/migration.js';
-
-import '../common/l10n.js';
-import Options from './Options.js';
-import ShortcutCustomizeUI from './ShortcutCustomizeUI.js';
 
 log.context = 'Options';
 const options = new Options(configs);

--- a/webextensions/resources/module/startup.js
+++ b/webextensions/resources/module/startup.js
@@ -5,9 +5,10 @@
 */
 'use strict';
 
+import '../../external/l10n.js';
+
 import { configs } from '../../common/common.js';
 import * as Permissions from '../../common/permissions.js';
-import '../../common/l10n.js';
 
 window.addEventListener('DOMContentLoaded', () => {
   document.querySelector('#title').textContent = document.title = `${browser.i18n.getMessage('extensionName')} ${browser.runtime.getManifest().version}`;

--- a/webextensions/sidebar/drag-and-drop.js
+++ b/webextensions/sidebar/drag-and-drop.js
@@ -36,6 +36,9 @@
  * ***** END LICENSE BLOCK ******/
 'use strict';
 
+
+import RichConfirm from '../external/RichConfirm.js';
+
 import {
   log,
   wait,
@@ -49,8 +52,6 @@ import * as TSTAPI from '../common/tst-api.js';
 import * as Scroll from './scroll.js';
 import * as EventUtils from './event-utils.js';
 import * as SidebarTabs from './sidebar-tabs.js';
-
-import RichConfirm from '../common/RichConfirm.js';
 
 
 const kTREE_DROP_TYPE   = 'application/x-treestyletab-tree';

--- a/webextensions/sidebar/index.js
+++ b/webextensions/sidebar/index.js
@@ -3,6 +3,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
+import '../external/l10n.js';
+import '../external/TabIdFixer.js';
+
 import {
   log
 } from '../common/common.js';
@@ -11,10 +14,8 @@ import * as MetricsData from '../common/metrics-data.js';
 
 import * as Sidebar from './sidebar.js';
 import './listener.js';
-import '../common/l10n.js';
 
 import './tab-context-menu.js';
-import '../common/TabIdFixer.js';
 
 log.context = 'Sidebar-?';
 

--- a/webextensions/sidebar/listener.js
+++ b/webextensions/sidebar/listener.js
@@ -38,6 +38,9 @@
  * ***** END LICENSE BLOCK ******/
 'use strict';
 
+import MenuUI from '../external/MenuUI.js';
+import TabFavIconHelper from '../external/TabFavIconHelper.js';
+
 import {
   log,
   dumpTab,
@@ -56,8 +59,6 @@ import * as ContextualIdentities from '../common/contextual-identities.js';
 import * as Commands from '../common/commands.js';
 import * as UserOperationBlocker from '../common/user-operation-blocker.js';
 import * as MetricsData from '../common/metrics-data.js';
-import MenuUI from '../common/MenuUI.js';
-import TabFavIconHelper from '../common/TabFavIconHelper.js';
 
 import * as Sidebar from './sidebar.js';
 import * as SidebarCache from './sidebar-cache.js';

--- a/webextensions/sidebar/sidebar.js
+++ b/webextensions/sidebar/sidebar.js
@@ -5,6 +5,9 @@
 */
 'use strict';
 
+import RichConfirm from '../external/RichConfirm.js';
+import TabIdFixer from '../external/TabIdFixer.js';
+
 import {
   log,
   nextFrame,
@@ -21,8 +24,6 @@ import * as ContextualIdentities from '../common/contextual-identities.js';
 import * as Commands from '../common/commands.js';
 import * as UserOperationBlocker from '../common/user-operation-blocker.js';
 import * as MetricsData from '../common/metrics-data.js';
-import RichConfirm from '../common/RichConfirm.js';
-import TabIdFixer from '../common/TabIdFixer.js';
 import EventListenerManager from '../common/EventListenerManager.js';
 
 import * as SidebarCache from './sidebar-cache.js';

--- a/webextensions/sidebar/tab-context-menu.js
+++ b/webextensions/sidebar/tab-context-menu.js
@@ -11,6 +11,7 @@
  See also: https://bugzilla.mozilla.org/show_bug.cgi?id=1376251
            https://bugzilla.mozilla.org/show_bug.cgi?id=1396031
 */
+import MenuUI from '../external/MenuUI.js';
 
 import {
   log,
@@ -24,7 +25,6 @@ import * as Tree from '../common/tree.js';
 import * as Bookmark from '../common/bookmark.js';
 import * as TSTAPI from '../common/tst-api.js';
 import EventListenerManager from '../common/EventListenerManager.js';
-import MenuUI from '../common/MenuUI.js';
 
 export const onTabsClosing = new EventListenerManager();
 


### PR DESCRIPTION
## Motivation

It's hard to recognize that it's an external libraries a file which is in managed directories by git.

## Detailed Design

* Copy external libraries into `external/`
   * We may have any other good naming for this library. But I think this is most straight and reasonable at now.