### PR TITLE
Add/fix keyboard shortcut

### DIFF
--- a/webextensions/_locales/zh_CN/messages.json
+++ b/webextensions/_locales/zh_CN/messages.json
@@ -519,7 +519,7 @@
         "hash": "3c498ce07f491477e7484e731f59aaf2"
     },
     "context_menu_label": {
-        "message": "标签树",
+        "message": "标签树(&T)",
         "hash": "8d7379195ed66f46fa8a084c80cac51c"
     },
     "context_reloadTree_label": {


### PR DESCRIPTION
After right click a tab in sidebar, press T to expand to TST sub-menu.

The translation accidentally and dramatically broke my workflow `Right click - key T - key C` to close a tree. It seems Firefox is using first letter as a default shorthand, therefore, translation breaks that.