### PR TITLE
Faster synchronization for loading throbbers

### DIFF
--- a/webextensions/sidebar/sidebar-tabs.js
+++ b/webextensions/sidebar/sidebar-tabs.js
@@ -27,7 +27,7 @@ let mInitialized = false;
 
 export function init() {
   mInitialized = true;
-  document.querySelector('#master-throbber').addEventListener('animationiteration', synchronizeThrobberAnimation);
+  document.querySelector('#sync-throbber').addEventListener('animationiteration', synchronizeThrobberAnimation);
 
   const tabbar = document.querySelector('#tabbar');
   tabbar.addEventListener('overflow', onOverflow);

--- a/webextensions/sidebar/sidebar-tabs.js
+++ b/webextensions/sidebar/sidebar-tabs.js
@@ -161,9 +161,9 @@ async function synchronizeThrobberAnimation() {
   for (const tab of Array.slice(toBeSynchronizedTabs)) {
     tab.classList.remove(Constants.kTAB_STATE_THROBBER_UNSYNCHRONIZED);
   }
-  await nextFrame();
+
   document.documentElement.classList.add(Constants.kTABBAR_STATE_THROBBER_SYNCHRONIZING);
-  await nextFrame();
+  void document.documentElement.offsetWidth;
   document.documentElement.classList.remove(Constants.kTABBAR_STATE_THROBBER_SYNCHRONIZING);
 }
 

--- a/webextensions/sidebar/sidebar.html
+++ b/webextensions/sidebar/sidebar.html
@@ -60,6 +60,7 @@
     <ul id="dummy-tabs">
       <span id="dummy-favicon-size-box"></span>
       <span id="dummy-highlight-color-box"></span>
+      <span class="throbber"><span id="sync-throbber"></span></span>
       <li id="dummy-tab" class="tab">
         <span class="favicon"><span class="throbber" id="master-throbber-container"><span id="master-throbber"></span></span></span>
         <span class="label">-</span>

--- a/webextensions/sidebar/sidebar.html
+++ b/webextensions/sidebar/sidebar.html
@@ -61,9 +61,7 @@
       <span id="dummy-favicon-size-box"></span>
       <span id="dummy-highlight-color-box"></span>
       <li id="dummy-tab" class="tab">
-        <span class="favicon">
-          <span class="throbber" id="master-throbber-container"><span id="master-throbber"></span></span>
-        </span>
+        <span class="favicon"><span class="throbber" id="master-throbber-container"><span id="master-throbber"></span></span></span>
         <span class="label">-</span>
         <span class="counter">0</span>
         <span class="closebox"></button>

--- a/webextensions/sidebar/styles/throbber.css
+++ b/webextensions/sidebar/styles/throbber.css
@@ -47,6 +47,7 @@
 
 :root:not(.throbber-synchronizing) .tab:not(.collapsed).loading:not(.throbber-unsynchronized) .throbber::before,
 :root:not(.throbber-synchronizing).have-loading-tab #master-throbber,
+:root.have-loading-tab #sync-throbber,
 :root.blocking-throbber #blocking-screen .throbber::before {
   animation: throbber 1.05s steps(60) infinite;
 }


### PR DESCRIPTION
Sometimes a stutter is quite noticeable when the loading throbbers are synchronized. This mostly happens when I have many open tabs or many loading tabs. The stutter is because all throbbers are stopped and then re-started to synchronize them. This is supposed to happen when the animation has just completed so that it is less noticeable but when Firefox is under heavy load this can be delayed and cause the animation to stop halfway through and the re-start from the beginning. 

This pull request tries to improve on this in two ways:
* Less time between when animation is completed and the throbbers are re-started. This is done by triggering a reflow instead of waiting for it. The method used is from https://css-tricks.com/restart-css-animation/#article-header-id-0.
* A `#sync-throbber` is used for the timing of the throbber animation. This animation is not re-started when the sync logic is run. Note that the `#master-throbber` is still re-started so that unsynchronized throbbers that use it remain in sync with the synchronized throbbers. If there is a delay in the sync code then the `#sync-throbber`'s animation will be slightly ahead of the synchronized throbbers' animations. This means that the sync code will be triggered slightly before the synchronized throbbers complete their animations and they will hopefully be stopped just as they complete their animations. 

From my testing both of these fixes seems to work really well. Both together and separately. I did my tested in two different windows. One with 100 loading tabs and the other with 10. The loading tabs were not loading a website and continued loading forever. 

This pull request also fixes a probable bug in the `sidebar.html` file. The `#master-throbber-container` is not located inside the `favicon` element as it should be. This can be seen by setting the `#dummy-tabs` area's `z-index` to something greater such as ´500´. This was fixed by removing some new lines before and after the `#master-throbber-container`.