### PR TITLE
Fix race condition when applying styles to sidebar

### DIFF
--- a/webextensions/sidebar/sidebar.js
+++ b/webextensions/sidebar/sidebar.js
@@ -97,6 +97,7 @@ const mContextualIdentitiesStyle  = document.querySelector('#contextual-identity
     configs.$loaded.then(async () => {
       await applyStyle();
       Size.update();
+      browser.theme.getCurrent(mTargetWindow).then(applyBrowserTheme);
     });
 
   configs.$loaded.then(applyUserStyleRules);


### PR DESCRIPTION
When testing my [Tree Style Tab in Separate Window](https://addons.mozilla.org/firefox/addon/tst-in-separate-window/) helper extension I noticed that the style is a bit messed up when the sidebar page is opened in a normal tab (and therefore also when it is opened in another window). To be precise I have dark theme enabled and the active tab is highlighted in white. I tracked the problem down to a race condition and confirmed that the change in this PR fixes it.

Sidebar page to the left and normal sidebar to the right:
![Tst style issue](https://user-images.githubusercontent.com/31554212/94999369-2d2dd880-05b9-11eb-8891-5feb3f3e51c2.png)
