### PR TITLE
Fix stutters for unsynchronized loading throbbers

### DIFF
--- a/webextensions/common/Tab.js
+++ b/webextensions/common/Tab.js
@@ -2143,6 +2143,14 @@ Tab.getNeedToBeSynchronizedTabs = (windowId = null, options = {}) => {
   });
 };
 
+Tab.hasNeedToBeSynchronizedTab = windowId => {
+  return !!TabsStore.query({
+    windowId,
+    tabs:     TabsStore.unsynchronizedTabsInWindow.get(windowId),
+    visible:  true
+  });
+};
+
 Tab.hasLoadingTab = windowId => {
   return !!TabsStore.query({
     windowId,

--- a/webextensions/common/constants.js
+++ b/webextensions/common/constants.js
@@ -219,6 +219,7 @@ export const kTABBAR_STATE_BLOCKING               = 'blocking';
 export const kTABBAR_STATE_BLOCKING_WITH_THROBBER = 'blocking-throbber';
 export const kTABBAR_STATE_BLOCKING_WITH_SHADE    = 'blocking-shade';
 export const kTABBAR_STATE_HAVE_LOADING_TAB       = 'have-loading-tab';
+export const kTABBAR_STATE_HAVE_UNSYNCHRONIZED_THROBBER = 'have-unsynchronized-throbber';
 export const kTABBAR_STATE_THROBBER_SYNCHRONIZING = 'throbber-synchronizing';
 export const kTABBAR_STATE_CONTEXTUAL_IDENTITY_SELECTABLE = 'contextual-identity-selectable';
 export const kTABBAR_STATE_NEWTAB_ACTION_SELECTABLE = 'newtab-action-selectable';

--- a/webextensions/sidebar/sidebar-tabs.js
+++ b/webextensions/sidebar/sidebar-tabs.js
@@ -84,6 +84,7 @@ async function reserveToUpdateLoadingState() {
 
 function updateLoadingState() {
   document.documentElement.classList.toggle(Constants.kTABBAR_STATE_HAVE_LOADING_TAB, Tab.hasLoadingTab(TabsStore.getCurrentWindowId()));
+  document.documentElement.classList.toggle(Constants.kTABBAR_STATE_HAVE_UNSYNCHRONIZED_THROBBER, Tab.hasNeedToBeSynchronizedTab(TabsStore.getCurrentWindowId()));
 }
 
 async function synchronizeThrobberAnimation() {
@@ -95,6 +96,8 @@ async function synchronizeThrobberAnimation() {
   }
   if (processedCount == 0)
     return;
+
+  document.documentElement.classList.remove(Constants.kTABBAR_STATE_HAVE_UNSYNCHRONIZED_THROBBER);
 
   document.documentElement.classList.add(Constants.kTABBAR_STATE_THROBBER_SYNCHRONIZING);
   void document.documentElement.offsetWidth;

--- a/webextensions/sidebar/styles/base.css
+++ b/webextensions/sidebar/styles/base.css
@@ -268,13 +268,15 @@ ul {
 
 #dummy-tabs {
   bottom: 0;
-  clip: rect(0, 0, 0, 0);
   left: 0;
   overflow-y: scroll;
   pointer-events: none;
   position: fixed;
   right: 0;
   z-index: var(--dummy-element-z-index); /* Put it below the background. See also: https://github.com/piroor/treestyletab/issues/1703#issuecomment-354646405 */
+}
+:root:not(.have-unsynchronized-throbber) #dummy-tabs {
+  clip: rect(0, 0, 0, 0); /* Don't hide animated throbber when its appearance is copied with -moz-element since doing so causes stuttering in the copied animation */
 }
 
 #dummy-favicon-size-box {


### PR DESCRIPTION
I noticed that the loading throbber animation seemed to stutter a lot when it was started. After some testing I found that this only occurred for unsynchronized throbbers. See how the bottom 5 tabs in the GIF below compares to the synchronized tabs at the top of the GIF:

![loading animation](https://user-images.githubusercontent.com/31554212/209709836-6d151f3a-73c3-4bc9-9d8e-c92d0d18aa6e.gif)

I remembered #1703 and investigated whether transparency was the problem again. Currently the background throbber is [always transparent](https://github.com/piroor/treestyletab/blob/d2ba9defe6469f785a04f127fac87d403c147607/webextensions/sidebar/styles/base.css#L271) so I added some custom CSS to disable that transparency:
```css
#dummy-tabs {
    clip: unset !important;
}
```

After that the animations no longer stuttered so that seems to fix the issue. I did some performance testing and unfortunately the change caused higher CPU usage. To minimize this disadvantage the PR makes the background throbber transparent as soon as there are no unsynchronized throbbers. Since the throbbers are only unsynchronized for a short time then maybe the higher CPU usage is worth it for the smoother animations?

# Performance

To easier observe CPU usage of loading tabs I create infinitely loadings tabs using the same method I used in issue #1703.

 1. Start Firefox with clean profile.
 2. Install TST.
 3. Open about 200 new tabs (hold `ctrl+t`) and wait for them to finish loading.
 4. Download  ["iperf-2.0.9-win64"](https://iperf.fr/iperf-download.php) and run the program with the command `iperf.exe -s -p 8888`.
 5. Open 10 infinitely loading tabs by entering the following URL: `localhost:8888`.
 6. Scroll so that tabs are not visible in native tabbar.
 7. Scroll so that the loading tabs are visibile in the sidebar.
 8. Observe Firefox CPU usage.
 9. Scroll so that the loading tabs are **not** visibile in the sidebar.
 10. Observe Firefox CPU usage.

I repeat all these steps for 3 different scenarios:

- Invisible: the background loading thobber is transparent.
  - This is the case if no custom CSS is applied to the current TST version.
- Shown: the background loading throbber is **never** transparent but is still hidden behind the sidebar background element.
  - This is the case if the following CSS is applied to the sidebar:
```css
#dummy-tabs {
    clip: unset !important;
}
```
- Dynamic: the background loading throbber is transparent if all throbbers are synchronized.
  - This is the case if this PR is applied.

## CPU usage when all throbbers are unsynchronized

To test this I disabled synchronization with the following css:

```css
/* Never sync loading throbbers */
#sync-throbber {
  animation: unset !important;
}
```

|                    | Invisible  |   Shown    | Dynamic (Same as `Shown`)  |
|--------------------|------------|------------|----------------------------|
| Scrolled into view |    4-6%    |    19%     |           19%              |
| Scroll out of view |    2%      |    14%     |           14%              |

## CPU usage when all throbbers are synchronized

|                    | Invisible  |   Shown    | Dynamic (Same as `Invisible`) |
|--------------------|------------|------------|-------------------------------|
| Scrolled into view |    6-8%    |    5-7%    |         6-8%                  |
| Scroll out of view |    2-3%    |    4-6%    |         2-3%                  |

## Environment

 * Platform (OS): Windows 10
 * Version of Firefox: 108.0.1
 * Version (or revision) of Tree Style Tab: 3.9.11