### PR TITLE
README: Bookmarking trees is now a native feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Some extend the behavior of TST's sidebar panel:
  * [Tree Style Tab in Separate Window](https://addons.mozilla.org/firefox/addon/tst-in-separate-window/) allows you to open the Tree Style Tab sidebar page in a new window.
  * [Auto Tab Discard](https://addons.mozilla.org/firefox/addon/auto-tab-discard/) supports the fake context menu in the Tree Style Tab sidebar.
  * [UnloadTabs](https://addons.mozilla.org/firefox/addon/unload-tabs/) supports the fake context menu in the Tree Style Tab sidebar.
- * [Bookmark Tree for Tree Style Tab](https://addons.mozilla.org/firefox/addon/bookmark-tree-for-tst/) allows you to bookmark and restore trees.
+ * [Bookmark Tree for Tree Style Tab](https://addons.mozilla.org/firefox/addon/bookmark-tree-for-tst/) allows you to bookmark and restore trees. (A similar feature is now built-in in TST since v3.2.0)
  * [TST Hoverswitch](https://addons.mozilla.org/firefox/addon/tst-hoverswitch/) allows you to switch tabs by hovering over them.
  * [TST Colored Tabs](https://addons.mozilla.org/firefox/addon/tst-colored-tabs/) gives custom background color for tabs based on their domain.
  * [Add Last Active Class To Tab](https://addons.mozilla.org/firefox/addon/add-last-active-class-to-tab/) helps you to give custom appearance for the "previously active tab".


### PR DESCRIPTION
I was confused by having two similar context menu entries relating to saving a tree of tabs as bookmarks. I then realized that the Bookmark Tree extension that I had installed effectively duplicates a functionality that is now available directly in TST since v3.2.0.

I added this information to the entry for the Bookmark Tree extension, to hopefully make this clearer to others. 