### PR TITLE
Improve performance of updateVisualMaxTreeLevel when animation is disabled

### DIFF
--- a/webextensions/sidebar/indent.js
+++ b/webextensions/sidebar/indent.js
@@ -146,15 +146,12 @@ export async function reserveToUpdateVisualMaxTreeLevel() {
     delete updateVisualMaxTreeLevel.waiting;
   }
 
-  if (!shouldApplyAnimation()) {
-    updateVisualMaxTreeLevel();
-    return;
-  }
+  const delay = shouldApplyAnimation() ? configs.collapseDuration * 1.5 : 0;
 
   updateVisualMaxTreeLevel.waiting = setTimeout(() => {
     delete updateVisualMaxTreeLevel.waiting;
     updateVisualMaxTreeLevel();
-  }, configs.collapseDuration * 1.5);
+  }, delay);
 }
 
 function updateVisualMaxTreeLevel() {


### PR DESCRIPTION
Resolves #3383.

With animation disabled, we were previously updating the max tree level every time we received a tab event. When closing large numbers of tabs, this gets extremely slow.

This PR changes it to batch the updates so they only occur once per frame at most.

I wasn't sure whether to go with a 0ms delay (so it appears instantaneous) or a 100ms delay (like reserveToUpdateIndent does just below). I went with a 0ms delay in the end so as to preserve existing behavior.

Maybe for a future PR, it would be nice to do something like what [Lodash.debounce](https://docs-lodash.com/v4/debounce/) offers with `options.leading`: the *first* time we receive the event, we apply it instaneously, but every event after that gets queued up with a certain delay. This would prevent visual feedback from being too delayed, while giving a good "buffer zone" to avoid updating too frequently.