### PR TITLE
Use a custom element to implement tab-favicon

### DIFF
--- a/webextensions/common/constants.js
+++ b/webextensions/common/constants.js
@@ -6,7 +6,7 @@
 'use strict';
 
 export const kBACKGROUND_CONTENTS_VERSION = 5;
-export const kSIDEBAR_CONTENTS_VERSION    = 10;
+export const kSIDEBAR_CONTENTS_VERSION    = 11;
 
 export const kCOMMAND_GET_INSTANCE_ID                = 'treestyletab:get-instance-id';
 export const kCOMMAND_RELOAD                         = 'treestyletab:reload';

--- a/webextensions/common/constants.js
+++ b/webextensions/common/constants.js
@@ -113,7 +113,6 @@ export const kPERSISTENT_SUBTREE_COLLAPSED = 'subtree-collapsed'; // obsolete
 export const kPERSISTENT_ORIGINAL_OPENER_TAB_ID            = 'data-original-opener-tab-id';
 export const kPERSISTENT_ALREADY_GROUPED_FOR_PINNED_OPENER = 'data-already-grouped-for-pinned-opener';
 
-export const kFAVICON         = 'favicon';
 export const kFAVICON_IMAGE   = 'favicon-image';
 export const kFAVICON_BUILTIN = 'favicon-builtin';
 export const kFAVICON_DEFAULT = 'favicon-default'; // just for backward compatibility, and this should be removed from future versions

