### PR TITLE
Expose span element in tab-label element with CSS Shadow Parts

### DIFF
--- a/webextensions/common/common.js
+++ b/webextensions/common/common.js
@@ -247,7 +247,7 @@ export const configs = new Configs({
   userStyleRules: `
 /* Show title of unread tabs with red and italic font */
 /*
-tab-item.unread .label-content {
+tab-label::part(label-text) {
   color: red !important;
   font-style: italic !important;
 }

--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -220,7 +220,7 @@
   "applications": {
     "gecko": {
       "id": "treestyletab@piro.sakura.ne.jp",
-      "strict_min_version": "65.0"
+      "strict_min_version": "72a1"
     }
   }
 }

--- a/webextensions/sidebar/components/TabLabelElement.js
+++ b/webextensions/sidebar/components/TabLabelElement.js
@@ -7,7 +7,6 @@
 export const kTAB_LABEL_ELEMENT_NAME = 'tab-label';
 
 const KLABEL_CLASS_NAME   = 'label';
-const kCONTENT_CLASS_NAME = `${KLABEL_CLASS_NAME}-content`;
 
 const kPART_LABEL_TEXT = 'label-text';
 
@@ -35,7 +34,6 @@ export class TabLabelElement extends HTMLElement {
 
     const label = document.createElement('span');
     shadow.appendChild(label);
-    label.classList.add(kCONTENT_CLASS_NAME);
     label.setAttribute('part', kPART_LABEL_TEXT);
   }
 
@@ -107,7 +105,7 @@ export class TabLabelElement extends HTMLElement {
   }
 
   get _content() {
-    return this.shadowRoot.querySelector(`.${kCONTENT_CLASS_NAME}`);
+    return this.shadowRoot.querySelector(`[part=${kPART_LABEL_TEXT}]`);
   }
 
   get value() {

--- a/webextensions/sidebar/components/TabLabelElement.js
+++ b/webextensions/sidebar/components/TabLabelElement.js
@@ -9,6 +9,8 @@ export const kTAB_LABEL_ELEMENT_NAME = 'tab-label';
 const KLABEL_CLASS_NAME   = 'label';
 const kCONTENT_CLASS_NAME = `${KLABEL_CLASS_NAME}-content`;
 
+const kPART_LABEL_TEXT = 'label-text';
+
 const kATTR_NAME_VALUE = 'value';
 
 export class TabLabelElement extends HTMLElement {
@@ -26,6 +28,15 @@ export class TabLabelElement extends HTMLElement {
     // We should initialize private properties with blank value for better performance with a fixed shape.
     this.__onOverflow = null;
     this.__onUnderflow = null;
+
+    const shadow = this.attachShadow({
+      mode: 'open',
+    });
+
+    const label = document.createElement('span');
+    shadow.appendChild(label);
+    label.classList.add(kCONTENT_CLASS_NAME);
+    label.setAttribute('part', kPART_LABEL_TEXT);
   }
 
   connectedCallback() {
@@ -53,9 +64,6 @@ export class TabLabelElement extends HTMLElement {
 
     // We preserve this class for backward compatibility with other addons.
     this.classList.add(KLABEL_CLASS_NAME);
-
-    const content = this.appendChild(document.createElement('span'));
-    content.classList.add(kCONTENT_CLASS_NAME);
 
     this._startListening();
     this.updateTextContent();
@@ -99,7 +107,7 @@ export class TabLabelElement extends HTMLElement {
   }
 
   get _content() {
-    return this.querySelector(`.${kCONTENT_CLASS_NAME}`);
+    return this.shadowRoot.querySelector(`.${kCONTENT_CLASS_NAME}`);
   }
 
   get value() {

--- a/webextensions/sidebar/sidebar-cache.js
+++ b/webextensions/sidebar/sidebar-cache.js
@@ -36,7 +36,7 @@ function log(...args) {
   internalLogger('sidebar/sidebar-cache', ...args);
 }
 
-const kCONTENTS_VERSION = 16;
+const kCONTENTS_VERSION = 17;
 
 export const onRestored = new EventListenerManager();
 

--- a/webextensions/sidebar/sidebar-cache.js
+++ b/webextensions/sidebar/sidebar-cache.js
@@ -36,7 +36,7 @@ function log(...args) {
   internalLogger('sidebar/sidebar-cache', ...args);
 }
 
-const kCONTENTS_VERSION = 17;
+const kCONTENTS_VERSION = 18;
 
 export const onRestored = new EventListenerManager();
 

--- a/webextensions/sidebar/styles/base.css
+++ b/webextensions/sidebar/styles/base.css
@@ -385,7 +385,7 @@ tab-item tab-label {
 }
 
 /* This is for backward compatibility about custom user style rules like https://github.com/piroor/treestyletab/issues/1363 */
-tab-item .label-content {
+tab-label::part(label-text) {
   color: inherit;
 }
 


### PR DESCRIPTION
## Motivation

* This is an experiment to use [CSS Shadow Parts](https://drafts.csswg.org/css-shadow-parts/), which Firefox will ship in v72.
* By CSS Shadow Parts, we can expose some elements in a shadow tree with strong encapsulation.
    * By this, we can provide a public API to customize style.

## Drawback or Considerations

1. User would not apply their custom style sheet without any limitation.
    * IMO, I doubt user requires that all elements should be exposed. But I'm not sure about TST's custom style sheet. My thought may be wrong.
2. This requires to bump up `strict_min_version` to `72a1`.
    * This means we cannot deliver our bugfix to Firefox ~71 which Mozilla plans to release in [2020-01-09](https://wiki.mozilla.org/Release_Management/Calendar).

## Tasks after merge this PR

1. We may need to update https://github.com/piroor/treestyletab/issues/1363 or other documents to note about this change.


## Related Issue

* https://github.com/piroor/treestyletab/issues/2000
* https://github.com/piroor/treestyletab/issues/1363