### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/auto-escape-special-unicode-characters-in-locales.yml
+++ b/.github/workflows/auto-escape-special-unicode-characters-in-locales.yml
@@ -6,8 +6,13 @@ on:
     branches:
       - "trunk"
 
+permissions:
+  contents: read
+
 jobs:
   auto-escape-special-unicode-characters-in-locales:
+    permissions:
+      contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: CI/CD
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
