### PR TITLE
Locale: Shorter message for animations config

### DIFF
--- a/webextensions/_locales/de/messages.json
+++ b/webextensions/_locales/de/messages.json
@@ -171,7 +171,7 @@
   "config_maxTreeLevel_after": { "message": "Stufen (*Negative Werte bedeuten \"unbegrenzt\")" },
 
   "config_faviconizePinnedTabs_label": { "message": "Angeheftete Tabs nur mit Ihrem Symbol anzeigen" },
-  "config_animation_label": { "message": "Animationen aktivieren" },
+  "config_animation_label": { "message": "Animationen" },
   "config_showCollapsedDescendantsByTooltip_label": { "message": "Eingeklappte untergeordnete Tabs als Tooltip anzeigen" },
 
   

--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -215,7 +215,7 @@
   "config_maxTreeLevel_after": { "message": "level(s) (*Negative value means \"infinite\")" },
 
   "config_faviconizePinnedTabs_label": { "message": "Show pinned tabs only with their icon" },
-  "config_animation_label": { "message": "Enable animation effects" },
+  "config_animation_label": { "message": "Animations" },
   "config_showCollapsedDescendantsByTooltip_label": { "message": "Show collapsed descendants in the tooltip on a tab" },
   "config_applyThemeColorToIcon_label": { "message": "Apply theme color to the toolbar button" },
   "config_applyThemeColorToIcon_label_info": { "message": "(*You need to set \"svg.context-properties.content.enabled\" to \"true\" via \"about:config\" on Firefox 62 or later)" },

--- a/webextensions/_locales/ja/messages.json
+++ b/webextensions/_locales/ja/messages.json
@@ -211,7 +211,7 @@
   "config_maxTreeLevel_after": { "message": "階層までインデント表示する（※負の値を指定した場合は無制限）" },
 
   "config_faviconizePinnedTabs_label": { "message": "ピン留めされたタブはアイコンのみ表示する" },
-  "config_animation_label": { "message": "アニメーション効果を有効にする" },
+  "config_animation_label": { "message": "アニメーション" },
   "config_showCollapsedDescendantsByTooltip_label": { "message": "タブのツールチップに折り畳まれた子孫タブの情報を含める" },
   "config_applyThemeColorToIcon_label": { "message": "ツールバーのボタンにテーマの配色を反映する" },
   "config_applyThemeColorToIcon_label_info": { "message": "（※Firefox 62以降で、「about:config」で「svg.context-properties.content.enabled」を「true」に設定する必要があります）" },

--- a/webextensions/_locales/ru/messages.json
+++ b/webextensions/_locales/ru/messages.json
@@ -164,7 +164,7 @@
   "config_maxTreeLevel_after": { "message": "level(s) (*Отрицательное значение = \"бесконечно\")" },
 
   "config_faviconizePinnedTabs_label": { "message": "Показывать закрепленные вкладки только со значком" },
-  "config_animation_label": { "message": "Включить эффекты анимации" },
+  "config_animation_label": { "message": "Анимации" },
   "config_showCollapsedDescendantsByTooltip_label": { "message": "Показывать свернутые дочерние элементы в подсказке на вкладке" },
 
 

--- a/webextensions/_locales/uk/messages.json
+++ b/webextensions/_locales/uk/messages.json
@@ -164,7 +164,7 @@
   "config_maxTreeLevel_after": { "message": "рівня(ів) (*Від'ємне значення означає \"нескінченно\")" },
 
   "config_faviconizePinnedTabs_label": { "message": "Показувати закріплені вкладки тільки зі значком" },
-  "config_animation_label": { "message": "Ввімкнути ефекти анімації" },
+  "config_animation_label": { "message": "Анімації" },
   "config_showCollapsedDescendantsByTooltip_label": { "message": "Показувати згорнуті дочірні елементи у підказці на вкладці" },
 
 

--- a/webextensions/_locales/zh_CN/messages.json
+++ b/webextensions/_locales/zh_CN/messages.json
@@ -484,10 +484,7 @@
         "message": "固定的标签页只显示图标",
         "hash": "9da551bbd5004005faa75eff95cc8391"
     },
-    "config_animation_label": {
-        "message": "启用动画效果",
-        "hash": "67af584b4338ca4351cee724f8b9f0a3"
-    },
+    "config_animation_label": { "message": "动画" },
     "config_showCollapsedDescendantsByTooltip_label": {
         "message": "标签页的悬停提示中显示折叠的后代",
         "hash": "3023e54eb03305a2f90f23992f792916"

--- a/webextensions/_locales/zh_TW/messages.json
+++ b/webextensions/_locales/zh_TW/messages.json
@@ -160,7 +160,7 @@
   "config_maxTreeLevel_after": { "message": "層分頁(負值表示無限制)" },
 
   "config_faviconizePinnedTabs_label": { "message": "釘選分頁只顯示網頁圖示" },
-  "config_animation_label": { "message": "啟用動畫效果" },
+  "config_animation_label": { "message": "動畫" },
 
 
   "config_extraItems_caption": { "message": "額外右鍵選單項" },


### PR DESCRIPTION
I mean, keep it simple. It already a checkbox, so why "enable"/"disable" text? And what's with those "effects" anyway — aren't they just "animations"?