### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/webextensions/common/bookmark.js
+++ b/webextensions/common/bookmark.js
@@ -237,7 +237,7 @@ export async function bookmarkTabs(tabs, options = {}) {
   const title = configs.bookmarkTreeFolderName
     .replace(/%TITLE%/gi, tabs[0].title)
     .replace(/%URL%/gi, tabs[0].url)
-    .replace(/%SHORT_?YEAR%/gi, year.substr(-2))
+    .replace(/%SHORT_?YEAR%/gi, year.slice(-2))
     .replace(/%(FULL_?)?YEAR%/gi, year)
     .replace(/%MONTH%/gi, String(now.getMonth() + 1).padStart(2, '0'))
     .replace(/%DATE%/gi, String(now.getDate()).padStart(2, '0'));

--- a/webextensions/common/common.js
+++ b/webextensions/common/common.js
@@ -704,10 +704,10 @@ function uneval(value) {
 
 function getTimeStamp() {
   const time = new Date();
-  const hours = `0${time.getHours()}`.substr(-2);
-  const minutes = `0${time.getMinutes()}`.substr(-2);
-  const seconds = `0${time.getSeconds()}`.substr(-2);
-  const milliseconds = `00${time.getMilliseconds()}`.substr(-3);
+  const hours = `0${time.getHours()}`.slice(-2);
+  const minutes = `0${time.getMinutes()}`.slice(-2);
+  const seconds = `0${time.getSeconds()}`.slice(-2);
+  const milliseconds = `00${time.getMilliseconds()}`.slice(-3);
   return `${hours}:${minutes}:${seconds}.${milliseconds}`;
 }
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.