### PR TITLE
 Don't populate window returned by browser.tabs.highlight. 

### DIFF
--- a/webextensions/background/handle-tab-multiselect.js
+++ b/webextensions/background/handle-tab-multiselect.js
@@ -93,6 +93,7 @@ export async function updateSelectionByTabClick(tab, event) {
       // for better performance, we should not call browser.tabs.update() for each tab.
       browser.tabs.highlight({
         windowId: tab.apiTab.windowId,
+        populate: false,
         tabs:     Array.from(highlightedTabIds).map(apiTabId => Tabs.getTabById(apiTabId).apiTab.index)
       });
     }
@@ -145,6 +146,7 @@ export async function updateSelectionByTabClick(tab, event) {
       // for better performance, we should not call browser.tabs.update() for each tab.
       browser.tabs.highlight({
         windowId: tab.apiTab.windowId,
+        populate: false,
         tabs:     Array.from(highlightedTabIds).map(apiTabId => Tabs.getTabById(apiTabId).apiTab.index)
       });
     }

--- a/webextensions/background/tab-context-menu.js
+++ b/webextensions/background/tab-context-menu.js
@@ -523,6 +523,7 @@ async function onClick(info, contextApiTab) {
       const apiTabs = await browser.tabs.query({ windowId: contextWindowId });
       browser.tabs.highlight({
         windowId: contextWindowId,
+        populate: false,
         tabs: apiTabs.map(tab => tab.index)
       });
     }; break;


### PR DESCRIPTION
By default the [browser.tabs.highlight](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/highlight) function returns the populated window that was changed. But we can instead return an unpopulated window for better performance if we aren't using the returned value (which we aren't). I have not tested this changes but according to the API reference this property is support in Firefox 63 the same as the function so there shouldn't be any issues.

More info: [Firefox bug 1489814](https://bugzilla.mozilla.org/show_bug.cgi?id=1489814)