### PR TITLE
Add "bookmarks" to manifest.json as it now required in nightly builds

### DIFF
--- a/webextensions/manifest.json
+++ b/webextensions/manifest.json
@@ -6,6 +6,7 @@
   "description": "__MSG_extensionDescription__",
   "permissions": [
     "activeTab",
+    "bookmarks",
     "contextualIdentities",
     "cookies",
     "menus",


### PR DESCRIPTION
Recent update of firefox nightly broke the extension. Currently permission "bookmarks" is required.