### PR TITLE
Remove TabIdFixer

### DIFF
--- a/webextensions/Makefile
+++ b/webextensions/Makefile
@@ -27,7 +27,6 @@ update_extlib:
 install_extlib:
 	rm -f $(EXTERNAL_LIB_DIR)/*.js
 	cp ../submodules/webextensions-lib-event-listener-manager/EventListenerManager.js $(EXTERNAL_LIB_DIR)/
-	cp ../submodules/webextensions-lib-tab-id-fixer/TabIdFixer.js $(EXTERNAL_LIB_DIR)/; echo 'export default TabIdFixer;' >> $(EXTERNAL_LIB_DIR)/TabIdFixer.js
 	cp ../submodules/webextensions-lib-tab-favicon-helper/TabFavIconHelper.js $(EXTERNAL_LIB_DIR)/; echo 'export default TabFavIconHelper;' >> $(EXTERNAL_LIB_DIR)/TabFavIconHelper.js
 	cp ../submodules/webextensions-lib-rich-confirm/RichConfirm.js $(EXTERNAL_LIB_DIR)/; echo 'export default RichConfirm;' >> $(EXTERNAL_LIB_DIR)/RichConfirm.js
 	cp ../submodules/webextensions-lib-menu-ui/MenuUI.js $(EXTERNAL_LIB_DIR)/; echo 'export default MenuUI;' >> $(EXTERNAL_LIB_DIR)/MenuUI.js

--- a/webextensions/background/api-tabs-listener.js
+++ b/webextensions/background/api-tabs-listener.js
@@ -26,8 +26,6 @@
  * ***** END LICENSE BLOCK ******/
 'use strict';
 
-import TabIdFixer from '/extlib/TabIdFixer.js';
-
 import {
   log as internalLogger,
   dumpTab,
@@ -213,9 +211,6 @@ async function onActivated(activeInfo) {
 async function onUpdated(tabId, changeInfo, tab) {
   if (mPromisedStarted)
     await mPromisedStarted;
-
-  TabIdFixer.fixTab(tab);
-  tabId = tab.id;
 
   if (!Tab.isTracked(tabId))
     await Tab.waitUntilTracked(tabId, { element: !!TabsStore.getWindow() });
@@ -886,7 +881,7 @@ async function onAttached(tabId, attachInfo) {
 
   try {
     log('tabs.onAttached, id: ', tabId, attachInfo);
-    let tab = Tab.get(tabId);
+    const tab = Tab.get(tabId);
     const attachedTab = await browser.tabs.get(tabId).catch(ApiTabs.createErrorHandler());
     if (!attachedTab) {
       onCompleted();
@@ -897,10 +892,6 @@ async function onAttached(tabId, attachInfo) {
       tab.windowId = attachInfo.newWindowId
       tab.index    = attachedTab.index;
       tab.reindexedBy = `tabs.onAttached (${tab.index})`;
-    }
-    else {
-      tab = attachedTab;
-      TabIdFixer.fixTab(tab);
     }
 
     TabsInternalOperation.clearOldActiveStateInWindow(attachInfo.newWindowId);

--- a/webextensions/background/background.js
+++ b/webextensions/background/background.js
@@ -6,7 +6,6 @@
 'use strict';
 
 import RichConfirm from '/extlib/RichConfirm.js';
-import TabIdFixer from '/extlib/TabIdFixer.js';
 
 import {
   log as internalLogger,
@@ -237,7 +236,6 @@ async function rebuildAll(windows) {
         trackedWindow = Window.init(window.id);
 
       for (const tab of window.tabs) {
-        TabIdFixer.fixTab(tab);
         Tab.track(tab);
         Tab.init(tab, { existing: true });
         tryStartHandleAccelKeyOnTab(tab);

--- a/webextensions/background/index.js
+++ b/webextensions/background/index.js
@@ -3,7 +3,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
-import '../extlib/TabIdFixer.js';
 
 import {
   log,

--- a/webextensions/background/tree.js
+++ b/webextensions/background/tree.js
@@ -26,8 +26,6 @@
  * ***** END LICENSE BLOCK ******/
 'use strict';
 
-import TabIdFixer from '/extlib/TabIdFixer.js';
-
 import {
   log as internalLogger,
   wait,
@@ -1098,7 +1096,7 @@ export async function moveTabs(tabs, options = {}) {
       const maxDelay = configs.maximumAcceptableDelayForTabDuplication;
       while (Date.now() - startTime < maxDelay) {
         newTabs = mapAndFilter(movedTabs,
-                               tab => Tab.get(TabIdFixer.fixTab(tab).id) || undefined);
+                               tab => Tab.get(tab.id) || undefined);
         if (mSlowDuplication)
           UserOperationBlocker.setProgress(Math.round(newTabs.length / tabs.length * 50) + 50, windowId);
         if (newTabs.length < tabs.length) {
@@ -1204,10 +1202,9 @@ export async function openNewWindowFromTabs(tabs, options = {}) {
     .then(window => {
       const movedTabIds = new Set(movedTabs.map(tab => tab.id));
       log('moved tabs: ', movedTabIds);
-      const removeTabs = mapAndFilter(window.tabs, tab => {
-        tab = TabIdFixer.fixTab(tab);
-        return !movedTabIds.has(tab.id) && Tab.get(tab.id) || undefined;
-      });
+      const removeTabs = mapAndFilter(window.tabs, tab =>
+        !movedTabIds.has(tab.id) && Tab.get(tab.id) || undefined
+      );
       log('removing tabs: ', removeTabs);
       TabsInternalOperation.removeTabs(removeTabs);
       UserOperationBlocker.unblockIn(newWindow.id);

--- a/webextensions/sidebar/index.js
+++ b/webextensions/sidebar/index.js
@@ -4,7 +4,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 import '/extlib/l10n.js';
-import '/extlib/TabIdFixer.js';
 
 import {
   log,

--- a/webextensions/sidebar/sidebar.js
+++ b/webextensions/sidebar/sidebar.js
@@ -6,7 +6,6 @@
 'use strict';
 
 import RichConfirm from '/extlib/RichConfirm.js';
-import TabIdFixer from '/extlib/TabIdFixer.js';
 
 import {
   log as internalLogger,
@@ -148,7 +147,6 @@ export async function init() {
 
       // Track only the first tab for now, because it is required to initialize
       // the container and it will be used by the SidebarCache module.
-      TabIdFixer.fixTab(tabs[0]);
       Tab.track(tabs[0]);
 
       promisedAllTabsTracked = MetricsData.addAsync('tracking all native tabs', async () => {
@@ -156,7 +154,6 @@ export async function init() {
         let count = 0;
         const maxCount = tabs.length - 1;
         for (const tab of tabs.slice(1)) {
-          TabIdFixer.fixTab(tab);
           Tab.track(tab);
           if (Date.now() - lastDraw > configs.intervalToUpdateProgressForBlockedUserOperation) {
             UserOperationBlocker.setProgress(Math.round(++count / maxCount * 16) + 16); // 2/6: track all tabs


### PR DESCRIPTION
It was a workaround for a [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1398272) fixed a year and a half ago. The Firefox fix should now be in all supported Firefox versions, so `TabIdFixer` is unnecessary.