### PR TITLE
Request optional permissions without toolbar button

### DIFF
--- a/webextensions/common/common.js
+++ b/webextensions/common/common.js
@@ -168,6 +168,7 @@ export const configs = new Configs({
   simulateSVGContextFill: true,
 
   requestingPermissions: null,
+  requestingPermissionsNatively: null,
 
   // https://dxr.mozilla.org/mozilla-central/rev/2535bad09d720e71a982f3f70dd6925f66ab8ec7/browser/base/content/browser.css#137
   newTabAnimationDuration: 100,

--- a/webextensions/common/permissions.js
+++ b/webextensions/common/permissions.js
@@ -93,7 +93,7 @@ export function bindToCheckbox(permissions, checkbox, options = {}) {
         configs.requestingPermissionsNatively = permissions;
         granted = await browser.permissions.request(permissions);
       } catch (error) {
-        alert(error);
+
       } finally {
         configs.requestingPermissionsNatively = null;
       }


### PR DESCRIPTION
[Firefox bug 1382953](https://bugzilla.mozilla.org/show_bug.cgi?id=1382953) has been fixed for Firefox 61 and Firefox ESR 60. This means that we can request optional permissions without using the toolbar button. 

This implementation attempts to request the permission without the toolbar button and if that fails it then tries to use the toolbar button instead. This can be useful since it allows permission to be request at times when the user hasn't done one of the interactions required to be allowed to request permissions. 

It also tracks if a request is currently pending and cancels all request until the current one is either allowed or denied. If this is not done then the user can click multiple times on the request button and the requests will be queued so that when the current request is denied it will appear again and again until the queue is emptied.