### PR TITLE
Unprefix -moz-linear-gradient()

### DIFF
--- a/skin/classic/treestyletab/sidebar/sidebar.css
+++ b/skin/classic/treestyletab/sidebar/sidebar.css
@@ -165,14 +165,14 @@ tabbrowser[treestyletab-mode="vertical"]
 }
 .tabbrowser-tabs[treestyletab-mode="vertical"]
   .tabbrowser-tab[visuallyselected="true"] {
-	background: -moz-linear-gradient(top, #A0B0CF, #7386AB) repeat-x !important;
+	background: linear-gradient(to bottom, #A0B0CF, #7386AB) repeat-x !important;
 }
 
 #main-window:-moz-window-inactive
   .tabbrowser-tabs[treestyletab-mode="vertical"]
   .tabbrowser-tab[visuallyselected="true"] {
 	border-top: 1px solid #979797 !important;
-	background: -moz-linear-gradient(top, #B4B4B4, #8A8A8A) repeat-x !important;  
+	background: linear-gradient(to bottom, #B4B4B4, #8A8A8A) repeat-x !important;
 }
 
 /* Keep the close button at a safe distance from the tab label. */

--- a/skin/classic/treestyletab/square/tab-surface.css
+++ b/skin/classic/treestyletab/square/tab-surface.css
@@ -13,8 +13,8 @@
   :-moz-any(.tab-background:not([pinned]),
             .tab-background[pinned]) {
 	background-color: var(--tst-tab-surface) !important;
-	background-image: -moz-linear-gradient(
-	                    top, 
+	background-image: linear-gradient(
+	                    to bottom,
 	                    rgba(0, 0, 0, 0.02) 0,
 	                    rgba(0, 0, 0, 0) 50%
 	                  ) !important;
@@ -25,8 +25,8 @@
   .tabbrowser-tab[visuallyselected="true"]
   .tab-background[selected="true"] {
 	background-color: var(--tst-tab-surface-selected) !important;
-	background-image: -moz-linear-gradient(
-	                    top,
+	background-image: linear-gradient(
+	                    to bottom,
 	                    rgba(4, 83, 227, 0.04) 0,
 	                    rgba(4, 83, 227, 0) 50%
 	                  ) !important;
@@ -40,8 +40,8 @@
   :-moz-any(.tab-background:not([pinned]),
             .tab-background[pinned]:not([titlechanged])) {
 	background-color: var(--tst-tab-surface-hover) !important;
-	background-image: -moz-linear-gradient(
-	                    top,
+	background-image: linear-gradient(
+	                    to bottom,
 	                    rgba(213, 224, 245, 1) 0,
 	                    rgba(213, 224, 245, 0.4) 50%
 	                  ) !important;
@@ -51,8 +51,8 @@
   .tabbrowser-tab:hover
   .tab-background[selected="true"] {
 	background-color: var(--tst-tab-surface-selected-hover) !important;
-	background-image: -moz-linear-gradient(
-	                    top,
+	background-image: linear-gradient(
+	                    to bottom,
 	                    rgba(199, 219, 252, 1) 0,
 	                    rgba(199, 219, 252, 0.4) 50%
 	                  ) !important;

--- a/skin/classic/treestyletab/ui-base.css
+++ b/skin/classic/treestyletab/ui-base.css
@@ -405,7 +405,7 @@ tabbrowser:not([treestyletab-tabbar-position="top"])
 .tabbrowser-tabs[treestyletab-mode="vertical"]
   .tabbrowser-arrowscrollbox
   > .scrollbutton-down[treestyletab-notifybgtab-phase] {
-	background: -moz-linear-gradient(-90deg, rgba(255,255,255,0), Highlight);
+	background: linear-gradient(-90deg, rgba(255,255,255,0), Highlight);
 	border: 0 none;
 	bottom: 0;
 	box-shadow: none;

--- a/webextensions/sidebar/styles/base.css
+++ b/webextensions/sidebar/styles/base.css
@@ -581,8 +581,8 @@ ul {
 
 #out-of-view-tab-notifier {
   background: transparent repeat-x bottom;
-  background-image: -moz-linear-gradient(
-                      bottom,
+  background-image: linear-gradient(
+                      to top,
                       var(--tab-highlighted-glow) 0,
                       transparent 100%
                     );

--- a/webextensions/sidebar/styles/sidebar/sidebar.css
+++ b/webextensions/sidebar/styles/sidebar/sidebar.css
@@ -40,8 +40,8 @@
   --shadow-color: #404040;
   --shadow-color-inactive: #868686;
   --tab-surface-active-color: #94A1C0;
-  --tab-surface-active-gradient: -moz-linear-gradient(top, #A0B0CF, #7386AB) repeat-x;
-  --tab-surface-active-gradient-inactive: -moz-linear-gradient(top, #B4B4B4, #8A8A8A) repeat-x;
+  --tab-surface-active-gradient: linear-gradient(to bottom, #A0B0CF, #7386AB) repeat-x;
+  --tab-surface-active-gradient-inactive: linear-gradient(to bottom, #B4B4B4, #8A8A8A) repeat-x;
   --tab-text: black;
   --tab-text-inverted: white;
   --tab-text-active: white;

--- a/webextensions/sidebar/styles/square/mixed.css
+++ b/webextensions/sidebar/styles/square/mixed.css
@@ -59,45 +59,45 @@
 
 
 :root.left .tab:not(.faviconized).active {
-  background-image: -moz-linear-gradient(
-                      left,
+  background-image: linear-gradient(
+                      to right,
                       var(--tab-surface-active-gradient-start) 0,
                       var(--tab-surface-active-gradient-end) 30%
                     );
 }
 :root.left .tab:not(.faviconized):not(.collapsed):hover {
-  background-image: -moz-linear-gradient(
-                      left,
+  background-image: linear-gradient(
+                      to right,
                       var(--tab-surface-active-gradient-start) 0,
                       var(--tab-surface-active-gradient-end) 50%
                     );
 }
 
 :root.right .tab:not(.faviconized).active {
-  background-image: -moz-linear-gradient(
-                      right,
+  background-image: linear-gradient(
+                      to left,
                       var(--tab-surface-active-gradient-start) 0,
                       var(--tab-surface-active-gradient-end) 30%
                     );
 }
 :root.right .tab:not(.faviconized):not(.collapsed):hover {
-  background-image: -moz-linear-gradient(
-                      right,
+  background-image: linear-gradient(
+                      to left,
                       var(--tab-surface-active-gradient-start) 0,
                       var(--tab-surface-active-gradient-end) 50%
                     );
 }
 
 .tab.faviconized.active {
-  background-image: -moz-linear-gradient(
-                      top,
+  background-image: linear-gradient(
+                      to bottom,
                       var(--tab-surface-active-gradient-start) 0,
                       var(--tab-surface-active-gradient-end) 40%
                     );
 }
 .tab.faviconized:hover {
-  background-image: -moz-linear-gradient(
-                      top,
+  background-image: linear-gradient(
+                      to bottom,
                       var(--tab-surface-active-gradient-start) 0,
                       var(--tab-surface-active-gradient-end) 60%
                     );
@@ -111,24 +111,24 @@
 }
 
 :root.left .tab:not(.faviconized):not(.active):not(.highlighted):hover .active-marker::before {
-  background-image: -moz-linear-gradient(
-                      left,
+  background-image: linear-gradient(
+                      to right,
                       var(--tab-active-marker-start) 0,
                       var(--tab-active-marker-end) 30%
                     );
 }
 
 :root.right .tab:not(.faviconized):not(.active):not(.highlighted):hover .active-marker::before {
-  background-image: -moz-linear-gradient(
-                      right,
+  background-image: linear-gradient(
+                      to left,
                       var(--tab-active-marker-start) 0,
                       var(--tab-active-marker-end) 30%
                     );
 }
 
 .tab.faviconized:not(.active):not(.highlighted):hover .active-marker::before {
-  background-image: -moz-linear-gradient(
-                      top,
+  background-image: linear-gradient(
+                      to bottom,
                       var(--tab-active-marker-start) 0,
                       var(--tab-active-marker-end) 30%
                     );


### PR DESCRIPTION
As of https://bugzilla.mozilla.org/show_bug.cgi?id=1337655, Nightly
doesn’t support the obsolete -moz-linear-gradient() syntax; and the plan
is to drop it on stable eventually too.

This involves the inversion in direction specification between the old
and current syntaxes: “left” becomes “to right”, &c. The default
side-or-corner is “to bottom”, but I decided to leave those ones in
rather than dropping it. Clarity, and all that: not everyone knows the
default direction of a gradient.