### PR TITLE
Avoid unnecessary shape transition for custom elements

### DIFF
--- a/webextensions/sidebar/components/TabCloseBoxElement.js
+++ b/webextensions/sidebar/components/TabCloseBoxElement.js
@@ -19,6 +19,7 @@ export class TabCloseBoxElement extends HTMLElement {
 
   constructor() {
     super();
+    this._reservedUpdate = null;
 
     this.initialized = false;
   }
@@ -51,7 +52,7 @@ export class TabCloseBoxElement extends HTMLElement {
       return;
 
     this._reservedUpdate = () => {
-      delete this._reservedUpdate;
+      this._reservedUpdate = null;
       this._updateTooltip();
     };
     this.addEventListener('mouseover', this._reservedUpdate, { once: true });

--- a/webextensions/sidebar/components/TabElement.js
+++ b/webextensions/sidebar/components/TabElement.js
@@ -63,6 +63,10 @@ export class TabElement extends HTMLElement {
 
   constructor() {
     super();
+    this._reservedUpdateTooltip = null;
+    this.__onMouseOver = null;
+    this.__onWindowResize = null;
+    this.__onConfigChange = null;
   }
 
   connectedCallback() {
@@ -232,7 +236,7 @@ export class TabElement extends HTMLElement {
       return;
 
     this._reservedUpdateTooltip = () => {
-      delete this._reservedUpdateTooltip;
+      this._reservedUpdateTooltip = null;
       this._updateTooltip();
     };
     this.addEventListener('mouseover', this._reservedUpdateTooltip, { once: true });
@@ -334,11 +338,11 @@ windowId = ${tab.windowId}
     if (!this.__onMouseOver)
       return;
     this.removeEventListener('mouseover', this.__onMouseOver);
-    delete this.__onMouseOver;
+    this.__onMouseOver = null;
     window.removeEventListener('resize', this.__onWindowResize);
-    delete this.__onWindowResize;
+    this.__onWindowResize = null;
     configs.$removeObserver(this.__onConfigChange);
-    delete this.__onConfigChange;
+    this.__onConfigChange = null;
   }
 
   _onMouseOver(_event) {

--- a/webextensions/sidebar/components/TabLabelElement.js
+++ b/webextensions/sidebar/components/TabLabelElement.js
@@ -22,6 +22,8 @@ export class TabLabelElement extends HTMLElement {
 
   constructor() {
     super();
+    this.__onOverflow = null;
+    this.__onUnderflow = null;
   }
 
   connectedCallback() {
@@ -118,8 +120,8 @@ export class TabLabelElement extends HTMLElement {
       return;
     this.removeEventListener('overflow', this.__onOverflow);
     this.removeEventListener('underflow', this.__onUnderflow);
-    delete this.__onOverflow;
-    delete this.__onUnderflow;
+    this.__onOverflow = null;
+    this.__onUnderflow = null;
   }
 
   _onOverflow(_event) {

--- a/webextensions/sidebar/components/TabSoundButtonElement.js
+++ b/webextensions/sidebar/components/TabSoundButtonElement.js
@@ -15,6 +15,7 @@ export class TabSoundButtonElement extends HTMLElement {
 
   constructor() {
     super();
+    this._reservedUpdate = null;
 
     this.initialized = false;
   }
@@ -46,7 +47,7 @@ export class TabSoundButtonElement extends HTMLElement {
       return;
 
     this._reservedUpdate = () => {
-      delete this._reservedUpdate;
+      this._reservedUpdate = null;
       this._updateTooltip();
     };
     this.addEventListener('mouseover', this._reservedUpdate, { once: true });

--- a/webextensions/sidebar/components/TabTwistyElement.js
+++ b/webextensions/sidebar/components/TabTwistyElement.js
@@ -18,6 +18,7 @@ export class TabTwistyElement extends HTMLElement {
 
   constructor() {
     super();
+    this._reservedUpdate = null;
 
     this.initialized = false;
   }
@@ -49,7 +50,7 @@ export class TabTwistyElement extends HTMLElement {
       return;
 
     this._reservedUpdate = () => {
-      delete this._reservedUpdate;
+      this._reservedUpdate = null;
       this._updateTooltip();
     };
     this.addEventListener('mouseover', this._reservedUpdate, { once: true });


### PR DESCRIPTION
`delete` causes to change a Shape (SM)/Hidden Class (V8)/Structure (JSC) in JSVM. They treats an object which we remove a property from by `detele` as _dictionary mode_ internally.

If we treat the object as dictionary or hashmap by adding/removeing properties frequently, this JSVM behavior is nice. But it would not be effectively if we treats the object as normal class.

Practically, to avoid unnecessary this kind of internal behavior and to stabilize object's shape,

1. We should initialize all properties with the same order for each of times.
    * _constructor_ function is nice place.
2. We should fill with empty value (`null`, `undefined`, empty string `''`, `-1`, or others) when we would not like to hold some values in a property.