### PR TITLE
Fix tab-mouseover events not being sent to other add-ons

### DIFF
--- a/webextensions/sidebar/mouse-event-listener.js
+++ b/webextensions/sidebar/mouse-event-listener.js
@@ -100,7 +100,7 @@ Sidebar.onReady.addListener(() => {
 });
 
 function updateSpecialEventListenersForAPIListeners() {
-  const shouldListenMouseMove = TSTAPI.getListenersForMessageType(TSTAPI.kNOTIFY_TAB_MOUSEMOVE) > 0;
+  const shouldListenMouseMove = TSTAPI.hasListenerForMessageType(TSTAPI.kNOTIFY_TAB_MOUSEMOVE);
   if (shouldListenMouseMove != onMouseMove.listening) {
     if (!onMouseMove.listening) {
       window.addEventListener('mousemove', onMouseMove, { capture: true, passive: true });
@@ -112,7 +112,7 @@ function updateSpecialEventListenersForAPIListeners() {
     }
   }
 
-  const shouldListenMouseOut = TSTAPI.getListenersForMessageType(TSTAPI.kNOTIFY_TAB_MOUSEOUT) > 0;
+  const shouldListenMouseOut = TSTAPI.hasListenerForMessageType(TSTAPI.kNOTIFY_TAB_MOUSEOUT);
   if (shouldListenMouseOut != onMouseOut.listening) {
     if (!onMouseOut.listening) {
       window.addEventListener('mouseout', onMouseOut, { capture: true, passive: true });
@@ -124,7 +124,7 @@ function updateSpecialEventListenersForAPIListeners() {
     }
   }
 
-  mHasMouseOverListeners = shouldListenMouseOut || TSTAPI.getListenersForMessageType(TSTAPI.kNOTIFY_TAB_MOUSEOVER) > 0;
+  mHasMouseOverListeners = shouldListenMouseOut || TSTAPI.hasListenerForMessageType(TSTAPI.kNOTIFY_TAB_MOUSEOVER);
 }
 
 


### PR DESCRIPTION
Previously the array returned by `TSTAPI.getListenersForMessageType` was directly compared to 0 (instead of its length property), which always resulted in false. However due to the structure of the code (and the following expression being true for any object: `undefined != [{}] > 0`), the listeners were enabled anyway, even if there wasn't any add-on listening. Recently, d2f5a42c15e7b52a89cabe049256c71f5fa62e4a changed the structure slightly to implement tab warming, and now the check failing actually results in `tab-mouseover` events no longer being sent to other add-ons.

This commit switches to the `TSTAPI.hasListenerForMessageType` function, which correctly checks the length property internally.

Speaking about tab warming: Could we add an option to disable it globally or alternatively add an API endpoint for other add-ons to disable it? Because quickly moving my mouse over my hundreds of tabs make my browser crawl to a halt, trying to load every hovered tab. I can also create a new issue to discuss this.