### PR TITLE
Add fill-opacity for toolbar icons

### DIFF
--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -31,26 +31,21 @@
   },
   "browser_action": {
     "default_title": "__MSG_sidebarTitle__",
-    "default_icon": {
-      "16": "resources/16x16.svg",
-      "20": "resources/20x20.svg",
-      "24": "resources/24x24.svg"
-    },
     "browser_style": true,
     "theme_icons": [
       {
-        "light": "resources/16x16-dark.svg",
-        "dark":  "resources/16x16-light.svg",
+        "light": "resources/16x16-dark.svg#toolbar",
+        "dark":  "resources/16x16-light.svg#toolbar",
         "size": 16
       },
       {
-        "light": "resources/20x20-dark.svg",
-        "dark":  "resources/20x20-light.svg",
+        "light": "resources/20x20-dark.svg#toolbar",
+        "dark":  "resources/20x20-light.svg#toolbar",
         "size": 20
       },
       {
-        "light": "resources/24x24-dark.svg",
-        "dark":  "resources/24x24-light.svg",
+        "light": "resources/24x24-dark.svg#toolbar",
+        "dark":  "resources/24x24-light.svg#toolbar",
         "size": 24
       }
     ]

--- a/webextensions/resources/16x16-dark.svg
+++ b/webextensions/resources/16x16-dark.svg
@@ -3,12 +3,28 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
 <!-- Generator: Adobe Illustrator 14.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 43363)  -->
-<g>
-	<path fill="#F9F9FA" d="M12,1H4C2.346,1,1,2.346,1,4v8c0,1.654,1.346,3,3,3h8c1.654,0,3-1.346,3-3V4C15,2.346,13.654,1,12,1z M3,4
+<style>
+	g:target {
+		fill: #F9F9FA;
+		fill-rule: evenodd;
+	}
+	g:not(#default):not(:target),
+	g:target ~ #default {
+		display: none;
+	}
+</style>
+<symbol id="icon-16">
+	<path d="M12,1H4C2.346,1,1,2.346,1,4v8c0,1.654,1.346,3,3,3h8c1.654,0,3-1.346,3-3V4C15,2.346,13.654,1,12,1z M3,4
 		c0-0.551,0.449-1,1-1h8c0.552,0,1,0.449,1,1v2H4C3.5,6,3,5.5,3,5V4z M7,10c-0.5,0-1-0.5-1-1H5.99V7H13v3H7z M12,13h-2
 		c-0.5,0-1-0.5-1-1v-1h4v1C13,12.552,12.552,13,12,13z"/>
-	<circle fill="#F9F9FA" cx="4.5" cy="4.5" r="0.5"/>
-	<circle fill="#F9F9FA" cx="7.5" cy="8.5" r="0.5"/>
-	<circle fill="#F9F9FA" cx="10.5" cy="12" r="0.5"/>
+	<circle cx="4.5" cy="4.5" r="0.5"/>
+	<circle cx="7.5" cy="8.5" r="0.5"/>
+	<circle cx="10.5" cy="12" r="0.5"/>
+</symbol>
+<g id="toolbar" fill-opacity="0.8">
+	<use href="#icon-16"/>
+</g>
+<g id="default" fill-opacity="1">
+	<use href="#icon-16"/>
 </g>
 </svg>

--- a/webextensions/resources/16x16-light.svg
+++ b/webextensions/resources/16x16-light.svg
@@ -3,12 +3,28 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
 <!-- Generator: Adobe Illustrator 14.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 43363)  -->
-<g>
-	<path fill="#0C0C0D" d="M12,1H4C2.346,1,1,2.346,1,4v8c0,1.654,1.346,3,3,3h8c1.654,0,3-1.346,3-3V4C15,2.346,13.654,1,12,1z M3,4
+<style>
+	g:target {
+		fill: #0C0C0D;
+		fill-rule: evenodd;
+	}
+	g:not(#default):not(:target),
+	g:target ~ #default {
+		display: none;
+	}
+</style>
+<symbol id="icon-16">
+	<path d="M12,1H4C2.346,1,1,2.346,1,4v8c0,1.654,1.346,3,3,3h8c1.654,0,3-1.346,3-3V4C15,2.346,13.654,1,12,1z M3,4
 		c0-0.551,0.449-1,1-1h8c0.552,0,1,0.449,1,1v2H4C3.5,6,3,5.5,3,5V4z M7,10c-0.5,0-1-0.5-1-1H5.99V7H13v3H7z M12,13h-2
 		c-0.5,0-1-0.5-1-1v-1h4v1C13,12.552,12.552,13,12,13z"/>
