### PR TITLE
More efficient heartbeats

### DIFF
--- a/webextensions/common/sidebar-connection.js
+++ b/webextensions/common/sidebar-connection.js
@@ -205,7 +205,8 @@ export function init() {
         return message.forEach(receiver);
       if (message.type == Constants.kCOMMAND_HEARTBEAT)
         updateTimeoutTimer();
-      onMessage.dispatch(windowId, message);
+      else
+        onMessage.dispatch(windowId, message);
     };
     port.onMessage.addListener(receiver);
     mReceivers.set(windowId, receiver);


### PR DESCRIPTION
I generally run with at least 100 tabs and have noticed that TST consumes a considerable amount of resources even when the system is idle. This has really impacted my battery life. I love TST though, so I really don't want to disable it. Consequently, I've begun profiling the extension using the Firefox Profiler.

For the current pass, I've been looking at heartbeat messages. They trigger all the time, even when idle, so they would ideally consume minimal resources. I found the message dispatch system accounted for 60%+ of all allocations. After stepping through the code with a debugger, I found that none of the registered `onMessage` handlers do anything with heartbeat messages. I suppose the idea was to keep the architecture clean and maybe allow for some handler to handle heartbeat messages in the future, but it's currently a fairly expensive no-op loop. This PR attempts to address this overhead in two ways:

* The sidebar connection, which already had a special case for heartbeat messages, no longer dispatches the heartbeat message when it is done with it, thus avoiding that unnecessary dispatch.
* The heartbeat messages are sent using the same message passing system as all other messages, but that involves boxing into an array to batch process, then processing that array, which ends up making a [recursive call](https://github.com/piroor/treestyletab/blob/caca3a0e00f0f65c9d1604356b7cb6d4ee487d45/webextensions/common/sidebar-connection.js) into the [`receiver` method](https://github.com/piroor/treestyletab/blob/caca3a0e00f0f65c9d1604356b7cb6d4ee487d45/webextensions/common/sidebar-connection.js) in the sidebar connection. By sending the heartbeat message directly, we don't need to allocate arrays and invoke iterators to process batch messages.

The code I replaced to post the heartbeat message by itself had a comment about not wanting to cause the UI to freeze. I don't know enough about web extensions to understand what the original problem was. I'm reasonably positive the heartbeat messages won't happen frequently enough to cause the UI to freeze. My understanding is this all runs on the same thread, so even if a non-heartbeat message comes immediately before or immediately after, the performance shouldn't be any worse on that batch operation than if the heartbeat message appeared in the batch. At least, these are the assumptions I've made. I'd appreciate if someone could evaluate them (and the code comment) I left for accuracy.