### PR TITLE
Generalize mouse move events to cover all possible cases

### DIFF
--- a/webextensions/sidebar/mouse-event-listener.js
+++ b/webextensions/sidebar/mouse-event-listener.js
@@ -164,18 +164,15 @@ onMouseMove = EventUtils.wrapWithErrorHandler(onMouseMove);
 
 function onMouseOver(event) {
   const tab = EventUtils.getTabFromEvent(event);
-  const relatedTab = Tabs.getTabFromChild(event.relatedTarget);
 
-  // We enter the tab element itself, but not from any of its children
-  const enterTabFromAncestor = event.target.classList.contains('tab') && !event.target.contains(event.relatedTarget);
-  // We enter the tab or any of its children from outside of the sidebar,
-  // which causes the relatedTarget (target of the mouseout event) to be null
-  const enterTabAndSidebar = tab && event.relatedTarget === null;
-  // We enter the tab or any of its children from another tab or any of its
-  // children, e.g. from close button to close button.
-  const enterTabFromOtherTab = tab && relatedTab && tab !== relatedTab;
+  // We enter the tab or one of its children, but not from any of the tabs
+  // (other) children, so we are now starting to hover this tab (relatedTarget
+  // contains the target of the mouseout event or null if there is none). This
+  // also includes the case where we enter the tab directly without going
+  // through another tab or the sidebar, which causes relatedTarget to be null
+  const enterTabFromAncestor = tab && !tab.contains(event.relatedTarget);
 
-  if (enterTabFromAncestor || enterTabAndSidebar || enterTabFromOtherTab) {
+  if (enterTabFromAncestor) {
     TSTAPI.sendMessage({
       type:     TSTAPI.kNOTIFY_TAB_MOUSEOVER,
       tab:      TSTAPI.serializeTab(tab),
@@ -192,18 +189,15 @@ onMouseOver = EventUtils.wrapWithErrorHandler(onMouseOver);
 
 function onMouseOut(event) {
   const tab = EventUtils.getTabFromEvent(event);
-  const relatedTab = Tabs.getTabFromChild(event.relatedTarget);
 
-  // We leave the tab element itself, but not for one of its children
-  const leaveTabToAncestor = event.target.classList.contains('tab') && !event.target.contains(event.relatedTarget);
-  // We leave the sidebar directly from the tab or a child element of it,
-  // which causes the relatedTarget (target of the mouseover event) to be null
-  const leaveSidebarFromTab = tab && event.relatedTarget === null;
-  // We leave the tab or any of its children to another tab or any of its
-  // children, e.g. from close button to close button.
-  const leaveTabToOtherTab = tab && relatedTab && tab != relatedTab;
+  // We leave the tab or any of its children, but not for one of the tabs
+  // (other) children, so we are no longer hovering this tab (relatedTarget
+  // contains the target of the mouseover event or null if there is none). This
+  // also includes the case where we leave the tab directly without going
+  // through another tab or the sidebar, which causes relatedTarget to be null
+  const leaveTabToAncestor = tab && !tab.contains(event.relatedTarget);
 
-  if (leaveTabToAncestor || leaveSidebarFromTab || leaveTabToOtherTab) {
+  if (leaveTabToAncestor) {
     TSTAPI.sendMessage({
       type:     TSTAPI.kNOTIFY_TAB_MOUSEOUT,
       tab:      TSTAPI.serializeTab(tab),


### PR DESCRIPTION
I found another mouse move case that was not covered: Moving the mouse from an empty part of the tab bar directly to the close button. Instead of adding yet another special case, I generalized the first check and it suddenly included all other cases as well (including the new one I found). :smiley:

> Previously, the enter and leave events for a tab were derived from the (bubbling) mouseover and mouseout events by checking a number of different cases, like when entering the top level tab element, but not from any of its children or entering the tab directly without going through another element. However, it turned out that moving the mouse directly between child elements of two tabs was not covered, so another case was added in a0653c03f14ba2e9ad42162723e89dedd29c42c2.
> 
> Later, another missing case was discovered: moving the mouse from an empty part of the tab to directly onto a child element of a tab.
> 
> Instead of adding another special case, this commit simplifies all previously mentioned cases into a single, most general check: We emit a tab enter event, when the tab or any of its children is entered, but
> not from any other of the same tab's children. This also includes the case where we cannot determine where the mouse came from (eg. from outside the sidebar).