### PR TITLE
Restrict `subPanel.url`'s origin to the extension's bundles files

### DIFF
--- a/webextensions/common/tst-api.js
+++ b/webextensions/common/tst-api.js
@@ -1,4 +1,4 @@
-/* ***** BEGIN LICENSE BLOCK ***** 
+/* ***** BEGIN LICENSE BLOCK *****
  * Version: MPL 1.1
  *
  * The contents of this file are subject to the Mozilla Public License Version
@@ -716,6 +716,14 @@ function onBackendCommand(message, sender) {
         message.internalId = sender.url.replace(/^moz-extension:\/\/([^\/]+)\/.*$/, '$1');
         message.id = sender.id;
         message.subPanel = message.subPanel || message.subpanel || null;
+        if (message.subPanel) {
+          const url = typeof message.subPanel.url === 'string' && new URL(message.subPanel.url, new URL('/', sender.url));
+          if (!url || url.hostname !== message.internalId) {
+            console.error(`"subPanel.url" must refer to a page packed in the registering extension.`);
+            message.subPanel.url = 'about:blank?error=invalid-origin'
+          } else
+            message.subPanel.url = url.href;
+        }
         message.newlyInstalled = !configs.cachedExternalAddons.includes(sender.id);
         registerAddon(sender.id, message);
         browser.runtime.sendMessage({


### PR DESCRIPTION
It somehow feels like a bad idea to allow other extensions to (directly) show just any remote content in the `subPanel`.

This restricts the `.url` to sources in the registering extensions origin, and allows relative URLs to be interpreted in that namespace.

I am not sure how you do error reporting here. A bit more type checking and the registration or other RPC calls failing with a reported error on invalid types, would probably be a good idea in general.

Hope you don't mind the trim on the first line too much.