### PR TITLE
Register wheel event as `passive : false`

### DIFF
--- a/webextensions/sidebar/scroll.js
+++ b/webextensions/sidebar/scroll.js
@@ -71,7 +71,7 @@ export function init(scrollPosition) {
     });
   }
 
-  document.addEventListener('wheel', onWheel, { capture: true });
+  document.addEventListener('wheel', onWheel, { capture: true, passive: false });
   mTabBar.addEventListener('scroll', onScroll);
   BackgroundConnection.onMessage.addListener(onBackgroundMessage);
   TSTAPI.onMessageExternal.addListener(onMessageExternal);


### PR DESCRIPTION
**Aim**
 - Make [Tree Style Tab Mouse Wheel](https://addons.mozilla.org/ja/firefox/addon/tree-style-tab-mouse-wheel/) works properly.
 - Tree Style Tab Mouse Wheel is an TST extend addon that enables users to switch active tab by scrolling mouse wheel on TST Sidebar, but now, this addon cannot handle scroll.
 - This TST extend addon calls Tree Style Tab API to handle scroll on sidebar, so this problem may not be fixed in extend addon side.

**Changes added**
 - Set `passive : false` in wheel event listener.
 - This change makes `event.preventDefault();` in `onWheel` event runs correctly.

**Risk**
 - This change may cause some degradation of rendering performance.
 - reference: https://developer.mozilla.org/ja/docs/Web/API/EventTarget/addEventListener#Improving_scrolling_performance_with_passive_listeners

**Environments**
 - Firefox 84.0
 - Latest version of Tree Style Tab / Tree Style Tab Mouse Wheel
 - KDE Plasma
 - Arch Linux