### PR TITLE
Update custom style rule example in options

### DIFF
--- a/webextensions/common/common.js
+++ b/webextensions/common/common.js
@@ -234,7 +234,7 @@ export const configs = new Configs({
   userStyleRules: `
 /* Show title of unread tabs with red and italic font */
 /*
-.tab.unread tab-label {
+.tab.unread .label-content {
   color: red !important;
   font-style: italic !important;
 }


### PR DESCRIPTION
Nothing important, but updated the commented example in advanced options to reflect the current way to change unread tab styles.