### PR TITLE
Fix minor typo in parent tab message

### DIFF
--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -54,7 +54,7 @@
       "title": { "content": "$1", "example": "title" }
     }},
   "groupTab_label_default": { "message": "Group" },
-  "groupTab_temporary_label": { "message": "Close this tab when there are no more child" },
+  "groupTab_temporary_label": { "message": "Close this tab when there are no more children" },
   "groupTab_fromPinnedTab_label": { "message": "Tabs from $TITLE$",
     "placeholders": {
       "title": { "content": "$1", "example": "title" }


### PR DESCRIPTION
Fixes https://github.com/piroor/treestyletab/issues/2006 .

Use plural form of child.