### PR TITLE
[WIP] Allocate less

### DIFF
--- a/webextensions/background/background-cache.js
+++ b/webextensions/background/background-cache.js
@@ -6,6 +6,7 @@
 'use strict';
 
 import {
+  filterMap,
   log as internalLogger,
   dumpTab,
   wait,
@@ -228,9 +229,8 @@ function fixupTabRestoredFromCache(tab, permanentStates, cachedTab, idMap) {
   tab.$TST.attributes = cachedTab.$TST.attributes;
 
   log('fixupTabRestoredFromCache children: ', cachedTab.$TST.childIds);
-  const childTabs = cachedTab.$TST.childIds
-    .map(oldId => idMap.get(oldId))
-    .filter(tab => !!tab);
+  const childTabs = filterMap(cachedTab.$TST.childIds, oldId =>
+    idMap.get(oldId) || undefined);
   tab.$TST.children = childTabs;
   if (childTabs.length > 0)
     tab.$TST.setAttribute(Constants.kCHILDREN, `|${childTabs.map(tab => tab.id).join('|')}|`);

--- a/webextensions/background/handle-misc.js
+++ b/webextensions/background/handle-misc.js
@@ -6,6 +6,7 @@
 'use strict';
 
 import {
+  filterMap,
   log as internalLogger,
   wait,
   configs
@@ -650,7 +651,12 @@ function onMessageExternal(message, sender) {
     case TSTAPI.kGRANT_TO_REMOVE_TABS:
       return (async () => {
         const tabs = await TSTAPI.getTargetTabs(message, sender);
-        const grantedRemovingTabIds = configs.grantedRemovingTabIds.concat(Array.from(tabs).filter(TabsStore.ensureLivingTab).map(tab => tab.id));
+        const grantedRemovingTabIds = configs
+          .grantedRemovingTabIds
+          .concat(filterMap(Array.from(tabs), tab => {
+            tab = TabsStore.ensureLivingTab(tab);
+            return tab ? tab.id : undefined;
+          }));
         configs.grantedRemovingTabIds = Array.from(new Set(grantedRemovingTabIds));
         return true;
       })();

--- a/webextensions/background/tab-context-menu.js
+++ b/webextensions/background/tab-context-menu.js
@@ -6,6 +6,7 @@
 'use strict';
 
 import {
+  filterMap,
   log as internalLogger,
   configs
 } from '/common/common.js';
@@ -673,7 +674,7 @@ async function onClick(info, contextTab) {
       browser.tabs.highlight({
         windowId,
         populate: false,
-        tabs:     [activeTab.index].concat(tabs.filter(tab => !tab.active).map(tab => tab.index))
+        tabs:     [activeTab.index].concat(filterMap(tabs, tab => !tab.active ? tab.index : undefined))
       }).catch(ApiTabs.createErrorSuppressor());
     }; break;
     case 'context_bookmarkTab':
@@ -725,7 +726,7 @@ async function onClick(info, contextTab) {
           multiselectedTabs.map(tab => tab.id) :
           [contextTab.id]
       );
-      const closeTabs = tabs.filter(tab => !tab.pinned && !keptTabIds.has(tab.id)).map(tab => Tab.get(tab.id));
+      const closeTabs = filterMap(tabs, tab => !tab.pinned && !keptTabIds.has(tab.id) ? Tab.get(tab.id) : undefined);
       const canceled = (await browser.runtime.sendMessage({
         type: Constants.kCOMMAND_NOTIFY_TABS_CLOSING,
         tabs: closeTabs.map(tab => tab.$TST.sanitized),

--- a/webextensions/common/Tab.js
+++ b/webextensions/common/Tab.js
@@ -589,7 +589,7 @@ export default class Tab {
   }
 
   sortChildren() {
-    this.childIds = Tab.sort(this.childIds.map(id => Tab.get(id))).map(tab => tab && tab.id);
+    this.childIds.sort((a, b) => Tab.compare(Tab.get(a), Tab.get(b)));
     this.invalidateCachedDescendants();
   }
 
@@ -1789,11 +1789,9 @@ Tab.doAndGetNewTabs = async (asyncTask, windowId) => {
   return addedTabs.map(tab => Tab.get(tab.id));
 };
 
-Tab.sort = tabs => {
-  if (tabs.length == 0)
-    return tabs;
-  return tabs.sort((a, b) => a.index - b.index);
-};
+Tab.compare = (a, b) => a.index - b.index;
+
+Tab.sort = tabs => tabs.length == 0 ? tabs : tabs.sort(Tab.compare);
 
 Tab.dumpAll = windowId => {
   if (!configs.debug)

--- a/webextensions/common/common.js
+++ b/webextensions/common/common.js
@@ -305,7 +305,7 @@ export const configs = new Configs({
 
   testKey: 0 // for tests/utils.js
 }, {
-  localKeys: `
+  localKeys: filterMap(`
     optionsExpandedSections
     sidebarPosition
     sidebarDirection
@@ -324,7 +324,10 @@ export const configs = new Configs({
     requestingPermissions
     requestingPermissionsNatively
     testKey
-  `.trim().split('\n').map(key => key.trim()).filter(key => key && key.indexOf('//') != 0)
+  `.trim().split('\n'), key => {
+    key = key.trim();
+    return key.indexOf('//') != 0 ? key : undefined;
+  })
 });
 
 configs.$loaded.then(() => {
@@ -332,6 +335,41 @@ configs.$loaded.then(() => {
   if (!configs.debug)
     log.logs = [];
 });
+
+
+export function filterMap(arr, callback, thisArg) {
+  if (arr == null) {
+    throw new TypeError('arr is null or undefined');
+  }
+
+  arr = Object(arr);
+  const maxi = arr.length >>> 0;
+
+  if (typeof callback !== 'function')
+    throw new TypeError(`${callback} is not a function`);
+
+  callback = callback.bind(thisArg == undefined ? arr : thisArg);
+
+  const newArr = new Array(maxi);
+  let counti = 0,
+      i = 0,
+      value,
+      newValue;
+
+  while (i < maxi) {
+    if (i in arr) {
+      value = arr[i];
+      newValue = callback(value, i, arr);
+      if (newValue !== undefined) {
+        newArr[counti++] = newValue;
+      }
+      i++;
+    }
+  }
+
+  newArr.length = counti;
+  return newArr;
+}
 
 
 export function log(module, ...args)

--- a/webextensions/common/tabs-internal-operation.js
+++ b/webextensions/common/tabs-internal-operation.js
@@ -8,6 +8,7 @@
 // internal operations means operations bypassing WebExtensions' tabs APIs.
 
 import {
+  filterMap,
   log as internalLogger,
   dumpTab,
   configs
@@ -46,8 +47,8 @@ export async function activateTab(tab, options = {}) {
       const highlightedTabs = Tab.getHighlightedTabs(tab.windowId);
       if (highlightedTabs.some(highlightedTab => highlightedTab.id == tab.id)) {
         // switch active tab with highlighted state
-        const otherTabs = highlightedTabs.filter(highlightedTab => highlightedTab.id != tab.id);
-        tabs = tabs.concat(otherTabs.map(tab => tab.index));
+        tabs = filterMap(highlightedTabs, highlightedTab =>
+          highlightedTab.id != tab.id ? tab.index : undefined);
       }
     }
     if (tabs.length == 1)

--- a/webextensions/common/tabs-store.js
+++ b/webextensions/common/tabs-store.js
@@ -171,31 +171,38 @@ function* getMatchedTabsIterator(tabs, query, offset) {
 }
 
 function matchedWithQuery(tab, query) {
-  for (const attribute of MATCHING_ATTRIBUTES) {
+  for (let i = 0, maxi = MATCHING_ATTRIBUTES.length; i < maxi; i++) {
+    const attribute = MATCHING_ATTRIBUTES[i];
+
     if (attribute in query &&
         !matched(tab[attribute], query[attribute]))
       return false;
-    if (`!${attribute}` in query &&
-        matched(tab[attribute], query[`!${attribute}`]))
+    const bangAttribute = `!${attribute}`
+    if (bangAttribute in query &&
+        matched(tab[attribute], query[bangAttribute]))
       return false;
   }
 
   if (!tab.$TST)
     return false;
 
-  if ('states' in query && tab.$TST.states) {
+  const tstStates = tab.$TST.states;
+  if ('states' in query && tstStates) {
+    const states    = query.states;
     for (let i = 0, maxi = query.states.length; i < maxi; i += 2) {
-      const state   = query.states[i];
-      const pattern = query.states[i+1];
-      if (!matched(tab.$TST.states.has(state), pattern))
+      const state   = states[i];
+      const pattern = states[i+1];
+      if (!matched(tstStates.has(state), pattern))
         return false;
     }
   }
-  if ('attributes' in query && tab.$TST.attributes) {
-    for (let i = 0, maxi = query.attributes.length; i < maxi; i += 2) {
-      const attribute = query.attributes[i];
-      const pattern   = query.attributes[i+1];
-      if (!matched(tab.$TST.attributes[attribute], pattern))
+  const tstAttributes = tab.$TST.attributes;
+  if ('attributes' in query && tstAttributes) {
+    const attributes    = query.attributes;
+    for (let i = 0, maxi = attributes.length; i < maxi; i += 2) {
+      const attribute = attributes[i];
+      const pattern   = attributes[i+1];
+      if (!matched(tstAttributes[attribute], pattern))
         return false;
     }
   }
@@ -205,18 +212,18 @@ function matchedWithQuery(tab, query) {
     return false;
   if (query.normal &&
       (tab.hidden ||
-       tab.$TST.states.has(Constants.kTAB_STATE_SHOWING) ||
+       tstStates.has(Constants.kTAB_STATE_SHOWING) ||
        tab.pinned))
     return false;
   if (query.visible &&
-      ((tab.$TST.states.has(Constants.kTAB_STATE_COLLAPSED) &&
-        !tab.$TST.states.has(Constants.kTAB_STATE_EXPANDING)) ||
+      ((tstStates.has(Constants.kTAB_STATE_COLLAPSED) &&
+        !tstStates.has(Constants.kTAB_STATE_EXPANDING)) ||
        tab.hidden ||
-       tab.$TST.states.has(Constants.kTAB_STATE_SHOWING)))
+       tstStates.has(Constants.kTAB_STATE_SHOWING)))
     return false;
   if (query.controllable &&
       (tab.hidden ||
-       tab.$TST.states.has(Constants.kTAB_STATE_SHOWING)))
+       tstStates.has(Constants.kTAB_STATE_SHOWING)))
     return false;
   if ('hasChild' in query &&
       query.hasChild != tab.$TST.hasChild)

--- a/webextensions/common/tabs-update.js
+++ b/webextensions/common/tabs-update.js
@@ -27,6 +27,7 @@
 'use strict';
 
 import {
+  filterMap,
   log as internalLogger,
   dumpTab,
   wait
@@ -392,7 +393,10 @@ export async function updateTabsHighlighted(highlightInfo) {
     ordered: false,
     '!id':   tabIds
   });
-  const highlightedTabs = tabIds.map(id => window.tabs.get(id)).filter(tab => tab && !tab.highlighted);
+  const highlightedTabs = filterMap(tabIds, id => {
+    const tab = window.tabs.get(id);
+    return tab && !tab.highlighted ? tab : undefined;
+  });
 
   //console.log(`updateTabsHighlighted: ${Date.now() - startAt}ms`);
 

--- a/webextensions/package-lock.json
+++ b/webextensions/package-lock.json
@@ -580,9 +580,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         }
       }
@@ -678,9 +678,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "path-parse": {
@@ -1025,9 +1025,9 @@
           "dev": true
         },
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "strip-ansi": {
@@ -1787,9 +1787,9 @@
           "dev": true
         },
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "string-width": {

--- a/webextensions/sidebar/drag-and-drop.js
+++ b/webextensions/sidebar/drag-and-drop.js
@@ -28,6 +28,7 @@
 import RichConfirm from '/extlib/RichConfirm.js';
 
 import {
+  filterMap,
   log as internalLogger,
   wait,
   configs
@@ -216,7 +217,7 @@ function getDropAction(event) {
     if (dragData && dragData.instanceId != mInstanceId)
       return [];
     const tabs     = dragData && dragData.tabs;
-    return tabs && tabs.map(tab => tab && Tab.get(tab.id) || tab).filter(tab => !!tab) || [];
+    return tabs && filterMap(tabs, tab => tab && Tab.get(tab.id) || tab || undefined) || [];
   });
   info.defineGetter('draggedTabIds', () => {
     return info.draggedTabs.map(tab => tab.id);


### PR DESCRIPTION
TST likes to suck up my CPU when it's doing nothing due to causing a bunch of tiny GC runs while mostly idle. Sometimes those pauses are noticeable in FX's UI. This PR helps by avoiding a ton of allocations on hot idle spots, but there are still significant issues while doing things like dragging tabs around or even opening new tabs (though to a lesser extent). Tested on a browser with ~1400 real tabs currently open, but without a lot of the more nested tree structure that normally makes this worse because somehow my session borked. (If you want me to profile more with that original worse-performing setup, I can do so by reorganizing my current session back to how it was; just say so and I'll try to speed up that when I've got time.)

The main thing is to stop using friendly APIs that copy a lot when dealing with things like the whole set of tabs, because that gets way more pathological as tab counts grow. JavaScript doesn't have Haskell's stream fusion. (Side thought: it might be helpful rewriting TST's core in something that emits Wasm, like AssemblyScript or Rust, so you can deal with the amortized cost of a linear memory slab and probably allocate less on top, reducing CPU pressure? I'm not sure if it'd be worthwhile, though; skimming the newest profile's allocation metrics makes me think heavier knowledge of the TST addon API & code would be required to move forward.)

This could be merged now, but I'm not sure about how to reduce some of the bigger allocation issues. (I'll upload some profiles below for examples on just switching tabs while otherwise idle, and actually idling. I unfortunately forgot to save my original profiles, but the GC pauses were a lot worse & more consistent.)

[idle-profile.json.gz](https://github.com/piroor/treestyletab/files/3532290/idle-profile.json.gz)

[idle-ish-profile.json.gz](https://github.com/piroor/treestyletab/files/3532297/idle-ish-profile.json.gz)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/piroor/treestyletab/2368)
<!-- Reviewable:end -->
