### PR TITLE
Pass the current `windowId` to the `subPanel`s

### DIFF
--- a/webextensions/sidebar/subpanel.js
+++ b/webextensions/sidebar/subpanel.js
@@ -195,7 +195,7 @@ async function applyProvider(id) {
     }
 
     const url = new URL(provider.subPanel.url);
-    url.searchParams.set('tst-windowId', mTargetWindow);
+    url.searchParams.set('windowId', mTargetWindow);
     provider.subPanel.url = url.href;
 
     if (mHeight > 0)

--- a/webextensions/sidebar/subpanel.js
+++ b/webextensions/sidebar/subpanel.js
@@ -166,9 +166,9 @@ async function applyProvider(id) {
     browser.sessions.setWindowValue(mTargetWindow, Constants.kWINDOW_STATE_SUBPANEL_PROVIDER_ID, id).catch(ApiTabs.createErrorHandler());
 
     const icon = mSelectorAnchor.querySelector('.icon > img');
-    const url = getProviderIconUrl(provider);
-    if (url)
-      icon.src = url;
+    const iconUrl = getProviderIconUrl(provider);
+    if (iconUrl)
+      icon.src = iconUrl;
     else
       icon.removeAttribute('src');
 
@@ -193,6 +193,10 @@ async function applyProvider(id) {
           mHeight = Size.calc(provider.subPanel.initialHeight);
       }
     }
+
+    const url = new URL(provider.subPanel.url);
+    url.searchParams.set('tst-windowId', mTargetWindow);
+    provider.subPanel.url = url.href;
 
     if (mHeight > 0)
       load(provider.subPanel);


### PR DESCRIPTION
I could not figure out a generic way for the `subPanel` to determine the id of the window it is in, ouside situations where it happens to be known to be the `currentWindow`.

There would be multiple possible ways for TST to pass that information. As far as I can tell, there is no direct RPC between the subpanel content and the sidebar yet. A simple `postMessage` by the sidebar would be sub-optimal, because the panel content might not be listening yet.
So I figured a URL query parameter is a simple way to transfer this information.

This information expects the `subPanel.url` to [be a valid URL](https://github.com/piroor/treestyletab/pull/2898).