### PR TITLE
Fix link to extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ If you need any new APIs, please file API proposals in the issue tracker.
   </details>
 * <details id="feature-requests-add-more-minor-trivial-options"><summary>Add more minor/trivial options</summary>
   
-  Please see the [list of helper extensions](#addons-that-extend-tst).
+  Please see the [list of helper extensions](#extensions-that-extend-tst).
   For the appearance of tabs in the sidebar, [custom user styles](https://github.com/piroor/treestyletab/wiki/Code-snippets-for-custom-style-rules) may help.
   
   The variety of configurations for TST will not increase infinitely.
@@ -332,7 +332,7 @@ If you need any new APIs, please file API proposals in the issue tracker.
   </details>
 * <details id="feature-requests-high-power-management-of-tree-like-sorting-child-tabs-auto-modification-of-tree-renaming-tabs-and-so-on"><summary>High-power management of tree, like <a href="https://github.com/piroor/treestyletab/issues/94">sorting child tabs</a>, <a href="https://github.com/piroor/treestyletab/issues/509">auto-modification of tree</a>, <a href="https://github.com/piroor/treestyletab/issues/794">renaming tabs</a>, and so on</summary>
   
-  Please see the [list of helper extensions](#addons-that-extend-tst).
+  Please see the [list of helper extensions](#extensions-that-extend-tst).
   [TST More Tree Commands](https://addons.mozilla.org/firefox/addon/tst-more-tree-commands/)'s [issue tracker](https://github.com/piroor/tst-more-tree-commands/issues) may be a good place to track your request.
   
   Please note that "useful" features won't be implemented to TST itself as a built-in feature.

--- a/webextensions/_locales/de/messages.json
+++ b/webextensions/_locales/de/messages.json
@@ -689,7 +689,7 @@
   "config_addons_description_before": { "message": "Es existieren " },
   "config_addons_description_link_label": { "message": "Erweiterungen, welche TST erweitern" },
   "config_addons_description_after": { "message": ". Probiere sie aus, wenn Du mehr Funktionen in der Seitenleiste von TST haben möchtest." },
-  "helper_addons_list_link_uri": { "message": "https://github.com/piroor/treestyletab/blob/master/README.md#addons-that-extend-tst" },
+  "helper_addons_list_link_uri": { "message": "https://github.com/piroor/treestyletab/blob/master/README.md#extensions-that-extend-tst" },
 
   "config_theme_description_before": { "message": "Aktuell gibt es nur die eingebauten Designs \"Pur\", \"Seitenleiste\" und \"Hoher Kontrast\". Für weitere Designs siehe " },
   "config_theme_description_link_label": { "message": "die Code-Beispiele im Wiki" },

--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -706,7 +706,7 @@
   "config_addons_description_before": { "message": "There are " },
   "config_addons_description_link_label": { "message": "addons which extend TST itself" },
   "config_addons_description_after": { "message": ". Check them out if you need more features on TST's sidebar." },
-  "helper_addons_list_link_uri": { "message": "https://github.com/piroor/treestyletab/blob/master/README.md#addons-that-extend-tst" },
+  "helper_addons_list_link_uri": { "message": "https://github.com/piroor/treestyletab/blob/master/README.md#extensions-that-extend-tst" },
 
   "config_theme_description_before": { "message": "Currently there are available built-in themes only \"Plain\", \"Sidebar\" and \"High Contrast\". If you want to use non-built-in theme, see " },
   "config_theme_description_link_label": { "message": "the code snippets" },

--- a/webextensions/_locales/fr/messages.json
+++ b/webextensions/_locales/fr/messages.json
@@ -1208,7 +1208,7 @@
     "hash": "59a6e79ef78c82f7ac8ef391e4de01f5"
   },
   "helper_addons_list_link_uri": {
-    "message": "https://github.com/piroor/treestyletab/blob/master/README.md#addons-that-extend-tst",
+    "message": "https://github.com/piroor/treestyletab/blob/master/README.md#extensions-that-extend-tst",
     "hash": "8273bc1584de40aaa4ec5f04b3cd200c"
   },
   "config_externaladdonpermissions_label": {

--- a/webextensions/_locales/ja/messages.json
+++ b/webextensions/_locales/ja/messages.json
@@ -702,7 +702,7 @@
   "config_addons_description_before": { "message": "\u200b" },
   "config_addons_description_link_label": { "message": "TST自体を拡張する他のアドオン" },
   "config_addons_description_after": { "message": "を組み合わせると、TSTのサイドバーにさらに機能を追加できます。" },
-  "helper_addons_list_link_uri": { "message": "https://github.com/piroor/treestyletab/blob/master/README.md#addons-that-extend-tst" },
+  "helper_addons_list_link_uri": { "message": "https://github.com/piroor/treestyletab/blob/master/README.md#extensions-that-extend-tst" },
 
   "config_theme_description_before": { "message": "組み込みのテーマは現在「Plain」「Sidebar」「ハイコントラスト」のみ利用可能です。他のテーマを使用したい場合、" },
   "config_theme_description_link_label": { "message": "コードスニペット" },

--- a/webextensions/_locales/ko/messages.json
+++ b/webextensions/_locales/ko/messages.json
@@ -2045,7 +2045,7 @@
         "hash": "59a6e79ef78c82f7ac8ef391e4de01f5"
     },
     "helper_addons_list_link_uri": {
-        "message": "https://github.com/piroor/treestyletab/blob/master/README.md#addons-that-extend-tst",
+        "message": "https://github.com/piroor/treestyletab/blob/master/README.md#extensions-that-extend-tst",
         "hash": "8273bc1584de40aaa4ec5f04b3cd200c"
     },
     "config_theme_description_before": {

--- a/webextensions/_locales/ru/messages.json
+++ b/webextensions/_locales/ru/messages.json
@@ -703,7 +703,7 @@
   "config_addons_description_before": { "message": "Имеются " },
   "config_addons_description_link_label": { "message": "аддоны, расширяющие возможности TST" },
   "config_addons_description_after": { "message": ". Посмотрите их, если вам нужно больше функций для панели TST." },
-  "helper_addons_list_link_uri": { "message": "https://github.com/piroor/treestyletab/blob/master/README.md#addons-that-extend-tst" },
+  "helper_addons_list_link_uri": { "message": "https://github.com/piroor/treestyletab/blob/master/README.md#extensions-that-extend-tst" },
 
   "config_theme_description_before": { "message": "В настоящее время доступны только три встроенные темы \"Простая\", \"Сайдбар\" и \"Контраст\". Если вы хотите использовать не встроенную тему, см. " },
   "config_theme_description_link_label": { "message": "'Восстановление старых встроенных тем'" },

--- a/webextensions/_locales/zh_CN/messages.json
+++ b/webextensions/_locales/zh_CN/messages.json
@@ -2069,7 +2069,7 @@
     "hash": "59a6e79ef78c82f7ac8ef391e4de01f5"
   },
   "helper_addons_list_link_uri": {
-    "message": "https://github.com/piroor/treestyletab/blob/master/README.md#addons-that-extend-tst",
+    "message": "https://github.com/piroor/treestyletab/blob/master/README.md#extensions-that-extend-tst",
     "hash": "8273bc1584de40aaa4ec5f04b3cd200c"
   },
   "config_theme_description_before": {

--- a/webextensions/_locales/zh_TW/messages.json
+++ b/webextensions/_locales/zh_TW/messages.json
@@ -689,7 +689,7 @@
     "config_addons_description_before": { "message": "結合" },
     "config_addons_description_link_label": { "message": "擴張 TST 本身的其他附加元件" },
     "config_addons_description_after": { "message": "，在 TST 的側邊欄追加額外功能。" },
-    "helper_addons_list_link_uri": { "message": "https://github.com/piroor/treestyletab/blob/master/README.md#addons-that-extend-tst" },
+    "helper_addons_list_link_uri": { "message": "https://github.com/piroor/treestyletab/blob/master/README.md#extensions-that-extend-tst" },
   
     "config_theme_description_before": { "message": "Currently there are available built-in themes only \"Plain\", \"Sidebar\" and \"High Contrast\". If you want to use non-built-in theme, see " },
     "config_theme_description_link_label": { "message": "the code snippets" },

--- a/webextensions/amo/description.en.html
+++ b/webextensions/amo/description.en.html
@@ -60,4 +60,4 @@ Some extend the behavior of TST's sidebar panel:
 <li><a href="https://addons.mozilla.org/firefox/addon/tst-new-tabs-first/">TST New Tabs First</a> puts a newly opened root level at the top of the sidebar.</li>
 </ul>
 
-Latest information is available at <a href="https://github.com/piroor/treestyletab/blob/master/README.md#addons-that-extend-tst">the repository</a>.
+Latest information is available at <a href="https://github.com/piroor/treestyletab/blob/master/README.md#extensions-that-extend-tst">the repository</a>.

--- a/webextensions/amo/description.fr.html
+++ b/webextensions/amo/description.fr.html
@@ -61,4 +61,4 @@ Il y a plusieurs extensions étendant les possibilités du panneau de TST, par e
 <li><a href="https://addons.mozilla.org/firefox/addon/tst-new-tabs-first/">TST New Tabs First</a> puts a newly opened root level at the top of the sidebar.</li>
 </ul>
 
-Latest information is available at <a href="https://github.com/piroor/treestyletab/blob/master/README.md#addons-that-extend-tst">the repository</a>.
+Latest information is available at <a href="https://github.com/piroor/treestyletab/blob/master/README.md#extensions-that-extend-tst">the repository</a>.

--- a/webextensions/amo/description.ja.html
+++ b/webextensions/amo/description.ja.html
@@ -59,4 +59,4 @@ TSTのサイドバーの機能を使い勝手を強化するアドオンもあ�
 <li><a href="https://addons.mozilla.org/firefox/addon/tst-new-tabs-first/">TST New Tabs First</a> 子タブでない形で開かれた新しいタブを、サイドバーの最上部に配置するようにします。</li>
 </ul>
 
-最新の情報は<a href="https://github.com/piroor/treestyletab/blob/master/README.md#addons-that-extend-tst">リポジトリ</a>をご参照下さい。
+最新の情報は<a href="https://github.com/piroor/treestyletab/blob/master/README.md#extensions-that-extend-tst">リポジトリ</a>をご参照下さい。


### PR DESCRIPTION
The ["Extensions that extend TST"](https://github.com/piroor/treestyletab/blob/trunk/README.md#extensions-that-extend-tst) header in the readme have been [renamed a while ago](https://github.com/piroor/treestyletab/blame/trunk/README.md#L61), but the options page is still referencing the old url, which does not exists.

![image](https://user-images.githubusercontent.com/55841/190192844-ed857ad4-95b6-4d90-b081-ee1d9f94038b.png)

