### PR TITLE
Fixed syncTabsOrder() / Unclickable Tabs (#2199) + Many (Not all) of v3.0.7 Critical Issues (#2238) + Auto Reload Sidebar on Critical Tab Order Failures

### DIFF
--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -17,6 +17,7 @@
   "command_focusNextSilently":     { "message": "Focus to Next Tab (don't expand tree)" },
   "command_focusParent":           { "message": "Focus to Parent Tab" },
   "command_focusFirstChild":       { "message": "Focus to First Child Tab" },
+  "command_reloadSidebars":        { "message": "Reload Sidebar" },
   "command_tabbarUp":              { "message": "Scroll Tabs Up by Line" },
   "command_tabbarPageUp":          { "message": "Scroll Tabs Up by Page" },
   "command_tabbarHome":            { "message": "Scroll Tabs to Top" },

--- a/webextensions/background/background.js
+++ b/webextensions/background/background.js
@@ -113,6 +113,7 @@ export async function init() {
   onBuilt.dispatch();
   MetricsData.add('init: started listening');
 
+  //provide reloadSidebars() implementation for use in Tab context menu (avoiding cyclical dependencies)
   const reloadSidebarsCommand = reloadSidebars;
   TabContextMenu.init(reloadSidebarsCommand);
   MetricsData.add('init: started initializing of context menu');
@@ -120,13 +121,20 @@ export async function init() {
   Permissions.clearRequest();
 
   for (const windowId of restoredFromCache.keys()) {
+
+    //MAYBE: Is await needed for lines commented with "//await needed?"
+    //Can remove some of the 4 added await uses, possibly later, to speed-up,
+    //but suggest doing *after* fixing the remaining major initialization issues from #2238 (in case this help to avoid or pinpoint them) like:
+    // "Error: Could not establish connection. Receiving end does not exist" 
+    // and "Tab opened during init never sets favicon or sometimes title"?
+  
     if (!restoredFromCache[windowId])
-      await BackgroundCache.reserveToCacheTree(windowId);
-    await TabsUpdate.completeLoadingTabs(windowId);
+      await BackgroundCache.reserveToCacheTree(windowId); //await needed?
+    await TabsUpdate.completeLoadingTabs(windowId); //await needed?
   }
 
   for (const tab of Tab.getAllTabs(null, { iterator: true })) {
-    await updateSubtreeCollapsed(tab);
+    await updateSubtreeCollapsed(tab); //await needed?
   }
   for (const tab of Tab.getActiveTabs()) {
     for (const ancestor of tab.$TST.ancestors) {
@@ -139,7 +147,7 @@ export async function init() {
 
   // we don't need to await that for the initialization of TST itself.
   //waiting to see if helps fix the m
-  await MetricsData.addAsync('init: initializing API for other addons', TSTAPI.initAsBackend());
+  await MetricsData.addAsync('init: initializing API for other addons', TSTAPI.initAsBackend()); //await needed?
 
   mInitialized = true;
   onReady.dispatch();

--- a/webextensions/background/context-menu.js
+++ b/webextensions/background/context-menu.js
@@ -254,8 +254,9 @@ function updateItems() {
 export const onClick = (info, tab) => {
   log('context menu item clicked: ', info, tab);
 
-  const contextTab = Tab.get(tab.id);
-  const selectedTabs = contextTab.$TST.multiselected ? Tab.getSelectedTabs(contextTab.windowId) : [];
+  //now fixed for right click on sidebar background (not on any tab) by checking for whether tab is undefined first
+  const contextTab = tab && Tab.get(tab.id);
+  const selectedTabs = contextTab && contextTab.$TST.multiselected ? Tab.getSelectedTabs(contextTab.windowId) : [];
 
   switch (info.menuItemId.replace(/^(?:grouped:|context_closeTabOptions_)/, '')) {
     case 'reloadTree':

--- a/webextensions/background/handle-misc.js
+++ b/webextensions/background/handle-misc.js
@@ -81,6 +81,7 @@ Background.onDestroy.addListener(() => {
 });
 
 
+
 function onToolbarButtonClick(tab) {
   if (Permissions.requestPostProcess())
     return;
@@ -89,6 +90,16 @@ function onToolbarButtonClick(tab) {
     browser.sidebarAction.close();
   else
     browser.sidebarAction.open();
+}
+
+
+//only works in response to a user action (and therefore can't be used indirectly via message sent to background)
+//slower alternative to reloadSidebars() in background.js
+async function reopenSidebar() {
+  //if (!Permissions.requestPostProcess()) return;
+  //if (!SidebarConnection.isOpen(windowId)) return;
+  await browser.sidebarAction.close();
+  await browser.sidebarAction.open();
 }
 
 async function onShortcutCommand(command) {
@@ -209,6 +220,10 @@ async function onShortcutCommand(command) {
     case 'focusFirstChild':
       TabsInternalOperation.activateTab(activeTab.$TST.firstChild);
       return;
+      
+    case 'reloadSidebars':
+      Background.reloadSidebars();
+      break;
 
     case 'tabbarUp':
       SidebarConnection.sendMessage({

--- a/webextensions/background/tab-context-menu.js
+++ b/webextensions/background/tab-context-menu.js
@@ -117,6 +117,9 @@ const mItemsById = {
     title:              browser.i18n.getMessage('tabContextMenu_close_label'),
     titleMultiselected: browser.i18n.getMessage('tabContextMenu_close_label_multiselected')
   },
+  'context_reloadSidebars': {
+    title: browser.i18n.getMessage('tabContextMenu_reloadSidebars_label') || 'Reload Sidebar'
+  },
 
   'noContextTab:context_reloadTab': {
     title: browser.i18n.getMessage('tabContextMenu_reload_label_multiselected')
@@ -129,6 +132,9 @@ const mItemsById = {
   },
   'noContextTab:context_undoCloseTab': {
     title: browser.i18n.getMessage('tabContextMenu_undoClose_label')
+  },
+  'noContextTab:context_reloadSidebars': {
+    title: browser.i18n.getMessage('tabContextMenu_reloadSidebars_label') || 'Reload Sidebar'
   },
 
   'lastSeparatorBeforeExtraItems': {
@@ -145,6 +151,7 @@ let mNativeMultiselectionAvailable = true;
 
 const SIDEBAR_URL_PATTERN = mNativeContextMenuAvailable ? [`moz-extension://${location.host}/*`] : null;
 
+let reloadSidebarsHandler;
 function getItemPlacementSignature(item) {
   if (item.placementSignature)
     return item.placementSignature;
@@ -152,7 +159,9 @@ function getItemPlacementSignature(item) {
     parentId: item.parentId
   });
 }
-export async function init() {
+
+export async function init(reloadSidebarsCommand) {
+  reloadSidebarsHandler = reloadSidebarsCommand;
   browser.runtime.onMessage.addListener(onMessage);
   browser.runtime.onMessageExternal.addListener(onExternalMessage);
 
@@ -502,6 +511,9 @@ async function onShown(info, contextTab) {
   updateItem('noContextTab:context_undoCloseTab', {
     visible: emulate && !contextTab
   }) && modifiedItemsCount++;
+  updateItem('noContextTab:context_reloadSidebars', {
+    visible: emulate && !contextTab
+  }) && modifiedItemsCount++;
 
   updateSeparator('context_separator:afterDuplicate') && modifiedItemsCount++;
   updateSeparator('context_separator:afterSendTab') && modifiedItemsCount++;
@@ -692,6 +704,12 @@ async function onClick(info, contextTab) {
       else {
         browser.tabs.remove(contextTab.id)
           .catch(ApiTabs.createErrorHandler(ApiTabs.handleMissingTabError));
+      }
+      break;
+
+    case 'context_reloadSidebars':
+      if (reloadSidebarsHandler) {
+        reloadSidebarsHandler(); //OR: await?
       }
       break;
 

--- a/webextensions/common/common.js
+++ b/webextensions/common/common.js
@@ -192,6 +192,10 @@ export const configs = new Configs({
 
   useCachedTree: true,
 
+  //workaround for: https://github.com/piroor/treestyletab/issues/2199 and parts of https://github.com/piroor/treestyletab/issues/2238
+  //WARNING: leave as false to avoid "Error: Could not establish connection. Receiving end does not exist" in exportTabsToSidebar()
+  useCachedTreeBackgroundExport: true,
+
   // This should be removed after https://bugzilla.mozilla.org/show_bug.cgi?id=1388193
   // or https://bugzilla.mozilla.org/show_bug.cgi?id=1421329 become fixed.
   // Otherwise you need to set "svg.context-properties.content.enabled"="true" via "about:config".

--- a/webextensions/common/common.js
+++ b/webextensions/common/common.js
@@ -193,7 +193,8 @@ export const configs = new Configs({
   useCachedTree: true,
 
   //workaround for: https://github.com/piroor/treestyletab/issues/2199 and parts of https://github.com/piroor/treestyletab/issues/2238
-  //WARNING: leave as false to avoid "Error: Could not establish connection. Receiving end does not exist" in exportTabsToSidebar()
+  //WARNING: Should change to false by default avoid "Error: Could not establish connection. Receiving end does not exist" in exportTabsToSidebar()
+  //However, leaving as true for now to reduce impact, and so can test first to see if = false will prevent caching for session restore (though that seems like cache use may already be broken due to the mentioned error)
   useCachedTreeBackgroundExport: true,
 
   // This should be removed after https://bugzilla.mozilla.org/show_bug.cgi?id=1388193

--- a/webextensions/common/constants.js
+++ b/webextensions/common/constants.js
@@ -67,6 +67,7 @@ export const kCOMMAND_REQUEST_CONNECTION_MESSAGE_LOGS  = 'treestyletab:request-c
 export const kCOMMAND_RESPONSE_CONNECTION_MESSAGE_LOGS = 'treestyletab:response-connection-message-logs';
 export const kCOMMAND_NOTIFY_TEST_KEY_CHANGED        = 'treestyletab:notify-test-key-changed';
 export const kCOMMAND_SIMULATE_SIDEBAR_MESSAGE       = 'treestyletab:simulate-sidebar-message';
+export const kCOMMAND_RELOAD_SIDEBARS                = 'treestyletab:reload-sidebars';
 
 export const kCOMMAND_SELECT_TAB              = 'treestyletab:select-tab';
 export const kCOMMAND_SET_SUBTREE_MUTED       = 'treestyletab:set-subtree-muted';

--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -164,6 +164,9 @@
     "focusFirstChild": {
       "description": "__MSG_command_focusFirstChild__"
     },
+    "reloadSidebars": {
+      "description": "__MSG_command_reloadSidebars__"
+    },
     "tabbarUp": {
       "description": "__MSG_command_tabbarUp__ (Alt+Shift+Up)"
     },


### PR DESCRIPTION
### Fixes for #2199 (with syncTabsOrder) + many (but not all) of #2238 (v3.0.7 Critical Issues), including:
- Fixed syncTabsOrder() never actually working (ever) due to always either deferring indefinitely or failing the initial conditions or comparing the wrong things, with a complete rewrite of it
- Added support for automatic complete rebuild of trees when syncTabsOrder() fails
- Added "Reload Sidebar" to context menu for sidebar, which users can use when encounter other critical issues like with unclickable tabs, or in wrong order, etc.
- Fixed "Error: Could not establish connection. Receiving end does not exist" at least when either:
   A. caching is disabled (configs.useCachedTree = false) OR 
   B. if configs.useCachedTreeBackgroundExport = false (left = true for now) (not exposed in Options UI)

### Remaining Issues from #2238 still not fixed

1. "Error: Could not establish connection. Receiving end does not exist" still occurs when caching is enabled
   - I added configs.useCachedTreeBackgroundExport option 
   - I left true by default for now 
   - I suggest you set = false after testing further with session restore cache use (may prevent that, or that may be already be prevented due to that error remaining anyways)
2. Tabs opened soon after Firefox startup (with TST sidebar auto shown on startup) *while TST is initializing*
   - For example if was to open "https://trakt.tv/calendars/my/shows", end up with animated loading icon showing forever,
   - Sometimes (not always) also shows only URL (instead of title) and/or has FaviconLoader error 
3. sendMessage(kCOMMAND_PULL_TABS) in rebuildAll() in background.js is returning undefined
   - At least this occurs when this is auto-called early on during init, but maybe anyways before too
   - Not mentioned in #2238 yet, but may be related to above 2 remaining issues
   - I fixed the error to handle undefined, but may be underlying issue causing this to happen which may relate to remaining unfixed startup issues described in #2238


