### PR TITLE
Move "Color scheme" option from Development to Appearance section

### DIFF
--- a/webextensions/options/options.html
+++ b/webextensions/options/options.html
@@ -83,6 +83,16 @@
               __MSG_config_style_none_info__</label></li>
       </ul>
     </fieldset>
+    <p>__MSG_config_colorScheme_caption__
+      <label class="has-radio inline"
+            ><input type="radio"
+                    name="colorScheme" value="photon">
+        __MSG_config_colorScheme_photon__</label>
+      <label class="has-radio inline"
+            ><input type="radio"
+                    name="colorScheme" value="system-color">
+        __MSG_config_colorScheme_systemColor__</label>
+   </p>
     <p><label class="has-checkbox"
              ><input id="animation"
                      type="checkbox">
@@ -932,16 +942,6 @@
         </ul>
       </li>
     </ul>
-    <p>__MSG_config_colorScheme_caption__
-       <label class="has-radio"
-             ><input type="radio"
-                     name="colorScheme" value="photon">
-         __MSG_config_colorScheme_photon__</label>
-       <label class="has-radio"
-             ><input type="radio"
-                     name="colorScheme" value="system-color">
-         __MSG_config_colorScheme_systemColor__</label>
-    </p>
     <div class="expert">
     <p><label class="has-checkbox"
              ><input id="simulateSVGContextFill"


### PR DESCRIPTION
I had the same issue as everyone else did, where Firefox doesn't seem to provide the correct colors when using dark themes on Linux.

It turns out that using the Photon color scheme fixes this and makes the sidebar appear dark again, but that option was hard to find because it was placed in the Development section with debugging options.

Since it affects the tab bar's appearance, I think it makes more sense to put it in the Appearance section. I'm not sure why it was put in Development--does it have no effect on non-Linux platforms or break them?

Before | After
-- | --
![image](https://user-images.githubusercontent.com/25993062/89368586-e5b6c900-d6a9-11ea-82d7-becad9107a00.png)| ![image](https://user-images.githubusercontent.com/25993062/89368597-e9e2e680-d6a9-11ea-8bbd-7235cff6e563.png)