--- a/webextensions/sidebar/components/TabCloseBoxElement.js
+++ b/webextensions/sidebar/components/TabCloseBoxElement.js
@@ -23,6 +23,8 @@ function getTooltipLabelKey(tooltipType) {
 
 export const kTAB_CLOSE_BOX_ELEMENT_NAME = 'tab-closebox';
 
+const kTAB_CLOSE_BOX_CLASS_NAME = 'closebox';
+
 export class TabCloseBoxElement extends HTMLElement {
   static define() {
     window.customElements.define(kTAB_CLOSE_BOX_ELEMENT_NAME, TabCloseBoxElement);
@@ -46,6 +48,10 @@ export class TabCloseBoxElement extends HTMLElement {
     //      "6. If result has children, then throw a "NotSupportedError" DOMException."
     //  * `connectedCallback()` may be called multiple times by append/remove operations.
     //  * `browser.i18n.getMessage()` might be a costly operation.
+
+    // We preserve this class for backward compatibility with other addons.
+    this.classList.add(kTAB_CLOSE_BOX_CLASS_NAME);
+
     this.setAttribute('title', browser.i18n.getMessage(NORMAL_TOOLTIP));
     this.setAttribute('draggable', true); // this is required to cancel click by dragging
 

--- a/webextensions/sidebar/components/TabFaviconElement.js
+++ b/webextensions/sidebar/components/TabFaviconElement.js
@@ -44,4 +44,8 @@ export class TabFaviconElement extends HTMLElement {
 
     this._isInitialized = true;
   }
+
+  getImageElement() {
+    return this.firstElementChild;
+  }
 }

--- a/webextensions/sidebar/components/TabFaviconElement.js
+++ b/webextensions/sidebar/components/TabFaviconElement.js
@@ -1,7 +1,47 @@
+import * as Constants from '/common/constants.js';
+
 export const kTAB_FAVICON_ELEMENT_NAME = 'tab-favicon';
 
 export class TabFaviconElement extends HTMLElement {
   static define() {
     window.customElements.define(kTAB_FAVICON_ELEMENT_NAME, TabFaviconElement);
+  }
+
+  constructor() {
+    super();
+
+    this._isInitialized = false;
+  }
+
+  connectedCallback() {
+    if (this._isInitialized) {
+      return;
+    }
+
+    // I make ensure to call these operation only once conservatively because:
+    //  * If we do these operations in a constructor of this class, Gecko throws `NotSupportedError: Operation is not supported`.
+    //    * I'm not familiar with details of the spec, but this is not Gecko's bug.
+    //      See https://dom.spec.whatwg.org/#concept-create-element
+    //      "6. If result has children, then throw a "NotSupportedError" DOMException."
+    //  * `connectedCallback()` may be called multiple times by append/remove operations.
+    //
+    // FIXME:
+    //  Ideally, these descendants should be in shadow tree. Thus I don't change these element to custom elements.
+    //  However, I hesitate to do it at this moment by these reasons.
+    //  If we move these to shadow tree,
+    //    * We need some rewrite our style.
+    //      * This includes that we need to move almost CSS code into this file as a string.
+    //    * I'm not sure about that whether we should require [CSS Shadow Parts](https://bugzilla.mozilla.org/show_bug.cgi?id=1559074).
+    //      * I suspect we can resolve almost problems by using CSS Custom Properties.
+    const faviconImage = this.appendChild(document.createElement('img'));
+    faviconImage.classList.add(Constants.kFAVICON_IMAGE);
+    const defaultIcon = this.appendChild(document.createElement('span'));
+    defaultIcon.classList.add(Constants.kFAVICON_BUILTIN);
+    defaultIcon.classList.add(Constants.kFAVICON_DEFAULT); // just for backward compatibility, and this should be removed from future versions
+
+    const throbber = this.appendChild(document.createElement('span'));
+    throbber.classList.add(Constants.kTHROBBER);
+
+    this._isInitialized = true;
   }
 }

--- a/webextensions/sidebar/components/TabFaviconElement.js
+++ b/webextensions/sidebar/components/TabFaviconElement.js
@@ -1,0 +1,7 @@
+export const kTAB_FAVICON_ELEMENT_NAME = 'tab-favicon';
+
+export class TabFaviconElement extends HTMLElement {
+  static define() {
+    window.customElements.define(kTAB_FAVICON_ELEMENT_NAME, TabFaviconElement);
+  }
+}

--- a/webextensions/sidebar/components/TabFaviconElement.js
+++ b/webextensions/sidebar/components/TabFaviconElement.js
@@ -2,6 +2,8 @@ import * as Constants from '/common/constants.js';
 
 export const kTAB_FAVICON_ELEMENT_NAME = 'tab-favicon';
 
+const KFAVICON_CLASS_NAME = 'favicon';
+
 export class TabFaviconElement extends HTMLElement {
   static define() {
     window.customElements.define(kTAB_FAVICON_ELEMENT_NAME, TabFaviconElement);
@@ -33,6 +35,10 @@ export class TabFaviconElement extends HTMLElement {
     //      * This includes that we need to move almost CSS code into this file as a string.
     //    * I'm not sure about that whether we should require [CSS Shadow Parts](https://bugzilla.mozilla.org/show_bug.cgi?id=1559074).
     //      * I suspect we can resolve almost problems by using CSS Custom Properties.
+
+    // We preserve this class for backward compatibility with other addons.
+    this.classList.add(KFAVICON_CLASS_NAME);
+
     const faviconImage = this.appendChild(document.createElement('img'));
     faviconImage.classList.add(Constants.kFAVICON_IMAGE);
     const defaultIcon = this.appendChild(document.createElement('span'));

--- a/webextensions/sidebar/components/TabFaviconElement.js
+++ b/webextensions/sidebar/components/TabFaviconElement.js
@@ -4,9 +4,15 @@ export const kTAB_FAVICON_ELEMENT_NAME = 'tab-favicon';
 
 const KFAVICON_CLASS_NAME = 'favicon';
 
+const kATTR_NAME_SRC = 'src';
+
 export class TabFaviconElement extends HTMLElement {
   static define() {
     window.customElements.define(kTAB_FAVICON_ELEMENT_NAME, TabFaviconElement);
+  }
+
+  static get observedAttributes() {
+    return [kATTR_NAME_SRC];
   }
 
   constructor() {
@@ -41,6 +47,9 @@ export class TabFaviconElement extends HTMLElement {
 
     const faviconImage = this.appendChild(document.createElement('img'));
     faviconImage.classList.add(Constants.kFAVICON_IMAGE);
+    const src = this.getAttribute(kATTR_NAME_SRC);
+    faviconImage.setAttribute(kATTR_NAME_SRC, src);
+
     const defaultIcon = this.appendChild(document.createElement('span'));
     defaultIcon.classList.add(Constants.kFAVICON_BUILTIN);
     defaultIcon.classList.add(Constants.kFAVICON_DEFAULT); // just for backward compatibility, and this should be removed from future versions
@@ -51,7 +60,35 @@ export class TabFaviconElement extends HTMLElement {
     this._isInitialized = true;
   }
 
-  getImageElement() {
+  attributeChangedCallback(name, oldValue, newValue, _namespace) {
+    if (oldValue === newValue) {
+      return;
+    }
+
+    switch (name) {
+      case kATTR_NAME_SRC: {
+        this._updateSrc(newValue);
+        break;
+      }
+      default:
+        throw new RangeError(`Handling \`${name}\` attribute has not been defined.`);
+    }
+  }
+
+  _updateSrc(newValue) {
+    const img = this._getImageElement();
+    if (!img) {
+      return;
+    }
+    img.setAttribute(kATTR_NAME_SRC, newValue);
+  }
+
+  _getImageElement() {
     return this.firstElementChild;
+  }
+
+  // These setter/getter is required by webextensions-lib-tab-favicon-helper
+  set src(value) {
+    this.setAttribute(kATTR_NAME_SRC, value);
   }
 }

--- a/webextensions/sidebar/sidebar-tabs.js
+++ b/webextensions/sidebar/sidebar-tabs.js
@@ -606,7 +606,7 @@ export function applyStatesToElement(tab) {
 
   const openerOfGroupTab = tab.$TST.isGroupTab && Tab.getOpenerFromGroupTab(tab);
   TabFavIconHelper.loadToImage({
-    image: getFavIcon(tab).getImageElement(),
+    image: getFavIcon(tab),
     tab,
     url: openerOfGroupTab && openerOfGroupTab.favIconUrl || tab.favIconUrl
   });
@@ -1176,7 +1176,7 @@ BackgroundConnection.onMessage.addListener(async message => {
         return;
       tab.favIconUrl = message.favIconUrl;
       TabFavIconHelper.loadToImage({
-        image: getFavIcon(tab).getImageElement(),
+        image: getFavIcon(tab),
         tab,
         url: message.favIconUrl
       });

--- a/webextensions/sidebar/sidebar-tabs.js
+++ b/webextensions/sidebar/sidebar-tabs.js
@@ -550,13 +550,6 @@ Tab.onInitialized.addListener((tab, _info) => {
   tabElement.insertBefore(twisty, label);
 
   const favicon = document.createElement(kTAB_FAVICON_ELEMENT_NAME);
-  const faviconImage = favicon.appendChild(document.createElement('img'));
-  faviconImage.classList.add(Constants.kFAVICON_IMAGE);
-  const defaultIcon = favicon.appendChild(document.createElement('span'));
-  defaultIcon.classList.add(Constants.kFAVICON_BUILTIN);
-  defaultIcon.classList.add(Constants.kFAVICON_DEFAULT); // just for backward compatibility, and this should be removed from future versions
-  const throbber = favicon.appendChild(document.createElement('span'));
-  throbber.classList.add(Constants.kTHROBBER);
   tabElement.insertBefore(favicon, label);
 
   const counter = document.createElement('span');

--- a/webextensions/sidebar/sidebar-tabs.js
+++ b/webextensions/sidebar/sidebar-tabs.js
@@ -606,7 +606,7 @@ export function applyStatesToElement(tab) {
 
   const openerOfGroupTab = tab.$TST.isGroupTab && Tab.getOpenerFromGroupTab(tab);
   TabFavIconHelper.loadToImage({
-    image: getFavIcon(tab).firstChild,
+    image: getFavIcon(tab).getImageElement(),
     tab,
     url: openerOfGroupTab && openerOfGroupTab.favIconUrl || tab.favIconUrl
   });
@@ -1176,7 +1176,7 @@ BackgroundConnection.onMessage.addListener(async message => {
         return;
       tab.favIconUrl = message.favIconUrl;
       TabFavIconHelper.loadToImage({
-        image: getFavIcon(tab).firstChild,
+        image: getFavIcon(tab).getImageElement(),
         tab,
         url: message.favIconUrl
       });

--- a/webextensions/sidebar/sidebar-tabs.js
+++ b/webextensions/sidebar/sidebar-tabs.js
@@ -104,7 +104,7 @@ function getTwisty(tab) {
 }
 
 function getFavIcon(tab) {
-  return tab && tab.$TST.element && tab.$TST.element.querySelector(`.${Constants.kFAVICON}`);
+  return tab && tab.$TST.element && tab.$TST.element.querySelector(kTAB_FAVICON_ELEMENT_NAME);
 }
 
 function getSoundButton(tab) {
@@ -550,7 +550,6 @@ Tab.onInitialized.addListener((tab, _info) => {
   tabElement.insertBefore(twisty, label);
 
   const favicon = document.createElement(kTAB_FAVICON_ELEMENT_NAME);
-  favicon.classList.add(Constants.kFAVICON);
   const faviconImage = favicon.appendChild(document.createElement('img'));
   faviconImage.classList.add(Constants.kFAVICON_IMAGE);
   const defaultIcon = favicon.appendChild(document.createElement('span'));

--- a/webextensions/sidebar/sidebar-tabs.js
+++ b/webextensions/sidebar/sidebar-tabs.js
@@ -32,6 +32,10 @@ import {
   TabCloseBoxElement,
   CloseBoxTooltipType,
 } from './components/TabCloseBoxElement.js';
+import {
+  kTAB_FAVICON_ELEMENT_NAME,
+  TabFaviconElement,
+} from './components/TabFaviconElement.js';
 
 function log(...args) {
   internalLogger('sidebar/sidebar-tabs', ...args);
@@ -56,6 +60,7 @@ export function init() {
   // but I think that it's safely to call `window.customElements.define(localName, constructor)` separately
   // in the application initialization phase.
   TabCloseBoxElement.define();
+  TabFaviconElement.define();
 
   document.querySelector('#sync-throbber').addEventListener('animationiteration', synchronizeThrobberAnimation);
 
@@ -544,7 +549,7 @@ Tab.onInitialized.addListener((tab, _info) => {
   twisty.setAttribute('title', browser.i18n.getMessage('tab_twisty_collapsed_tooltip'));
   tabElement.insertBefore(twisty, label);
 
-  const favicon = document.createElement('span');
+  const favicon = document.createElement(kTAB_FAVICON_ELEMENT_NAME);
   favicon.classList.add(Constants.kFAVICON);
   const faviconImage = favicon.appendChild(document.createElement('img'));
   faviconImage.classList.add(Constants.kFAVICON_IMAGE);

--- a/webextensions/sidebar/sidebar-tabs.js
+++ b/webextensions/sidebar/sidebar-tabs.js
@@ -29,12 +29,10 @@ import EventListenerManager from '/extlib/EventListenerManager.js';
 
 import {
   kTAB_CLOSE_BOX_ELEMENT_NAME,
-  TabCloseBoxElement,
   CloseBoxTooltipType,
 } from './components/TabCloseBoxElement.js';
 import {
   kTAB_FAVICON_ELEMENT_NAME,
-  TabFaviconElement,
 } from './components/TabFaviconElement.js';
 
 function log(...args) {
@@ -51,17 +49,6 @@ export const wholeContainer = document.querySelector('#all-tabs');
 export const onSyncFailed = new EventListenerManager();
 
 export function init() {
-  // If we call `window.customElements.define(localName, constructor)`;` from a file defining a custom element,
-  // it would be a side-effect and happen accidentally that defining a custom element
-  // when we import a new file which defines a new custom element.
-  // It causes a complex side-effect relations and usually causes a bug. It's tough to fix.
-  //
-  // I have not concluded the best practice about it yet,
-  // but I think that it's safely to call `window.customElements.define(localName, constructor)` separately
-  // in the application initialization phase.
-  TabCloseBoxElement.define();
-  TabFaviconElement.define();
-
   document.querySelector('#sync-throbber').addEventListener('animationiteration', synchronizeThrobberAnimation);
 
   document.documentElement.setAttribute(Constants.kLABEL_OVERFLOW, configs.labelOverflowStyle);

--- a/webextensions/sidebar/sidebar.html
+++ b/webextensions/sidebar/sidebar.html
@@ -95,7 +95,7 @@
       <span id="dummy-highlight-color-box"></span>
       <span class="throbber"><span id="sync-throbber"></span></span>
       <li id="dummy-tab" class="tab">
-        <tab-favicon><span class="throbber" id="master-throbber-container"><span id="master-throbber"></span></span></tab-favicon>
+        <tab-favicon class="favicon"><span class="throbber" id="master-throbber-container"><span id="master-throbber"></span></span></tab-favicon>
         <span class="label">-</span>
         <span class="counter">0</span>
         <span class="closebox"></button>

--- a/webextensions/sidebar/sidebar.html
+++ b/webextensions/sidebar/sidebar.html
@@ -95,7 +95,7 @@
       <span id="dummy-highlight-color-box"></span>
       <span class="throbber"><span id="sync-throbber"></span></span>
       <li id="dummy-tab" class="tab">
-        <span class="favicon"><span class="throbber" id="master-throbber-container"><span id="master-throbber"></span></span></span>
+        <tab-favicon><span class="throbber" id="master-throbber-container"><span id="master-throbber"></span></span></tab-favicon>
         <span class="label">-</span>
         <span class="counter">0</span>
         <span class="closebox"></button>

--- a/webextensions/sidebar/sidebar.js
+++ b/webextensions/sidebar/sidebar.js
@@ -29,6 +29,10 @@ import * as MetricsData from '/common/metrics-data.js';
 import Tab from '/common/Tab.js';
 import Window from '/common/Window.js';
 
+
+import { TabCloseBoxElement } from './components/TabCloseBoxElement.js';
+import { TabFaviconElement } from './components/TabFaviconElement.js';
+
 import * as BackgroundConnection from './background-connection.js';
 import * as SidebarCache from './sidebar-cache.js';
 import * as SidebarTabs from './sidebar-tabs.js';
@@ -91,6 +95,21 @@ UserOperationBlocker.block({ throbber: true });
 export async function init() {
   MetricsData.add('init: start');
   log('initialize sidebar on load');
+
+  // If we call `window.customElements.define(localName, constructor)`;` from a file defining a custom element,
+  // it would be a side-effect and happen accidentally that defining a custom element
+  // when we import a new file which defines a new custom element.
+  // It causes a complex side-effect relations and usually causes a bug. It's tough to fix.
+  //
+  // I have not concluded the best practice about it yet,
+  // but I think that it's safely to call `window.customElements.define(localName, constructor)` separately
+  // in the application initialization phase.
+  //
+  // XXX:
+  //  We define our custom elements at first to avoid a problem which calls a method of custom element
+  //  which has not been defined yet.
+  TabCloseBoxElement.define();
+  TabFaviconElement.define();
 
   // Read caches from existing tabs at first, for better performance.
   // Those promises will be resolved while waiting other operations.

--- a/webextensions/sidebar/styles/base.css
+++ b/webextensions/sidebar/styles/base.css
@@ -276,8 +276,8 @@ ul {
 
 .tab .highlighter,
 .tab .burster,
-.tab.faviconized.unread .favicon::before,
-.tab.attention .favicon::before,
+.tab.faviconized.unread tab-favicon::before,
+.tab.attention tab-favicon::before,
 .tab .extra-items-container.behind {
   bottom: 0;
   left: 0;
@@ -300,8 +300,8 @@ ul {
   z-index: 4000;
 }
 
-.tab.faviconized.unread .favicon::before,
-.tab.attention .favicon::before {
+.tab.faviconized.unread tab-favicon::before,
+.tab.attention tab-favicon::before {
   bottom: auto;
   content: '';
   height: var(--faviconized-tab-size);
@@ -349,13 +349,13 @@ ul {
   display: none;
 }
 
-.tab.faviconized.unread:not(.active):not(:hover) .favicon::before,
-.tab.attention:not(:hover) .favicon::before {
+.tab.faviconized.unread:not(.active):not(:hover) tab-favicon::before,
+.tab.attention:not(:hover) tab-favicon::before {
   background-image: var(--attention-marker-gradient);
 }
 
-.tab.faviconized.unread:not(.active):hover .favicon::before,
-.tab.attention:hover .favicon::before {
+.tab.faviconized.unread:not(.active):hover tab-favicon::before,
+.tab.attention:hover tab-favicon::before {
   background-image: var(--attention-marker-gradient-hover);
 }
 

--- a/webextensions/sidebar/styles/favicon.css
+++ b/webextensions/sidebar/styles/favicon.css
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-.favicon {
+tab-favicon {
   display: inline-block;
   font-size: var(--favicon-size);
   height: var(--favicon-size);
@@ -19,11 +19,11 @@
   white-space: pre;
   width: var(--favicon-size);
 }
-.tab .favicon,
-.tab .favicon * {
+.tab tab-favicon,
+.tab tab-favicon * {
   vertical-align: baseline;
 }
-.tab .favicon * {
+.tab tab-favicon * {
   position: relative;
   z-index: 20;
 }

--- a/webextensions/sidebar/styles/favicon.css
+++ b/webextensions/sidebar/styles/favicon.css
@@ -107,7 +107,7 @@ tab-favicon {
 }
 
 
-.tab.group-tab .favicon-image[src]:not(.error) {
+.tab.group-tab tab-favicon:not(.error) .favicon-image[src] {
   bottom: 0;
   max-height: 10px;
   max-width: 10px;
@@ -117,14 +117,14 @@ tab-favicon {
 }
 
 
-.favicon-image.error,
+tab-favicon.error .favicon-image,
 .favicon-image:not([src]),
 .tab[data-current-uri^="chrome:"] .favicon-image,
 .tab[data-current-uri^="about:addons"] .favicon-image,
 .tab[data-current-uri^="about:debugging"] .favicon-image,
 .tab[data-current-uri^="about:preferences"] .favicon-image,
 .tab:not(.group-tab):not([data-current-uri^="chrome:"]):not([data-current-uri^="about:addons"]):not([data-current-uri^="about:debugging"]):not([data-current-uri^="about:preferences"])
-  .favicon-image[src]:not(.error) ~ .favicon-builtin::before,
+  tab-favicon:not(.error) .favicon-image[src] ~ .favicon-builtin::before,
 .tab.loading .favicon-image,
 .tab.loading .favicon-builtin::before {
   display: none !important;

--- a/webextensions/sidebar/styles/metal/metal.css
+++ b/webextensions/sidebar/styles/metal/metal.css
@@ -67,7 +67,7 @@
   padding-right: var(--scrollbar-placeholder-size); /* it will be enough larger than the default padding */
 }
 
-.favicon {
+tab-favicon {
   background: url("icon-bg.png") no-repeat bottom;
   background-size: 100%;
   padding: 0 3px 3px;
@@ -100,8 +100,8 @@ tab-closebox {
   padding: 2px 4px 2px 3px;
 }
 
-.tab.faviconized.unread .favicon::before,
-.tab.attention .favicon::before {
+.tab.faviconized.unread tab-favicon::before,
+.tab.attention tab-favicon::before {
   left: calc(var(--attention-marker-x-offset) + 3px);
 }
 

--- a/webextensions/sidebar/styles/square/base.css
+++ b/webextensions/sidebar/styles/square/base.css
@@ -37,7 +37,7 @@
   padding: 0 0 0.25em 0;
 }
 
-.tab .favicon {
+.tab tab-favicon {
   margin-bottom: 0.25em;
   margin-top: 0.25em;
 }

--- a/webextensions/sidebar/styles/square/border.css
+++ b/webextensions/sidebar/styles/square/border.css
@@ -43,7 +43,7 @@
   border-right-width: 1px;
 }
 
-.tab .favicon {
+.tab tab-favicon {
   margin-bottom: 0.25em;
   margin-top: 0.25em;
 }


### PR DESCRIPTION
* This simply replace `span` element to `tab-favicon` custom element.
* Ideally, these descendants should be in shadow tree. Thus I don't change these element to custom elements. But I hesitate to do it at this moment by these reasons.
    * If we move these to shadow tree,
        * We need some rewrite our style.
            * This includes that we need to move almost CSS code into this file as a string.
            * I'm not sure about the decision to move CSS code as a string into each of custom element file. Of course, there are some pros/cons. 
        * I'm not sure about that whether we should require [CSS Shadow Parts](https://bugzilla.mozilla.org/show_bug.cgi?id=1559074).
        * I suspect we can resolve almost problems by using CSS Custom Properties.

## Related Issue

https://github.com/piroor/treestyletab/issues/2000