-	<circle fill="#0C0C0D" cx="4.5" cy="4.5" r="0.5"/>
-	<circle fill="#0C0C0D" cx="7.5" cy="8.5" r="0.5"/>
-	<circle fill="#0C0C0D" cx="10.5" cy="12" r="0.5"/>
+	<circle cx="4.5" cy="4.5" r="0.5"/>
+	<circle cx="7.5" cy="8.5" r="0.5"/>
+	<circle cx="10.5" cy="12" r="0.5"/>
+</symbol>
+<g id="toolbar" fill-opacity="0.8">
+	<use href="#icon-16"/>
+</g>
+<g id="default" fill-opacity="1">
+	<use href="#icon-16"/>
 </g>
 </svg>

--- a/webextensions/resources/20x20-dark.svg
+++ b/webextensions/resources/20x20-dark.svg
@@ -3,12 +3,28 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
 <!-- Generator: Adobe Illustrator 14.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 43363)  -->
-<g>
-	<path fill="#F9F9FA" d="M16,1H4C2.346,1,1,2.346,1,4v12c0,1.654,1.346,3,3,3h12c1.654,0,3-1.346,3-3V4C19,2.346,17.654,1,16,1z
+<style>
+	g:target {
+		fill: #F9F9FA;
+		fill-rule: evenodd;
+	}
+	g:not(#default):not(:target),
+	g:target ~ #default {
+		display: none;
+	}
+</style>
+<symbol id="icon-20">
+	<path d="M16,1H4C2.346,1,1,2.346,1,4v12c0,1.654,1.346,3,3,3h12c1.654,0,3-1.346,3-3V4C19,2.346,17.654,1,16,1z
 		 M8,12c-0.5,0-1-0.5-1-1V8h10v4H8z M3,4c0-0.551,0.449-1,1-1h12c0.552,0,1,0.449,1,1v3H4C3.5,7,3,6.5,3,6V4z M16,17h-4
 		c-0.5,0-1-0.5-1-1v-3h6v3C17,16.552,16.552,17,16,17z"/>
-	<circle fill="#F9F9FA" cx="5" cy="5" r="1"/>
-	<circle fill="#F9F9FA" cx="9" cy="10" r="1"/>
-	<circle fill="#F9F9FA" cx="13" cy="15" r="1"/>
+	<circle cx="5" cy="5" r="1"/>
+	<circle cx="9" cy="10" r="1"/>
+	<circle cx="13" cy="15" r="1"/>
+</symbol>
+<g id="toolbar" fill-opacity="0.8">
+	<use href="#icon-20"/>
+</g>
+<g id="default" fill-opacity="1">
+	<use href="#icon-20"/>
 </g>
 </svg>

--- a/webextensions/resources/20x20-light.svg
+++ b/webextensions/resources/20x20-light.svg
@@ -3,12 +3,28 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
 <!-- Generator: Adobe Illustrator 14.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 43363)  -->
-<g>
+<style>
+	g:target {
+		fill: #0C0C0D;
+		fill-rule: evenodd;
+	}
+	g:not(#default):not(:target),
+	g:target ~ #default {
+		display: none;
+	}
+</style>
+<symbol id="1con-20">
 	<path fill="#0C0C0D" d="M16,1H4C2.346,1,1,2.346,1,4v12c0,1.654,1.346,3,3,3h12c1.654,0,3-1.346,3-3V4C19,2.346,17.654,1,16,1z
 		 M8,12c-0.5,0-1-0.5-1-1V8h10v4H8z M3,4c0-0.551,0.449-1,1-1h12c0.552,0,1,0.449,1,1v3H4C3.5,7,3,6.5,3,6V4z M16,17h-4
 		c-0.5,0-1-0.5-1-1v-3h6v3C17,16.552,16.552,17,16,17z"/>
 	<circle fill="#0C0C0D" cx="5" cy="5" r="1"/>
 	<circle fill="#0C0C0D" cx="9" cy="10" r="1"/>
 	<circle fill="#0C0C0D" cx="13" cy="15" r="1"/>
+</symbol>
+<g id="toolbar" fill-opacity="0.8">
+	<use href="#icon-20"/>
+</g>
+<g id="default" fill-opacity="1">
+	<use href="#icon-20"/>
 </g>
 </svg>

