### PR TITLE
Use filter for browser.tabs.onUpdated event.

### DIFF
--- a/webextensions/common/api-tabs-listener.js
+++ b/webextensions/common/api-tabs-listener.js
@@ -61,8 +61,20 @@ function logUpdated(...args) {
 }
 
 export function startListen() {
+  const targetWindow = Tabs.getWindow();
+  
   browser.tabs.onActivated.addListener(onActivated);
-  browser.tabs.onUpdated.addListener(onUpdated);
+  
+  let hasOnUpdated = false;
+  try {
+    if (typeof targetWindow === 'number') {
+      browser.tabs.onUpdated.addListener(onUpdated, { windowId: targetWindow });
+      hasOnUpdated = true;
+    }
+  } catch (error) { /* browser.tabs.onUpdated filter not supported (Firefox 60 or earlier) */ }
+  if (!hasOnUpdated)
+    browser.tabs.onUpdated.addListener(onUpdated);
+  
   browser.tabs.onHighlighted.addListener(onHighlighted);
   browser.tabs.onCreated.addListener(onCreated);
   browser.tabs.onRemoved.addListener(onRemoved);


### PR DESCRIPTION
[Firefox 61 and later supports using a filter](https://bugzilla.mozilla.org/show_bug.cgi?id=1329507) for the [browser.tabs.onUpdated event](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onUpdated). This should improve performance. 

I have tested this code change for TST v2.6.8 and it works for Firefox 60 (ESR) and Firefox 64.0 (stable).