### PR TITLE
fix API:subPanel.initial/fixedHeight

### DIFF
--- a/webextensions/sidebar/subpanel.js
+++ b/webextensions/sidebar/subpanel.js
@@ -143,10 +143,9 @@ async function applyProvider(id) {
 
     mSelectorAnchor.querySelector('.label').textContent = provider.subPanel.title || provider.name || provider.id;
 
-    const headerHeight = mHeader.getBoundingClientRect().height;
     if ('fixedHeight' in provider.subPanel) {
       const unit = typeof provider.subPanel.fixedHeight == 'number' && 'px' || '';
-      mHeight = Size.calc(`${provider.subPanel.fixedHeight}${unit} + ${headerHeight}px`);
+      mHeight = Size.calc(`${provider.subPanel.fixedHeight}${unit}`);
       mHeader.classList.remove('resizable');
     }
     else {
@@ -156,7 +155,7 @@ async function applyProvider(id) {
       }
       else if ('initialHeight' in provider.subPanel) {
         const unit = typeof provider.subPanel.initialHeight == 'number' && 'px' || '';
-        mHeight = Size.calc(`${provider.subPanel.initialHeight}${unit} + ${headerHeight}px`);
+        mHeight = Size.calc(`${provider.subPanel.initialHeight}${unit}`);
       }
     }
 


### PR DESCRIPTION
Following #2865 I now tested the `subPanel.initial/fixedHeight` integration options, and the height was off.
Actually removing a bit of code fixes that. And it also makes more sense now. the `mHeight` eventually ends up being assigned directly to the `subPanel` `<iframe>`, which is what the height should be for.