--- a/webextensions/resources/24x24-dark.svg
+++ b/webextensions/resources/24x24-dark.svg
@@ -3,12 +3,28 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 <!-- Generator: Adobe Illustrator 14.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 43363)  -->
-<g>
-	<path fill="#F9F9FA" d="M20,1H4C2.346,1,1,2.346,1,4v16c0,1.654,1.346,3,3,3h16c1.654,0,3-1.346,3-3V4C23,2.346,21.654,1,20,1z
+<style>
+	g:target {
+		fill: #F9F9FA;
+		fill-rule: evenodd;
+	}
+	g:not(#default):not(:target),
+	g:target ~ #default {
+		display: none;
+	}
+</style>
+<symbol id="icon-24">
+	<path d="M20,1H4C2.346,1,1,2.346,1,4v16c0,1.654,1.346,3,3,3h16c1.654,0,3-1.346,3-3V4C23,2.346,21.654,1,20,1z
 		 M9,15c-0.5,0-1-0.5-1-1v-4h13v5H9z M3,4c0-0.551,0.449-1,1-1h16c0.552,0,1,0.449,1,1v5H4C3.5,9,3,8.5,3,8V4z M20,21h-6
 		c-0.5,0-1-0.5-1-1v-4h8v4C21,20.552,20.552,21,20,21z"/>
-	<circle fill="#F9F9FA" cx="6" cy="6" r="1"/>
-	<circle fill="#F9F9FA" cx="11" cy="12.375" r="1"/>
-	<circle fill="#F9F9FA" cx="16" cy="18.5" r="1"/>
+	<circle cx="6" cy="6" r="1"/>
+	<circle cx="11" cy="12.375" r="1"/>
+	<circle cx="16" cy="18.5" r="1"/>
+</symbol>
+<g id="toolbar" fill-opacity="0.8">
+	<use href="#icon-24"/>
+</g>
+<g id="default" fill-opacity="1">
+	<use href="#icon-24"/>
 </g>
 </svg>

--- a/webextensions/resources/24x24-light.svg
+++ b/webextensions/resources/24x24-light.svg
@@ -3,12 +3,28 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 <!-- Generator: Adobe Illustrator 14.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 43363)  -->
-<g>
-	<path fill="#0C0C0D" d="M20,1H4C2.346,1,1,2.346,1,4v16c0,1.654,1.346,3,3,3h16c1.654,0,3-1.346,3-3V4C23,2.346,21.654,1,20,1z
+<style>
+	g:target {
+		fill: #0C0C0D;
+		fill-rule: evenodd;
+	}
+	g:not(#default):not(:target),
+	g:target ~ #default {
+		display: none;
+	}
+</style>
+<symbol id="icon-24">
+	<path d="M20,1H4C2.346,1,1,2.346,1,4v16c0,1.654,1.346,3,3,3h16c1.654,0,3-1.346,3-3V4C23,2.346,21.654,1,20,1z
 		 M9,15c-0.5,0-1-0.5-1-1v-4h13v5H9z M3,4c0-0.551,0.449-1,1-1h16c0.552,0,1,0.449,1,1v5H4C3.5,9,3,8.5,3,8V4z M20,21h-6
 		c-0.5,0-1-0.5-1-1v-4h8v4C21,20.552,20.552,21,20,21z"/>
-	<circle fill="#0C0C0D" cx="6" cy="6" r="1"/>
-	<circle fill="#0C0C0D" cx="11" cy="12.375" r="1"/>
-	<circle fill="#0C0C0D" cx="16" cy="18.5" r="1"/>
+	<circle cx="6" cy="6" r="1"/>
+	<circle cx="11" cy="12.375" r="1"/>
+	<circle cx="16" cy="18.5" r="1"/>
+</symbol>
+<g id="toolbar" fill-opacity="0.8">
+	<use href="#icon-24"/>
+</g>
+<g id="default" fill-opacity="1">
+	<use href="#icon-24"/>
 </g>
 </svg>


### PR DESCRIPTION
* Added `fill-opacity` for toolbar icons. Ref [Iconography · Visuals | Photon Design System](https://design.firefox.com/photon/visuals/iconography.html#color "Iconography · Visuals | Photon Design System")
* Removed `default_icon` in manifest.json, there is `theme_icons` so `default_icon` is needless.
