### PR TITLE
New Issue Type for Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Discussions
+    about: General discussions and questions about TST including CSS customization
+    url: https://github.com/piroor/treestyletab/discussions


### PR DESCRIPTION
Adds a new "issue type" that is called "Discussions" and will simply open the "Discussion" URL.  This might reduce the number of CSS questions from the "Issues" section.

Tested code (different text) in test repo:

![image](https://user-images.githubusercontent.com/979729/179367266-90555d0e-b4b2-4f5a-b8aa-7f6edc92fc97.png)

Results (this generates the "Discussions" type):

![image](https://user-images.githubusercontent.com/979729/179367281-b9987acf-aab1-44ea-a22a-db914878c25c.png)

Feel free to modify the text to your liking.  I was thinking this might reduce the number of questions\comments\CSS items in the "Issues" section.
