### PR TITLE
Locales: Finish RU, update DE; fix EN

### DIFF
--- a/webextensions/_locales/de/messages.json
+++ b/webextensions/_locales/de/messages.json
@@ -1,824 +1,2135 @@
 {
-  "extensionName": { "message": "Tree Style Tab" },
-  "extensionDescription": { "message": "Stellt Tabs in einer Baumstruktur dar." },
-
-  "sidebarTitle": { "message": "Tree Style Tab" },
-  "sidebarToggleDescription": { "message": "\"Tree Style Tab\" Seitenleiste Ein-/Ausblenden" },
-
-  "command_tabMoveUp":             { "message": "Aktuellen Tab nach oben schieben" },
-  "command_treeMoveUp":            { "message": "Aktuellen Zweig nach oben schieben" },
-  "command_tabMoveDown":           { "message": "Aktuellen Tab nach unten schieben" },
-  "command_treeMoveDown":          { "message": "Aktuellen Zweig nach unten schieben" },
-  "command_focusPrevious":         { "message": "Zum vorherigen Tab wechseln (Zweig ausklappen)" },
-  "command_focusPreviousSilently": { "message": "Zum vorherigen Tab wechseln (Zweig nicht ausklappen)" },
-  "command_focusNext":             { "message": "Zum nächsten Tab wechseln (Zweig ausklappen)" },
-  "command_focusNextSilently":     { "message": "Zum nächsten Tab wechseln (Zweig nicht ausklappen)" },
-  "command_focusParent":           { "message": "Zum übergeordneten Tab wechseln" },
-  "command_focusFirstChild":       { "message": "Zum ersten untergeordneten Tab wechseln" },
-  "command_focusLastChild":        { "message": "Zum letzten untergeordneten Tab wechseln" },
-  "command_focusPreviousSibling":  { "message": "Zum vorherigen benachbarten Tab wechseln" },
-  "command_focusNextSibling":      { "message": "Zum nächsten benachbarten Tab wechseln" },
-  "command_tabbarUp":              { "message": "Zeilenweise in Tabs nach oben scrollen" },
-  "command_tabbarPageUp":          { "message": "Seitenweise in Tabs nach oben scrollen" },
-  "command_tabbarHome":            { "message": "Zum ersten Tab scrollen" },
-  "command_tabbarDown":            { "message": "Zeilenweise in Tabs nach unten scrollen" },
-  "command_tabbarPageDown":        { "message": "Seitenweise in Tabs nach unten scrollen" },
-  "command_tabbarEnd":             { "message": "Zum letzten Tab scrollen" },
-  "command_toggleSubPanel":        { "message": "Sichtbarkeit des Unter-Bedienfelds umschalten" },
-  "command_switchSubPanel":        { "message": "Inhalt des Unter-Bedienfelds wechseln" },
-  "command_increaseSubPanel":      { "message": "Größe des Unter-Bedienfeld erhöhen" },
-  "command_decreaseSubPanel":      { "message": "Größe des Unter-Bedienfeld verringern" },
-
-  "tab_closebox_aria_label": { "message": "Tab #$ID$ schließen",
+  "extensionName": {
+    "message": "Tree Style Tab"
+  },
+  "extensionDescription": {
+    "message": "Stellt Tabs in einer Baumstruktur dar."
+  },
+  "sidebarTitle": {
+    "message": "Tree Style Tab"
+  },
+  "sidebarToggleDescription": {
+    "message": "\"Tree Style Tab\" Seitenleiste Ein-/Ausblenden"
+  },
+  "command_tabMoveUp": {
+    "message": "Aktuellen Tab nach oben schieben"
+  },
+  "command_treeMoveUp": {
+    "message": "Aktuellen Zweig nach oben schieben"
+  },
+  "command_tabMoveDown": {
+    "message": "Aktuellen Tab nach unten schieben"
+  },
+  "command_treeMoveDown": {
+    "message": "Aktuellen Zweig nach unten schieben"
+  },
+  "command_focusPrevious": {
+    "message": "Zum vorherigen Tab wechseln (Zweig ausklappen)"
+  },
+  "command_focusPreviousSilently": {
+    "message": "Zum vorherigen Tab wechseln (Zweig nicht ausklappen)"
+  },
+  "command_focusNext": {
+    "message": "Zum nächsten Tab wechseln (Zweig ausklappen)"
+  },
+  "command_focusNextSilently": {
+    "message": "Zum nächsten Tab wechseln (Zweig nicht ausklappen)"
+  },
+  "command_focusParent": {
+    "message": "Zum übergeordneten Tab wechseln"
+  },
+  "command_focusFirstChild": {
+    "message": "Zum ersten untergeordneten Tab wechseln"
+  },
+  "command_focusLastChild": {
+    "message": "Zum letzten untergeordneten Tab wechseln"
+  },
+  "command_focusPreviousSibling": {
+    "message": "Zum vorherigen benachbarten Tab wechseln"
+  },
+  "command_focusNextSibling": {
+    "message": "Zum nächsten benachbarten Tab wechseln"
+  },
+  "command_tabbarUp": {
+    "message": "Zeilenweise in Tabs nach oben scrollen"
+  },
+  "command_tabbarPageUp": {
+    "message": "Seitenweise in Tabs nach oben scrollen"
+  },
+  "command_tabbarHome": {
+    "message": "Zum ersten Tab scrollen"
+  },
+  "command_tabbarDown": {
+    "message": "Zeilenweise in Tabs nach unten scrollen"
+  },
+  "command_tabbarPageDown": {
+    "message": "Seitenweise in Tabs nach unten scrollen"
+  },
+  "command_tabbarEnd": {
+    "message": "Zum letzten Tab scrollen"
+  },
+  "command_toggleSubPanel": {
+    "message": "Sichtbarkeit des Unter-Bedienfelds umschalten"
+  },
+  "command_switchSubPanel": {
+    "message": "Inhalt des Unter-Bedienfelds wechseln"
+  },
+  "command_increaseSubPanel": {
+    "message": "Größe des Unter-Bedienfeld erhöhen"
+  },
+  "command_decreaseSubPanel": {
+    "message": "Größe des Unter-Bedienfeld verringern"
+  },
+  "tab_closebox_aria_label": {
+    "message": "Tab #$ID$ schließen",
     "placeholders": {
-      "id": { "content": "$1", "example": "1" }
-    }},
-  "tab_closebox_tab_tooltip": { "message": "Tab schließen" },
-  "tab_closebox_tab_tooltip_multiselected": { "message": "Tabs schließen" },
-  "tab_closebox_tree_tooltip": { "message": "Zweig schließen" },
-  "tab_soundButton_aria_label": { "message": "Tab #$ID$ stumm schalten",
+      "id": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "tab_closebox_tab_tooltip": {
+    "message": "Tab schließen"
+  },
+  "tab_closebox_tab_tooltip_multiselected": {
+    "message": "Tabs schließen"
+  },
+  "tab_closebox_tree_tooltip": {
+    "message": "Zweig schließen"
+  },
+  "tab_soundButton_aria_label": {
+    "message": "Tab #$ID$ stumm schalten",
     "placeholders": {
-      "id": { "content": "$1", "example": "1" }
-    }},
-  "tab_soundButton_muted_tooltip": { "message": "Stummschaltung für Tab aufheben" },
-  "tab_soundButton_muted_tooltip_multiselected": { "message": "Stummschaltung für Tabs aufheben" },
-  "tab_soundButton_playing_tooltip": { "message": "Tab stumm schalten" },
-  "tab_soundButton_playing_tooltip_multiselected": { "message": "Tabs stumm schalten" },
-  "tab_twisty_aria_label": { "message": "Zweig #$ID$ umschalten",
+      "id": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "tab_sharingState_sharingCamera_tooltip": {
+    "message": "Sie teilen Ihre Kamera"
+  },
+  "tab_sharingState_sharingMicrophone_tooltip": {
+    "message": "Sie teilen Ihren Mikrofon"
+  },
+  "tab_sharingState_sharingScreen_tooltip": {
+    "message": "Sie teilen ein Fenster oder einen Bildschirm"
+  },
+  "tab_soundButton_muted_tooltip": {
+    "message": "Stummschaltung für Tab aufheben"
+  },
+  "tab_soundButton_muted_tooltip_multiselected": {
+    "message": "Stummschaltung für Tabs aufheben"
+  },
+  "tab_soundButton_playing_tooltip": {
+    "message": "Tab stumm schalten"
+  },
+  "tab_soundButton_playing_tooltip_multiselected": {
+    "message": "Tabs stumm schalten"
+  },
+  "tab_soundButton_autoplayBlocked_tooltip": {
+    "message": "Tab widergeben"
+  },
+  "tab_soundButton_autoplayBlocked_tooltip_multiselected": {
+    "message": "Tabs widergeben"
+  },
+  "tab_twisty_aria_label": {
+    "message": "Zweig #$ID$ umschalten",
     "placeholders": {
-      "id": { "content": "$1", "example": "1" }
-    }},
-  "tab_twisty_expanded_tooltip": { "message": "Zweig zuklappen" },
-  "tab_twisty_collapsed_tooltip": { "message": "Zweig aufklappen" },
-  "tab_tree_tooltip": { "message": "$TREE$\n  …und $COUNT$ weitere(r) Tab (s)",
+      "id": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "tab_twisty_expanded_tooltip": {
+    "message": "Zweig zuklappen"
+  },
+  "tab_twisty_collapsed_tooltip": {
+    "message": "Zweig aufklappen"
+  },
+  "tab_tree_tooltip": {
+    "message": "$TREE$\n  …und $COUNT$ weitere(r) Tab (s)",
     "placeholders": {
-      "tree": { "content": "$1", "example": "* Tree\n  * Style\n    * Tab" },
-      "count": { "content": "$2", "example": "3" }
-    }},
-  "tabbar_newTabButton_tooltip": { "message": "Neuen Tab öffnen" },
-
-  "tabbar_newTabAction_tooltip":           { "message": "Neuen Tab öffnen als…" },
-  "tabbar_newTabAction_independent_label": { "message": "&Eigenständigen Tab" },
-  "tabbar_newTabAction_independent_command": { "message": "Eigenständigen Tab" },
-  "tabbar_newTabAction_child_label":       { "message": "&Untergeordneten Tab" },
-  "tabbar_newTabAction_child_command":       { "message": "Untergeordneten Tab" },
-  "tabbar_newTabAction_sibling_label":     { "message": "Tab auf der Ebene des &aktiven Tab" },
-  "tabbar_newTabAction_sibling_command":     { "message": "Tab auf der Ebene des aktiven Tab" },
-  "tabbar_newTabAction_nextSibling_label": { "message": "Direkter &Nachbar auf der Ebene des aktiven Tab" },
-  "tabbar_newTabAction_nextSibling_command": { "message": "Direkter Nachbar auf der Ebene des aktiven Tab" },
-
-  "tabbar_newTabWithContexualIdentity_tooltip": { "message": "Neuer Tab in Umgebung" },
-  "tabbar_newTabWithContexualIdentity_default": { "message": "Keine Tab-&Umgebung" },
-
-  "groupTab_label": { "message": "$TITLE$ und mehr",
+      "tree": {
+        "content": "$1",
+        "example": "* Tree\n  * Style\n    * Tab"
+      },
+      "count": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "tabbar_newTabButton_tooltip": {
+    "message": "Neuen Tab öffnen"
+  },
+  "tabbar_newTabAction_tooltip": {
+    "message": "Neuen Tab öffnen als…"
+  },
+  "tabbar_newTabAction_independent_label": {
+    "message": "&Eigenständigen Tab"
+  },
+  "tabbar_newTabAction_independent_command": {
+    "message": "Eigenständigen Tab"
+  },
+  "tabbar_newTabAction_child_label": {
+    "message": "&Untergeordneten Tab"
+  },
+  "tabbar_newTabAction_child_command": {
+    "message": "Untergeordneten Tab"
+  },
+  "tabbar_newTabAction_sibling_label": {
+    "message": "Tab auf der Ebene des &aktiven Tab"
+  },
+  "tabbar_newTabAction_sibling_command": {
+    "message": "Tab auf der Ebene des aktiven Tab"
+  },
+  "tabbar_newTabAction_nextSibling_label": {
+    "message": "Nächster &Nachbar auf der Ebene des aktiven Tab"
+  },
+  "tabbar_newTabAction_nextSibling_command": {
+    "message": "Nächster Nachbar auf der Ebene des aktiven Tab"
+  },
+  "tabbar_newTabWithContexualIdentity_tooltip": {
+    "message": "Neuer Tab in Umgebung"
+  },
+  "tabbar_newTabWithContexualIdentity_default": {
+    "message": "Keine Tab-&Umgebung"
+  },
+  "groupTab_label": {
+    "message": "$TITLE$ und mehr",
     "placeholders": {
-      "title": { "content": "$1", "example": "Titel" }
-    }},
-  "groupTab_label_default": { "message": "Gruppe" },
-  "groupTab_temporary_label": { "message": "Diesen Tab schließen, wenn keine untergeordneten Tabs mehr existieren" },
-  "groupTab_temporaryAggressive_label": { "message": "Diesen Tab schließen, wenn nicht mehr als ein untergeordneter Tab existiert" },
-  "groupTab_fromPinnedTab_label": { "message": "Tabs von $TITLE$",
+      "title": {
+        "content": "$1",
+        "example": "title"
+      }
+    }
+  },
+  "groupTab_label_default": {
+    "message": "Gruppe"
+  },
+  "groupTab_temporary_label": {
+    "message": "Diesen Tab schließen, wenn keine untergeordneten Tabs mehr existieren"
+  },
+  "groupTab_temporaryAggressive_label": {
+    "message": "Diesen Tab schließen, wenn nicht mehr als ein untergeordneter Tab existiert"
+  },
+  "groupTab_fromPinnedTab_label": {
+    "message": "Tabs von $TITLE$",
     "placeholders": {
-      "title": { "content": "$1", "example": "Titel" }
-    }},
-  "groupTab_options_label": { "message": "Es gibt eine Einstellung um das Öffnen von Tabs dieser Art zu deaktivieren." },
-  "groupTab_options_dismiss": { "message": "Diesen Hinweis ausblenden" },
-
-  "bookmarkFolder_label_default": { "message": "%ANY(\"%GROUP%\", \"$TITLE$ und mehr\")% (%YEAR%.%MONTH%.%DATE%)",
+      "title": {
+        "content": "$1",
+        "example": "title"
+      }
+    }
+  },
+  "groupTab_options_label": {
+    "message": "Es gibt eine Einstellung um das Öffnen von Tabs dieser Art zu deaktivieren."
+  },
+  "groupTab_options_dismiss": {
+    "message": "Diesen Hinweis ausblenden"
+  },
+  "bookmarkFolder_label_default": {
+    "message": "%ANY(\"%GROUP%\", \"$TITLE$ und mehr\")% (%YEAR%.%MONTH%.%DATE%)",
     "placeholders": {
-      "title": { "content": "$1", "example": "Titel" }
-    }},
-
-  "bookmark_notification_notPermitted_title": { "message": "Berechtigungs-Fehler" },
-  "bookmark_notification_notPermitted_message": { "message": "Fehlende Berechtigung zum Erstellen von Lesezeichen. Bitte hier klicken um Berechtigungen zu erteilen." },
-  "bookmark_notification_notPermitted_message_linux": { "message": "Fehlende Berechtigung zum Erstellen von Lesezeichen. Bitte auf die Schaltfläche klicken um Berechtigungen zu erteilen." },
-
-  "bookmarkContext_notification_notPermitted_title": { "message": "Berechtigungs-Fehler" },
-  "bookmarkContext_notification_notPermitted_message": { "message": "Fehlende Berechtigung zum Öffnen des Kontextmenüs für Lesezeichen. Bitte hier klicken um Berechtigungen zu erteilen." },
-  "bookmarkContext_notification_notPermitted_message_linux": { "message": "Fehlende Berechtigung zum Öffnen des Kontextmenüs für Lesezeichen. Bitte auf die Schaltfläche klicken um Berechtigungen zu erteilen." },
-
-  "dropLinksOnTabBehavior_message": { "message": "Wie soll der Link geöffnet werden?" },
-  "dropLinksOnTabBehavior_save":    { "message": "Die Auswahl beim nächsten Mal beibehalten" },
-  "dropLinksOnTabBehavior_load":    { "message": "In diesem Tab öffnen" },
-  "dropLinksOnTabBehavior_newtab":  { "message": "In neuem untergeordneten Tab öffnen" },
-
-  "tabDragBehaviorNotification_message_duration_single":  { "message": "8s" },
-  "tabDragBehaviorNotification_message_duration_both":  { "message": "16s" },
-  "tabDragBehaviorNotification_message_base":  { "message": "Ablegen außerhalb der Seitenleiste wird $RESULT$.",
+      "title": {
+        "content": "$1",
+        "example": "Title"
+      }
+    }
+  },
+  "bookmark_notification_notPermitted_title": {
+    "message": "Berechtigungs-Fehler"
+  },
+  "bookmark_notification_notPermitted_message": {
+    "message": "Fehlende Berechtigung zum Erstellen von Lesezeichen. Bitte hier klicken um Berechtigungen zu erteilen."
+  },
+  "bookmark_notification_notPermitted_message_linux": {
+    "message": "Fehlende Berechtigung zum Erstellen von Lesezeichen. Bitte auf die Schaltfläche klicken um Berechtigungen zu erteilen."
+  },
+  "bookmarkContext_notification_notPermitted_title": {
+    "message": "Berechtigungs-Fehler"
+  },
+  "bookmarkContext_notification_notPermitted_message": {
+    "message": "Fehlende Berechtigung zum Öffnen des Kontextmenüs für Lesezeichen. Bitte hier klicken um Berechtigungen zu erteilen."
+  },
+  "bookmarkContext_notification_notPermitted_message_linux": {
+    "message": "Fehlende Berechtigung zum Öffnen des Kontextmenüs für Lesezeichen. Bitte auf die Schaltfläche klicken um Berechtigungen zu erteilen."
+  },
+  "dropLinksOnTabBehavior_message": {
+    "message": "Wie soll der Link geöffnet werden?"
+  },
+  "dropLinksOnTabBehavior_save": {
+    "message": "Die Auswahl beim nächsten Mal beibehalten"
+  },
+  "dropLinksOnTabBehavior_load": {
+    "message": "In diesem Tab öffnen"
+  },
+  "dropLinksOnTabBehavior_newtab": {
+    "message": "In neuem untergeordneten Tab öffnen"
+  },
+  "tabDragBehaviorNotification_message_duration_single": {
+    "message": "8s"
+  },
+  "tabDragBehaviorNotification_message_duration_both": {
+    "message": "16s"
+  },
+  "tabDragBehaviorNotification_message_base": {
+    "message": "Ablegen außerhalb der Seitenleiste wird $RESULT$.",
     "placeholders": {
-      "result": { "content": "$1", "example": "irgendwas geschehen lassen" }
-    }},
-  "tabDragBehaviorNotification_message_inverted_base_with_shift":  { "message": "Shift-Ziehen wird $RESULT$.",
+      "result": {
+        "content": "$1",
+        "example": "something happen"
+      }
+    }
+  },
+  "tabDragBehaviorNotification_message_inverted_base_with_shift": {
+    "message": "Shift-Ziehen wird $RESULT$.",
     "placeholders": {
-      "result": { "content": "$1", "example": "irgendwas geschehen lassen" }
-    }},
-  "tabDragBehaviorNotification_message_inverted_base_without_shift":  { "message": "Ziehen ohne Shift wird $RESULT$.",
+      "result": {
+        "content": "$1",
+        "example": "something happen"
+      }
+    }
+  },
+  "tabDragBehaviorNotification_message_inverted_base_without_shift": {
+    "message": "Ziehen ohne Shift wird $RESULT$.",
     "placeholders": {
-      "result": { "content": "$1", "example": "irgendwas geschehen lassen" }
-    }},
-  "tabDragBehaviorNotification_message_tree_tearoff":  { "message": "Tabs vom Fenster ablösen" },
-  "tabDragBehaviorNotification_message_tab_tearoff":   { "message": "den Tab vom Fenster ablösen" },
-  "tabDragBehaviorNotification_message_tree_bookmark": { "message": "Verweise oder Lesezeichen an dem Platz anlegen, an dem die Tabs abgelegt werden" },
-  "tabDragBehaviorNotification_message_tab_bookmark":  { "message": "einen Verweis oder ein Lesezeichen an dem Platz anlegen, an dem der Tab abgelegt wird" },
-
-  "warnOnCloseTabs_title":     { "message": "Tabs schließen?" },
-  "warnOnCloseTabs_message":   { "message": "Möchtest du wirklich $NUMBER$ Tabs schließen?",
+      "result": {
+        "content": "$1",
+        "example": "something happen"
+      }
+    }
+  },
+  "tabDragBehaviorNotification_message_tree_tearoff": {
+    "message": "Tabs vom Fenster ablösen"
+  },
+  "tabDragBehaviorNotification_message_tab_tearoff": {
+    "message": "den Tab vom Fenster ablösen"
+  },
+  "tabDragBehaviorNotification_message_tree_bookmark": {
+    "message": "Verweise oder Lesezeichen an dem Platz anlegen, an dem die Tabs abgelegt werden"
+  },
+  "tabDragBehaviorNotification_message_tab_bookmark": {
+    "message": "einen Verweis oder ein Lesezeichen an dem Platz anlegen, an dem der Tab abgelegt wird"
+  },
+  "tabsHighlightingNotification_message": {
+    "message": "Hervorhebung der Tabs... $PROGRESS$ %",
     "placeholders": {
-      "NUMBER": { "content": "$1", "example": "10" }
-    }},
-  "warnOnCloseTabs_warnAgain": { "message": "Warnen wenn mehrere Tabs geschlossen werden sollen" },
-  "warnOnCloseTabs_close":     { "message": "Tabs schließen" },
-  "warnOnCloseTabs_cancel":    { "message": "Abbrechen" },
-
-  "warnOnCloseTabs_fromOutside_title":     { "message": "Mit untergeordneten Tabs schließen?" },
-  "warnOnCloseTabs_fromOutside_message":   { "message": "Der geschlossene Tab hatte $NUMBER$ untergeordnete Tabs. Sicher, dass diese auch geschlossen werden sollen?\n(*Abbruch wird den geschlossenen übergeordneten Tab wiederherstellen.)",
+      "progress": {
+        "content": "$1",
+        "example": "50"
+      }
+    }
+  },
+  "warnOnCloseTabs_title": {
+    "message": "Tabs schließen?"
+  },
+  "warnOnCloseTabs_message": {
+    "message": "Möchtest du wirklich $NUMBER$ Tabs schließen?",
     "placeholders": {
-      "NUMBER": { "content": "$1", "example": "10" }
-    }},
-
-  "warnOnCloseTabs_notification_message": { "message": "Falls nicht, hier zum Abbrechen klicken.\nAndernfalls werden die Tabs nach $TIMEOUT$ Sekunden geschlossen.",
+      "NUMBER": {
+        "content": "$1",
+        "example": "10"
+      }
+    }
+  },
+  "warnOnCloseTabs_warnAgain": {
+    "message": "Warnen wenn mehrere Tabs geschlossen werden sollen"
+  },
+  "warnOnCloseTabs_close": {
+    "message": "Tabs schließen"
+  },
+  "warnOnCloseTabs_cancel": {
+    "message": "Abbrechen"
+  },
+  "warnOnCloseTabs_fromOutside_title": {
+    "message": "Mit untergeordneten Tabs schließen?"
+  },
+  "warnOnCloseTabs_fromOutside_message": {
+    "message": "Der geschlossene Tab hatte $NUMBER$ untergeordnete Tabs. Sicher, dass diese auch geschlossen werden sollen?\n(*Abbruch wird den geschlossenen übergeordneten Tab wiederherstellen.)",
     "placeholders": {
-      "TIMEOUT": { "content": "$1", "example": "10" }
-    }},
-  "warnOnCloseTabs_notification_message_linux": { "message": "Falls nicht, zum Abbrechen auf die Schaltfläche klicken.\nAndernfalls werden die Tabs nach $TIMEOUT$ Sekunden geschlossen.",
+      "NUMBER": {
+        "content": "$1",
+        "example": "10"
+      }
+    }
+  },
+  "warnOnCloseTabs_notification_message": {
+    "message": "Falls nicht, hier zum Abbrechen klicken.\nAndernfalls werden die Tabs nach $TIMEOUT$ Sekunden geschlossen.",
     "placeholders": {
-      "TIMEOUT": { "content": "$1", "example": "10" }
-    }},
-
-  "warnOnAutoGroupNewTabs_title":     { "message": "Tabs gruppieren?" },
-  "warnOnAutoGroupNewTabs_message":   { "message": "$NUMBER$ Tabs werden gleichzeitig geöffnet. Sollen sie in einem Zweig gruppiert geöffnet werden?",
+      "TIMEOUT": {
+        "content": "$1",
+        "example": "10"
+      }
+    }
+  },
+  "warnOnCloseTabs_notification_message_linux": {
+    "message": "Falls nicht, zum Abbrechen auf die Schaltfläche klicken.\nAndernfalls werden die Tabs nach $TIMEOUT$ Sekunden geschlossen.",
     "placeholders": {
-      "NUMBER": { "content": "$1", "example": "10" }
-    }},
-  "warnOnAutoGroupNewTabs_warnAgain": { "message": "Fragen, wenn mehrere Tabs gleichzeitig geöffnet werden" },
-  "warnOnAutoGroupNewTabs_close":     { "message": "Tabs gruppieren" },
-  "warnOnAutoGroupNewTabs_cancel":    { "message": "Tabs nebeneinander anzeigen" },
-
-  "bookmarkDialog_dialogTitle_single":   { "message": "Neues Lesezeichen" },
-  "bookmarkDialog_dialogTitle_multiple": { "message": "Neue Lesezeichen" },
-  "bookmarkDialog_title":    { "message": "Name:" },
-  "bookmarkDialog_title_accessKey": { "message": "n" },
-  "bookmarkDialog_url":      { "message": "Ort:" },
-  "bookmarkDialog_url_accessKey": { "message": "l" },
-  "bookmarkDialog_parentId": { "message": "Ordner:" },
-  "bookmarkDialog_saveContainerRedirectKey": { "message": "Umgebungs-Informationen für Container Bookmarks speichern" },
-  "bookmarkDialog_accept":   { "message": "Speichern" },
-  "bookmarkDialog_cancel":   { "message": "Abbrechen" },
-
-  "bookmarkFolderChooser_unspecified":   { "message": "(unbekannt)" },
-  "bookmarkFolderChooser_blank":         { "message": "(kein Name)" },
-  "bookmarkFolderChooser_useThisFolder": { "message": "Diesen Orner nutzen" },
-
-  "syncDeviceDefaultName": { "message": "$BROWSER$ unter $PLATFORM$",
+      "TIMEOUT": {
+        "content": "$1",
+        "example": "10"
+      }
+    }
+  },
+  "warnOnAutoGroupNewTabs_title": {
+    "message": "Tabs gruppieren?"
+  },
+  "warnOnAutoGroupNewTabs_message": {
+    "message": "$NUMBER$ Tabs werden gleichzeitig geöffnet. Sollen sie in einem Zweig gruppiert geöffnet werden?",
     "placeholders": {
-      "PLATFORM": { "content": "$1", "example": "Firefox" },
-      "BROWSER":  { "content": "$2", "example": "Windows" }
-    }},
-  "syncDeviceMissingDeviceName": { "message": "ein nicht benanntes Gerät" },
-  "syncDeviceUnknownDevice":     { "message": "ein unbekanntes Gerät" },
-  "syncAvailable_notification_title":   { "message": "Tabs können nun auf andere Geräte gesendet werden." },
-  "syncAvailable_notification_message": { "message": "Tabs köknnen nun zwischen Geräten synchronisiert werden. Hier klicken um diesem Gerät einen Namen zu geben." },
-  "syncAvailable_notification_message_linux": { "message": "Tabs köknnen nun zwischen Geräten synchronisiert werden. Auf die Schaltfläche klicken um diesem Gerät einen Namen zu geben." },
-  "sentTabs_notification_title":            { "message": "\u200b" },
-  "sentTabs_notification_message":          { "message": "Tabs werden an $DEVICE$ gesendet",
+      "NUMBER": {
+        "content": "$1",
+        "example": "10"
+      }
+    }
+  },
+  "warnOnAutoGroupNewTabs_warnAgain": {
+    "message": "Fragen, wenn mehrere Tabs gleichzeitig geöffnet werden"
+  },
+  "warnOnAutoGroupNewTabs_close": {
+    "message": "Tabs gruppieren"
+  },
+  "warnOnAutoGroupNewTabs_cancel": {
+    "message": "Tabs nebeneinander anzeigen"
+  },
+  "bookmarkDialog_dialogTitle_single": {
+    "message": "Neues Lesezeichen"
+  },
+  "bookmarkDialog_dialogTitle_multiple": {
+    "message": "Neue Lesezeichen"
+  },
+  "bookmarkDialog_title": {
+    "message": "Name:"
+  },
+  "bookmarkDialog_title_accessKey": {
+    "message": "n"
+  },
+  "bookmarkDialog_url": {
+    "message": "Ort:"
+  },
+  "bookmarkDialog_url_accessKey": {
+    "message": "l"
+  },
+  "bookmarkDialog_parentId": {
+    "message": "Ordner:"
+  },
+  "bookmarkDialog_saveContainerRedirectKey": {
+    "message": "Umgebungs-Informationen für Container Bookmarks speichern"
+  },
+  "bookmarkDialog_accept": {
+    "message": "Speichern"
+  },
+  "bookmarkDialog_cancel": {
+    "message": "Abbrechen"
+  },
+  "bookmarkFolderChooser_unspecified": {
+    "message": "(unbekannt)"
+  },
+  "bookmarkFolderChooser_blank": {
+    "message": "(kein Name)"
+  },
+  "bookmarkFolderChooser_useThisFolder": {
+    "message": "Diesen Orner nutzen"
+  },
+  "syncDeviceDefaultName": {
+    "message": "$BROWSER$ unter $PLATFORM$",
     "placeholders": {
-      "DEVICE": { "content": "$1", "example": "Firefox auf Gerät X" }
-    }},
-  "sentTabs_notification_title_multiple":   { "message": "\u200b" },
-  "sentTabs_notification_message_multiple": { "message": "Tabs wurden an $DEVICE$ gesendet",
+      "PLATFORM": {
+        "content": "$1",
+        "example": "Firefox"
+      },
+      "BROWSER": {
+        "content": "$2",
+        "example": "Windows"
+      }
+    }
+  },
+  "syncDeviceMissingDeviceName": {
+    "message": "ein nicht benanntes Gerät"
+  },
+  "syncDeviceUnknownDevice": {
+    "message": "ein unbekanntes Gerät"
+  },
+  "syncAvailable_notification_title": {
+    "message": "Tabs können nun auf andere Geräte gesendet werden."
+  },
+  "syncAvailable_notification_message": {
+    "message": "Tabs köknnen nun zwischen Geräten synchronisiert werden. Hier klicken um diesem Gerät einen Namen zu geben."
+  },
+  "syncAvailable_notification_message_linux": {
+    "message": "Tabs köknnen nun zwischen Geräten synchronisiert werden. Auf die Schaltfläche klicken um diesem Gerät einen Namen zu geben."
+  },
+  "sentTabs_notification_title": {
+    "message": "​"
+  },
+  "sentTabs_notification_message": {
+    "message": "Tabs werden an $DEVICE$ gesendet",
     "placeholders": {
-      "DEVICE": { "content": "$1", "example": "Firefox auf Gerät X" }
-    }},
-  "sentTabsToAllDevices_notification_title":            { "message": "\u200b" },
-  "sentTabsToAllDevices_notification_message":          { "message": "Tab wird an alle Geräte gesendet" },
-  "sentTabsToAllDevices_notification_title_multiple":   { "message": "\u200b" },
-  "sentTabsToAllDevices_notification_message_multiple": { "message": "Tabs werden an alle Geräte gesendet" },
-  "receiveTabs_notification_title":            { "message": "Tab von $DEVICE$",
+      "DEVICE": {
+        "content": "$1",
+        "example": "Firefox on Device X"
+      }
+    }
+  },
+  "sentTabs_notification_title_multiple": {
+    "message": "​"
+  },
+  "sentTabs_notification_message_multiple": {
+    "message": "Tabs wurden an $DEVICE$ gesendet",
     "placeholders": {
-      "DEVICE": { "content": "$1", "example": "Firefox auf Gerät X" }
-    }},
-  "receiveTabs_notification_message":          { "message": "$URL$",
+      "DEVICE": {
+        "content": "$1",
+        "example": "Firefox on Device X"
+      }
+    }
+  },
+  "sentTabsToAllDevices_notification_title": {
+    "message": "​"
+  },
+  "sentTabsToAllDevices_notification_message": {
+    "message": "Tab wird an alle Geräte gesendet"
+  },
+  "sentTabsToAllDevices_notification_title_multiple": {
+    "message": "​"
+  },
+  "sentTabsToAllDevices_notification_message_multiple": {
+    "message": "Tabs werden an alle Geräte gesendet"
+  },
+  "receiveTabs_notification_title": {
+    "message": "Tab von $DEVICE$",
     "placeholders": {
-      "URL": { "content": "$1", "example": "http://example.com/" }
-    }},
-  "receiveTabs_notification_title_multiple":   { "message": "Tabs von $DEVICE$",
+      "DEVICE": {
+        "content": "$1",
+        "example": "Firefox on Device X"
+      }
+    }
+  },
+  "receiveTabs_notification_message": {
+    "message": "$URL$",
     "placeholders": {
-      "DEVICE": { "content": "$1", "example": "Firefox auf Gerät X" }
-    }},
-  "receiveTabs_notification_message_multiple": { "message": "$URL$\nund $REST$ mehr Tab(s)",
+      "URL": {
+        "content": "$1",
+        "example": "http://example.com/"
+      }
+    }
+  },
+  "receiveTabs_notification_title_multiple": {
+    "message": "Tabs von $DEVICE$",
     "placeholders": {
-      "URL": { "content": "$1", "example": "http://example.com/" },
-      "ALL": { "content": "$2", "example": "4" },
-      "REST": { "content": "$3", "example": "3" }
-    }},
-
-  "sidebarPositionRighsideNotification_message":   { "message": "TST hat die Position der Seitenleiste als \"Rechte Seite\" erkannt. Soll das Erscheinungsbild an die aktuelle Position angepasst werden?" },
-  "sidebarPositionRighsideNotification_rightside": { "message": "Erscheinungsbild an rechte Seite anpassen" },
-  "sidebarPositionRighsideNotification_leftside":  { "message": "Erscheinungsbild für linke Seite beibehalten" },
-
-  "sidebarPositionOptionNotification_title":   { "message": "Anzeigeeinstellungen für die Seitenleiste wurden gespeichert" },
-  "sidebarPositionOptionNotification_message": { "message": "Bitte den Abschnitt \"Erscheinungsbild\" der Optionen von Tree Style Tab zum Anpassen der Einstellungen beachten." },
-
-  "startup_notification_title_installed":   { "message": "Für neue Nutzer von Tree Style Tab" },
-  "startup_notification_message_installed": { "message": "Einige zusätzliche Berechtigungen sind für ein natürlicheres Nutzererlebnis erforderlich. Hier klicken um sie zu gewähren." },
-  "startup_notification_message_installed_linux": { "message": "Einige zusätzliche Berechtigungen sind für ein natürlicheres Nutzererlebnis erforderlich. Auf die Schaltfläche klicken um sie zu gewähren." },
-  "startup_notification_title_updated":     { "message": "Spürbare Änderungen von Tree Style Tab" },
-  "startup_notification_message_updated":   { "message": "Einige Änderungen können die gewohnte Nutzung beeinträchtigen. Hier klicken um die Änderungen zu sehen." },
-  "startup_notification_message_updated_linux":   { "message": "Einige Änderungen können die gewohnte Nutzung beeinträchtigen. Auf die Schaltfläche klicken um die Änderungen zu sehen." },
-
-  "message_startup_description_1": { "message": "Tree Style Tab wurde wiedergeboren basierend auf der WebExtensions-Technologie für Firefox 57 (und neuer). Seine senkrechte Tab-Leiste ist als eine der auswählbaren Seitenleiste verfügbar. Falls sie noch nicht angezeigt wird, drücke die " },
-  "message_startup_description_key": { "message": "\"F1\" Taste" },
-  "message_startup_description_2": { "message": " oder klicke auf den " },
-  "message_startup_description_3": { "message": " Button in der Symbolleiste um die Seitenleiste zu aktivieren." },
-  "message_startup_description_sync_before": { "message": "Tabs können via Firefox Sync nur auf Geräte gesendet werden, auf denen TST installiert ist. Bitte zuerst Firefox Sync über die Browsereinstellungen aktivieren und TST auf den anderen Geräten installieren. Außerdem" },
-  "message_startup_description_sync_link":   { "message": "sollte der Gerätename manuell angepasst werden" },
-  "message_startup_description_sync_after":  { "message": "." },
-
-  "message_startup_history_before":     { "message": "Geändertes Verhalten kann (oder auch nicht) durch Workarounds wiederhergestellt werden. Siehe" },
-  "message_startup_history_uri":        { "message": "https://addons.mozilla.org/firefox/addon/tree-style-tab/versions/" },
-  "message_startup_history_link_label": { "message": "die Liste der Änderungen" },
-  "message_startup_history_after":      { "message": " für weitere Informationen." },
-
-  "message_startup_requestPermissions_description": { "message": "⚠Für einige Funktionen sind zusätzliche Berechtigungen erforderlich. Falls du sie aktivieren möchtest, erteile bitte manuell die Berechtigungen." },
-  "message_startup_requestPermissions_bookmarks": { "message": "\"Lesezeichen für diesen Zweig erstellen\" im Kontextmenü von Tabs (benötigt Zugriff auf Lesezeichen.)" },
-  "message_startup_requestPermissions_allUrls":   { "message": "Beim Auswählen von Tabs per Tastatur zugeklappte Zweige nicht ausklappen und zugeklappte untergeordnete Tabs überspringen / Don't restore blank window which was for a closed dialog, by actions to restore closed tabs." },
-
-  "message_startup_userChromeCss_notify": { "message": "Wie kann man die Tableiste und die Überschrift der Seitenleiste ausblenden?" },
-  "message_startup_userChromeCss_description_1": { "message": "Aufgrund von Beschränkungen für WebExtensions, hat Tree Style Tab keine Kontrolle über die Tableiste und die Seitenleiste-Überschriften von Firefox. Um sie zu verändern, siehe " },
-  "message_startup_userChromeCss_description_link_label": { "message": "Beispiele zur Anpassung durch userChrome.css" },
-  "message_startup_userChromeCss_description_link_uri": { "message": "https://github.com/piroor/treestyletab/wiki/Code-snippets-for-custom-style-rules#for-userchromecss" },
-  "message_startup_userChromeCss_description_2": { "message": ". Aber " },
-  "message_startup_userChromeCss_description_note": { "message": "sei Dir bewusst, dass es sich um tiefgreifende Anpassungen handelt. Daher gibt es keine Garantie und sie können in künftigen Firefox-Versionen Probleme verursachen. Bitte auf eigenes Risiko ausprobieren und nur wenn du weißt, was du tust und dir zutraust, mögliche Probleme selbst zu beheben." },
-  "message_startup_userChromeCss_description_3": { "message": "." },
-
-  "api_requestedPermissions_title": { "message": "Erteilung von zusätzlichen Berechtigungen" },
-  "api_requestedPermissions_message": { "message": "⚠Die Erweiterung \"$NAME$\" bittet um zusätzliche Berechtigungen über Tree Style Tab:\n\n$PERMISSIONS$\n\nHier klicken um die Berechtigungen zu erteilen.",
+      "DEVICE": {
+        "content": "$1",
+        "example": "Firefox on Device X"
+      }
+    }
+  },
+  "receiveTabs_notification_message_multiple": {
+    "message": "$URL$\nund $REST$ mehr Tab(s)",
     "placeholders": {
-      "NAME":        { "content": "$1", "example": "foobar" },
-      "PERMISSIONS": { "content": "$2", "example": "tabs" }
-    }},
-  "api_requestedPermissions_message_linux": { "message": "⚠Die Erweiterung \"$NAME$\" bittet um zusätzliche Berechtigungen über Tree Style Tab:\n\n$PERMISSIONS$\n\nAuf die Schaltfläche klicken um die Berechtigungen zu erteilen.",
+      "URL": {
+        "content": "$1",
+        "example": "http://example.com/"
+      },
+      "ALL": {
+        "content": "$2",
+        "example": "4"
+      },
+      "REST": {
+        "content": "$3",
+        "example": "3"
+      }
+    }
+  },
+  "sidebarPositionRighsideNotification_message": {
+    "message": "TST hat die Position der Seitenleiste als \"Rechte Seite\" erkannt. Soll das Erscheinungsbild an die aktuelle Position angepasst werden?"
+  },
+  "sidebarPositionRighsideNotification_rightside": {
+    "message": "Erscheinungsbild an rechte Seite anpassen"
+  },
+  "sidebarPositionRighsideNotification_leftside": {
+    "message": "Erscheinungsbild für linke Seite beibehalten"
+  },
+  "sidebarPositionOptionNotification_title": {
+    "message": "Anzeigeeinstellungen für die Seitenleiste wurden gespeichert"
+  },
+  "sidebarPositionOptionNotification_message": {
+    "message": "Bitte den Abschnitt \"Erscheinungsbild\" der Optionen von Tree Style Tab zum Anpassen der Einstellungen beachten."
+  },
+  "startup_notification_title_installed": {
+    "message": "Für neue Nutzer von Tree Style Tab"
+  },
+  "startup_notification_message_installed": {
+    "message": "Einige zusätzliche Berechtigungen sind für ein natürlicheres Nutzererlebnis erforderlich. Hier klicken um sie zu gewähren."
+  },
+  "startup_notification_message_installed_linux": {
+    "message": "Einige zusätzliche Berechtigungen sind für ein natürlicheres Nutzererlebnis erforderlich. Auf die Schaltfläche klicken um sie zu gewähren."
+  },
+  "startup_notification_title_updated": {
+    "message": "Spürbare Änderungen von Tree Style Tab"
+  },
+  "startup_notification_message_updated": {
+    "message": "Einige Änderungen können die gewohnte Nutzung beeinträchtigen. Hier klicken um die Änderungen zu sehen."
+  },
+  "startup_notification_message_updated_linux": {
+    "message": "Einige Änderungen können die gewohnte Nutzung beeinträchtigen. Auf die Schaltfläche klicken um die Änderungen zu sehen."
+  },
+  "message_startup_description_1": {
+    "message": "Tree Style Tab wurde wiedergeboren basierend auf der WebExtensions-Technologie für Firefox 57 (und neuer). Seine senkrechte Tab-Leiste ist als eine der auswählbaren Seitenleiste verfügbar. Falls sie noch nicht angezeigt wird, drücke die "
+  },
+  "message_startup_description_key": {
+    "message": "\"F1\" Taste"
+  },
+  "message_startup_description_2": {
+    "message": " oder klicke auf den "
+  },
+  "message_startup_description_3": {
+    "message": " Button in der Symbolleiste um die Seitenleiste zu aktivieren."
+  },
+  "message_startup_description_sync_before": {
+    "message": "Tabs können via Firefox Sync nur auf Geräte gesendet werden, auf denen TST installiert ist. Bitte zuerst Firefox Sync über die Browsereinstellungen aktivieren und TST auf den anderen Geräten installieren. Außerdem"
+  },
+  "message_startup_description_sync_link": {
+    "message": "sollte der Gerätename manuell angepasst werden"
+  },
+  "message_startup_description_sync_after": {
+    "message": "."
+  },
+  "message_startup_history_before": {
+    "message": "Geändertes Verhalten kann (oder auch nicht) durch Workarounds wiederhergestellt werden. Siehe"
+  },
+  "message_startup_history_uri": {
+    "message": "https://addons.mozilla.org/firefox/addon/tree-style-tab/versions/"
+  },
+  "message_startup_history_link_label": {
+    "message": "die Liste der Änderungen"
+  },
+  "message_startup_history_after": {
+    "message": " für weitere Informationen."
+  },
+  "message_startup_requestPermissions_description": {
+    "message": "⚠Für einige Funktionen sind zusätzliche Berechtigungen erforderlich. Falls du sie aktivieren möchtest, erteile bitte manuell die Berechtigungen."
+  },
+  "message_startup_requestPermissions_bookmarks": {
+    "message": "\"Lesezeichen für diesen Zweig erstellen\" im Kontextmenü von Tabs (benötigt Zugriff auf Lesezeichen.)"
+  },
+  "message_startup_requestPermissions_allUrls": {
+    "message": "Beim Auswählen von Tabs per Tastatur zugeklappte Zweige nicht ausklappen und zugeklappte untergeordnete Tabs überspringen / Don't restore blank window which was for a closed dialog, by actions to restore closed tabs."
+  },
+  "message_startup_userChromeCss_notify": {
+    "message": "Wie kann man die Tableiste und die Überschrift der Seitenleiste ausblenden?"
+  },
+  "message_startup_userChromeCss_description_1": {
+    "message": "Aufgrund von Beschränkungen für WebExtensions, hat Tree Style Tab keine Kontrolle über die Tableiste und die Seitenleiste-Überschriften von Firefox. Um sie zu verändern, siehe "
+  },
+  "message_startup_userChromeCss_description_link_label": {
+    "message": "Beispiele zur Anpassung durch userChrome.css"
+  },
+  "message_startup_userChromeCss_description_link_uri": {
+    "message": "https://github.com/piroor/treestyletab/wiki/Code-snippets-for-custom-style-rules#for-userchromecss"
+  },
+  "message_startup_userChromeCss_description_2": {
+    "message": ". Aber "
+  },
+  "message_startup_userChromeCss_description_note": {
+    "message": "sei Dir bewusst, dass es sich um tiefgreifende Anpassungen handelt. Daher gibt es keine Garantie und sie können in künftigen Firefox-Versionen Probleme verursachen. Bitte auf eigenes Risiko ausprobieren und nur wenn du weißt, was du tust und dir zutraust, mögliche Probleme selbst zu beheben."
+  },
+  "message_startup_userChromeCss_description_3": {
+    "message": "."
+  },
+  "api_requestedPermissions_title": {
+    "message": "Erteilung von zusätzlichen Berechtigungen"
+  },
+  "api_requestedPermissions_message": {
+    "message": "⚠Die Erweiterung \"$NAME$\" bittet um zusätzliche Berechtigungen über Tree Style Tab:\n\n$PERMISSIONS$\n\nHier klicken um die Berechtigungen zu erteilen.",
     "placeholders": {
-      "NAME":        { "content": "$1", "example": "foobar" },
-      "PERMISSIONS": { "content": "$2", "example": "tabs" }
-    }},
-  "api_requestedPermissions_type_activeTab": { "message": "Zugriff auf aktiven Tab" },
-  "api_requestedPermissions_type_tabs":      { "message": "Zugriff auf Tabs" },
-  "api_requestedPermissions_type_cookies":   { "message": "Erkennung der Tab-Umgebungen" },
-
-
-  "context_menu_label": { "message": "Baumstruktur" },
-
-  "context_reloadTree_label": { "message": "Zweig neu la&den" },
-  "context_reloadTree_label_multiselected": { "message": "Ausgewählte Zweige neu la&den" },
-  "context_reloadTree_command": { "message": "Zweig neu laden" },
-  "context_reloadDescendants_label": { "message": "&Untergeordnete Tabs neu laden" },
-  "context_reloadDescendants_label_multiselected": { "message": "&Untergeordnete Tabs der Auswahl neu laden" },
-  "context_reloadDescendants_command": { "message": "Untergeordnete Tabs neu laden" },
-  "context_closeTree_label": { "message": "Zweig &schließen" },
-  "context_closeTree_label_multiselected": { "message": "Ausgewählte Zweige &schließen" },
-  "context_closeTree_command": { "message": "Zweig schließen" },
-  "context_closeDescendants_label": { "message": "U&ntergeordnete Tabs schließen" },
-  "context_closeDescendants_label_multiselected": { "message": "U&ntergeordnete Tabs der Auswahl schließen" },
-  "context_closeDescendants_command": { "message": "Untergeordnete Tabs schließen" },
-  "context_closeOthers_label": { "message": "&Alle anderen Tabs außer diesen Zweig schließen" },
-  "context_closeOthers_label_multiselected": { "message": "&Alle anderen Tabs außer ausgewählter Zweige schließen" },
-  "context_closeOthers_command": { "message": "Alle anderen Tabs außer diesen Zweig schließen" },
-  "context_collapseTree_label": { "message": "Di&esen Zweig zuklappen" },
-  "context_collapseTree_label_multiselected": { "message": "Ausgewählte Zw&eige zuklappen" },
-  "context_collapseTree_command": { "message": "Diesen Zweig zuklappen" },
-  "context_collapseTreeRecursively_label": { "message": "Diesen Zweig rekursiv zuklappen" },
-  "context_collapseTreeRecursively_label_multiselected": { "message": "Ausgewählte Zweige rekursiv zuklappen" },
-  "context_collapseTreeRecursively_command": { "message": "Diesen Zwei rekursiv zuklappen" },
-  "context_collapseAll_label": { "message": "Alle &zuklappen" },
-  "context_collapseAll_command": { "message": "Alle zuklappen" },
-  "context_expandTree_label": { "message": "Diesen Zweig auskla&ppen" },
-  "context_expandTree_label_multiselected": { "message": "Ausgewählte Zweige auskla&ppen" },
-  "context_expandTree_command": { "message": "Diesen Zweig ausklappen" },
-  "context_expandTreeRecursively_label": { "message": "Diesen Zweig rekursiv ausklappen" },
-  "context_expandTreeRecursively_label_multiselected": { "message": "Ausgewählte Zweige rekursiv ausklappen" },
-  "context_expandTreeRecursively_command": { "message": "Diesen Zweig rekursiv ausklappen" },
-  "context_expandAll_label": { "message": "Alle au&fklappen" },
-  "context_expandAll_command": { "message": "Alle aufklappen" },
-  "context_bookmarkTree_label": { "message": "&Lesezeichen für diesen Zweig anlegen…" },
-  "context_bookmarkTree_label_multiselected": { "message": "&Lesezeichen für ausgewählte Zweige anlegen…" },
-  "context_bookmarkTree_command": { "message": "Lesezeichen für diesen Zweig anlegen…" },
-  "context_sendTreeToDevice_label": { "message": "Sen&de diesen Zweig an Gerät" },
-  "context_sendTreeToDevice_label_multiselected": { "message": "Sen&de ausgewählte Zweige an Gerät" },
-  "context_sendTreeToDevice_command": { "message": "Sende diesen Zweig an Gerät" },
-  "context_topLevel_prefix": { "message": "Oberstes Objekt: " },
-
-  "context_collapsed_label": { "message": "Zugeklappt (für Test eines \"checkbox\" Menüs)" },
-  "context_pinnedTab_label": { "message": "Angeheftet (für Test eines \"radio\" Menüs)" },
-  "context_unpinnedTab_label": { "message": "Abgelöst (für Test eines \"radio\" Menüs)" },
-
-  "context_openAllBookmarksWithStructure_label": { "message": "&Alle als Zweig laden" },
-  "context_openAllBookmarksWithStructureRecursively_label": { "message": "&Alle als Zweig inklusive Unterverzeichnisse laden" },
-
-
-  "config_title": { "message": "Tree Style Tab Einstellungen" },
-
-  "config_recommended_choice": { "message": "(empfohlen)" },
-  "config_firefoxCompatible_choice": { "message": "(simuliert das Standardverhalten von Firefox)" },
-
-  "config_showExpertOptions_label": { "message": "Experteneinstellungen anzeigen" },
-  "config_openOptionsInTab_label": { "message": "Diese Einstellungsseite verbreitert anzeigen" },
-
-  "config_appearance_caption": { "message": "Erscheinungsbild" },
-
-  "config_sidebarPosition_caption": { "message": "Ausrichtung des Seitenleisten-Inhalts:" },
-  "config_sidebarPosition_left": { "message": "Rechtsbündig" },
-  "config_sidebarPosition_right": { "message": "Linksbündig" },
-  "config_sidebarPosition_auto": { "message": "Automatisch erkennen, wenn die Seitenleiste angezeigt wird" },
-  "config_sidebarPosition_description": { "message": "*Diese Einstellung ändert nicht die Position der Seitenleiste. Klicke dafür auf die Seitenleisten-Überschrift und dann auf \"Seitenleiste nach rechts (links) verschieben\"." },
-
-  "config_style_caption": { "message": "Design" },
-  "config_style_proton": { "message": "Proton" },
-  "config_style_photon": { "message": "Photon" },
-  "config_style_sidebar": { "message": "Seitenleiste" },
-  "config_style_highcontrast": { "message": "Hoher Kontrast" },
-  "config_style_none": { "message": "Keine Designvorgabe" },
-  "config_style_none_info": { "message": " (*Passe alles selbst über das Feld \"Erweitert\" => \"User Style Sheet\" an)" },
-
-  "config_colorScheme_caption": { "message": "Farbschema:" },
-  "config_colorScheme_photon": { "message": "Photon" },
-  "config_colorScheme_systemColor": { "message": "Systemfarben" },
-
-  "config_maxTreeLevel_before": { "message": "Tabs einrücken bis" },
-  "config_maxTreeLevel_after": { "message": "Stufen (*Negative Werte bedeuten \"unbegrenzt\")" },
-
-  "config_faviconizePinnedTabs_label": { "message": "Angeheftete Tabs nur mit Ihrem Symbol anzeigen" },
-  "config_maxFaviconizedPinnedTabsInOneRow_label_before": { "message": "Zeige " },
-  "config_maxFaviconizedPinnedTabsInOneRow_label_after": { "message": " oder weniger Tabs für jede Reihe (*0 oder weniger bedeutet automatische Bestimmung)" },
-  "config_maxPinnedTabsRowsAreaPercentage_label_before": { "message": "Maximale Höhe des Bereichs für angeheftete Tabs:" },
-  "config_maxPinnedTabsRowsAreaPercentage_label_after":  { "message": "% der Seitenleiste" },
-  "config_animation_label": { "message": "Animationen aktivieren" },
-  "config_animationForce_label": { "message": "Animationen unabhängig von der Einstellung \"Animationen verringern\" aktivieren" },
-  "config_showCollapsedDescendantsByTooltip_label": { "message": "Eingeklappte untergeordnete Tabs als Tooltip anzeigen" },
-  "config_shiftTabsForScrollbarDistance_label_before": { "message": "Tabs um " },
-  "config_shiftTabsForScrollbarDistance_label_after": { "message": " verschieben, damit Tab-Schaltflächen erreichbar bleiben und nicht von der Scrollbar verdeckt werden" },
-  "config_shiftTabsForScrollbarDistance_placeholder": { "message": "(CSS Länge)" },
-  "config_shiftTabsForScrollbarOnlyOnHover_label": { "message": "Tabs nur verschieben, wenn der Mauszeiger in der Nähe der Scrollbar ist" },
-  "config_suppressGapFromShownOrHiddenToolbar_caption": { "message": "Den Abstand zwischen Seitenleisteninhalten in Fällen reduzieren, die durch vorübergehend angezeigte Toolbars entstehen" },
-  "config_suppressGapFromShownOrHiddenToolbarOnFullScreen_label": { "message": "Vollbildfenster" },
-  "config_suppressGapFromShownOrHiddenToolbarOnNewTab_label": { "message": "Neuer leerer Tab unter Firefox 85 und später" },
-  "config_suppressGapFromShownOrHiddenToolbarOnlyOnMouseOperation_label": { "message": "Nur wenn von einer Mausaktion auf der Seitenleiste ausgelöst" },
-  "config_showDialogInSidebar_label": { "message": "Zeige Dialoge in Seitenleiste falls möglich" },
-
-
-  "config_context_caption": { "message": "Kontexmenü" },
-  "config_emulateDefaultContextMenu_label": { "message": "Tab-Kontextmenü in der Seitenleiste simulieren" },
-  "config_extraItems_tabs_caption": { "message": "Zusätzliche Kontextmenü-Einträge" },
-  "config_extraItems_tabs_topLevel": { "message": "Oberste Ebene" },
-  "config_extraItems_tabs_subMenu": { "message": "Untermenü" },
-  "config_extraItems_tabs_middleClick": { "message": "Aktion bei Mittelklick" },
-  "config_extraItems_bookmarks_caption": { "message": "Zusätzliche Einträge im Lesezeichen-Kontextmenü" },
-  "config_openAllBookmarksWithStructureDiscarded_label": { "message": "Tabs ausstehend lassen bis sie aktiv werden" },
-
-  "config_sendTabsToDevice_caption": { "message": "Tabs über das Kontextmenü via Firefox Sync zu anderen Geräten senden" },
-  "config_syncRequirements_description": { "message": "Diese Funktion hängt ab von Firefox Sync und Tabs können nur an Geräte gesendet werden, auf denen TST installiert ist. Bitte Firefox Sync über die Browsereinstellungen aktivieren und TST auf den anderen Geräten installieren." },
-  "config_syncDeviceInfo_name_label": { "message": "Name und Bild dieses Geräts:" },
-  "config_syncDeviceInfo_name_description_before": { "message": "Aufgrund von Einschränkungen der WebExtensions API kann TST den Namen dieses Geräts nicht automatisch bestimmen. Bitte manuell einen beschreibenden Namen für dieses Gerät eingeben. (Es wird empfohlen, " },
-  "config_syncDeviceInfo_name_description_link": { "message": "den Gerätenamen von Firefox Sync" },
-  "config_syncDeviceInfo_name_description_href": { "message": "https://accounts.firefox.com/settings/clients" },
-  "config_syncDeviceInfo_name_description_after": { "message": " zu verwenden.)" },
-  "config_syncDeviceExpirationDays_label_before": { "message": "Geräte autmatisch ablaufen lassen, wenn sie " },
-  "config_syncDeviceExpirationDays_label_after": { "message": " Tage nicht verwendet wurden (\"0\" bedeutet \"kein Ablaufen\")" },
-  "config_syncUnsendableUrlPattern_label": { "message": "Regel zum Erkennen von Tabs, die nicht gesendet werden sollen (*Dies muss mit der Einstellung \"services.sync.engine.tabs.filteredUrls\" von Firefox synchronisiert sein):" },
-  "config_otherDevices_caption": { "message": "Andere aktive Geräte:" },
-  "config_removeDeviceButton_label": { "message": "Löschen" },
-  "config_removeDeviceButton_tooltip": { "message": "Dieses Gerät von der Liste löschen" },
-
-
-  "config_newTabWithOwner_caption": { "message": "Neue Tabs, die von existierenden Tabs geöffnet wurden" },
-
-  "config_autoAttachOnOpenedWithOwner_before": { "message": "Wenn ein neuer Tab von einem existierenden Tab geöffnet wird, öffne ihn als" },
-  "config_autoAttachOnOpenedWithOwner_noControl": { "message": "(keine Steuerung)" },
-  "config_autoAttachOnOpenedWithOwner_independent": { "message": "eigenständigen Tab" },
-  "config_autoAttachOnOpenedWithOwner_child": { "message": "untergeordneten Tab des übergeordneten Tab" },
-  "config_autoAttachOnOpenedWithOwner_sibling": { "message": "Tab auf der Ebene des übergeordneten Tab" },
-  "config_autoAttachOnOpenedWithOwner_nextSibling": { "message": "direkten Nachbar auf der Ebene des übergeordneten Tab" },
-  "config_autoAttachOnOpenedWithOwner_after": { "message": "\u200b" },
-
-  "config_insertNewTabFromPinnedTabAt_caption": { "message": "Einfügeposition von neuen untergeordneten Tabs (werden als Wurzel-Tab behandelt) für angeheftete Tabs" },
-  "config_insertNewTabFromPinnedTabAt_noControl": { "message": "Keine Steuerung (berücksichtigt die Entscheidung von Firefox oder anderen Erweiterungen)" },
-  "config_insertNewTabFromPinnedTabAt_nextToLastRelatedTab": { "message": "Neben dem zuletzt geöffneten Tab oder in der Nähe des öffnenden Tabs" },
-  "config_insertNewTabFromPinnedTabAt_top": { "message": "Am Anfang des Baums (nahe des öffnenden Tabs)" },
-  "config_insertNewTabFromPinnedTabAt_end": { "message": "Am Ende des Baums" },
-
-  "config_autoGroupNewTabsFromPinned_label": { "message": "Tabs automatisch gruppieren, wenn sie vom gleichen angehefteten Tab geöffnet werden (es wird ein neuer Gruppentab mit einem Titel wie \"Tabs von ...\" geöffnet)" },
-  "config_groupTabTemporaryStateForChildrenOfPinned_label": { "message": "Standardzustand der Gruppentabs, welche für Tabs des gleichen angehefteten Tabs geöffnet wurden:" },
-
-
-  "config_newTab_caption": { "message": "Neue Tabs, die nicht von existierenden Tabs geöffnet wurden" },
-
-  "config_newTabButton_caption": { "message": "Besondere Aktionen für die \"Neuer Tab\" Schaltfläche" },
-  "config_longPressOnNewTabButton_before":               { "message": "Die Schaltfläche \"Neuer Tab\" lang gedrückt halten, um " },
-  "config_longPressOnNewTabButton_newTabAction":         { "message": "auszuwählen, wo der neue Tab geöffnet werden soll" },
-  "config_longPressOnNewTabButton_contextualIdentities": { "message": "eine Tab-Umgebung auszuwählen" },
-  "config_longPressOnNewTabButton_none":                 { "message": "(nichts)" },
-  "config_longPressOnNewTabButton_after":                { "message": "\u200b" },
-  "config_showNewTabActionSelector_label":               { "message": "Auswahl wo der neue Tab geöffnet werden soll, auf der Schaltfläche \"Neuer Tab \" anzeigen, wenn der Cursor auf die Schaltfläche zeigt" },
-  "config_showContextualIdentitiesSelector_label":       { "message": "Auswahl der Tab-Umgebung auf der Schaltfläche \"Neuer Tab\" anzeigen, wenn der Cursor auf die Schaltfläche zeigt" },
-
-  "config_newTabAction_caption": { "message": "Grundsätzliche Steuerung für \"Neuer leerer Tab\"" },
-  "config_autoAttachOnNewTabCommand_before": { "message": "Neuen leeren Tab als " },
-  "config_autoAttachOnNewTabCommand_noControl": { "message": "(keine Steuerung)" },
-  "config_autoAttachOnNewTabCommand_independent": { "message": "eigenständigen Tab" },
-  "config_autoAttachOnNewTabCommand_child": { "message": "untergeordneten Tab des aktiven Tab" },
-  "config_autoAttachOnNewTabCommand_sibling": { "message": "Tab auf der Ebene des aktiven Tab" },
-  "config_autoAttachOnNewTabCommand_nextSibling": { "message": "direkten Nachbar auf der Ebene des aktiven Tab" },
-  "config_autoAttachOnNewTabCommand_after": { "message": "öffnen" },
-  "config_guessNewOrphanTabAsOpenedByNewTabCommandUrl_before": { "message": "Einen neuen Tab behandeln als sei er durch den Befehl \"Neuer leerer Tab\" geöffnet worden, wenn er mit dieser URL geöffnet wird:" },
-  "_config_guessNewOrphanTabAsOpenedByNewTabCommandUrl_after": { "message": "\u200b" },
-
-  "config_autoAttachOnNewTabButtonMiddleClick_before": { "message": "Mit der mittleren Maustaste einen neuen leeren Tab öffnen als" },
-  "config_autoAttachOnNewTabButtonMiddleClick_noControl": { "message": "(keine Steuerung)" },
-  "config_autoAttachOnNewTabButtonMiddleClick_independent": { "message": "eigenständigen Tab" },
-  "config_autoAttachOnNewTabButtonMiddleClick_child": { "message": "untergeordneten Tab des aktiven Tabs" },
-  "config_autoAttachOnNewTabButtonMiddleClick_sibling": { "message": "Tab auf der Ebene des aktiven Tab" },
-  "config_autoAttachOnNewTabButtonMiddleClick_nextSibling": { "message": "direkten Nachbar auf der Ebene des aktiven Tab" },
-  "config_autoAttachOnNewTabButtonMiddleClick_nextSiblingWithInheritedContainer": { "message": "identisch mit Strg-Klick (nächster Nachbar, gleiche Umgebung)" },
-  "config_autoAttachOnNewTabButtonMiddleClick_after": { "message": "\u200b" },
-
-  "config_autoAttachOnNewTabButtonAccelClick_before": { "message": "Für Strg/⌘-Klick, neuen leeren Tab öffnen als" },
-  "config_autoAttachOnNewTabButtonAccelClick_noControl": { "message": "(keine Steuerung)" },
-  "config_autoAttachOnNewTabButtonAccelClick_independent": { "message": "eigenständigen Tab" },
-  "config_autoAttachOnNewTabButtonAccelClick_child": { "message": "untergeordneten Tab des aktiven Tab" },
-  "config_autoAttachOnNewTabButtonAccelClick_sibling": { "message": "Tab auf der Ebene des aktiven Tab" },
-  "config_autoAttachOnNewTabButtonAccelClick_nextSibling": { "message": "direkten Nachbar auf der Ebene des aktiven Tab" },
-  "config_autoAttachOnNewTabButtonAccelClick_nextSiblingWithInheritedContainer": { "message": "direkter Nachbar, gleiche Umgebung" },
-  "config_autoAttachOnNewTabButtonAccelClick_after": { "message": "\u200b" },
-
-  "config_autoAttachWithURL_caption": { "message": "Nicht-leere neue Tabs" },
-
-  "config_duplicateTabAction_caption": { "message": "Tabs duplizieren (Mittelklick auf die \"Neu laden\"-Schaltfläche usw.)" },
-
-  "config_autoAttachOnDuplicated_before": { "message": "Den Tab duplizieren als" },
-  "config_autoAttachOnDuplicated_noControl": { "message": "(keine Steuerung)" },
-  "config_autoAttachOnDuplicated_independent": { "message": "eigenständigen Tab" },
-  "config_autoAttachOnDuplicated_child": { "message": "untergeordneten Tab des aktiven Tabs" },
-  "config_autoAttachOnDuplicated_sibling": { "message": "Tab auf der Ebene des aktiven Tab" },
-  "config_autoAttachOnDuplicated_nextSibling": { "message": "direkten Nachbar auf der Ebene des aktiven Tab" },
-  "config_autoAttachOnDuplicated_after": { "message": "\u200b" },
-
-  "config_fromExternal_caption": { "message": "Neuer Tab außerhalb von Firefox" },
-  "config_autoAttachOnOpenedFromExternal_before": { "message": "Öffnen als" },
-  "config_autoAttachOnOpenedFromExternal_noControl": { "message": "(keine Steuerung)" },
-  "config_autoAttachOnOpenedFromExternal_independent": { "message": "unabhängigen Tab" },
-  "config_autoAttachOnOpenedFromExternal_child": { "message": "untergeordneten Tab des aktuellen Tab" },
-  "config_autoAttachOnOpenedFromExternal_sibling": { "message": "Tab auf der Ebene des aktiven Tab" },
-  "config_autoAttachOnOpenedFromExternal_nextSibling": { "message": "direkten Nachbar auf der Ebene des aktiven Tab" },
-  "config_autoAttachOnOpenedFromExternal_after": { "message": "\u200b" },
-  "config_inheritContextualIdentityToTabsFromExternalMode_label": { "message": "Tab-Umgebung:" },
-  "config_inheritContextualIdentityToTabsFromExternalMode_default": { "message": "(keine Steuerung)" },
-  "config_inheritContextualIdentityToTabsFromExternalMode_parent": { "message": "Vom übergeordneten Tab im Zweig erben" },
-  "config_inheritContextualIdentityToTabsFromExternalMode_lastActive": { "message": "Vom aktuellen Tab erben" },
-
-  "config_sameSiteOrphan_caption": { "message": "Neuer Tab mit der gleichen Webseite wie der aktuelle Tab über die Adressleiste, Lesezeichen, Verlauf oder anderes" },
-  "config_autoAttachSameSiteOrphan_before": { "message": "Öffnen als" },
-  "config_autoAttachSameSiteOrphan_noControl": { "message": "(keine Steuerung)" },
-  "config_autoAttachSameSiteOrphan_independent": { "message": "unabhängigen Tab" },
-  "config_autoAttachSameSiteOrphan_child": { "message": "untergeordneten Tab des aktuellen Tab" },
-  "config_autoAttachSameSiteOrphan_sibling": { "message": "Tab auf der Ebene des aktiven Tab" },
-  "config_autoAttachSameSiteOrphan_nextSibling": { "message": "direkten Nachbar auf der Ebene des aktiven Tab" },
-  "config_autoAttachSameSiteOrphan_after": { "message": "\u200b" },
-  "config_inheritContextualIdentityToSameSiteOrphanMode_label": { "message": "Tab-Umgebung:" },
-  "config_inheritContextualIdentityToSameSiteOrphanMode_default": { "message": "(keine Steuerung)" },
-  "config_inheritContextualIdentityToSameSiteOrphanMode_parent": { "message": "Vom übergeordneten Tab im Zweig erben" },
-  "config_inheritContextualIdentityToSameSiteOrphanMode_lastActive": { "message": "Vom aktuellen Tab erben" },
-
-  "config_anyOtherTrigger_caption": { "message": "Tabs aus einem anderen Grund" },
-  "config_autoAttachOnAnyOtherTrigger_before": { "message": "Öffnen als" },
-  "config_autoAttachOnAnyOtherTrigger_noControl": { "message": "(keine Steuerung)" },
-  "config_autoAttachOnAnyOtherTrigger_independent": { "message": "unabhängigen Tab" },
-  "config_autoAttachOnAnyOtherTrigger_child": { "message": "untergeordneten Tab des aktuellen Tab" },
-  "config_autoAttachOnAnyOtherTrigger_sibling": { "message": "Tab auf der Ebene des aktiven Tab" },
-  "config_autoAttachOnAnyOtherTrigger_nextSibling": { "message": "direkten Nachbar auf der Ebene des aktiven Tab" },
-  "config_autoAttachOnAnyOtherTrigger_after": { "message": "\u200b" },
-  "config_autoAttachOnAnyOtherTrigger_caution": { "message": "*ACHTUNG: Diese Option birgt die Gefahr, andere Erweiterungen zu behindern." },
-  "config_inheritContextualIdentityToTabsFromAnyOtherTriggerMode_label": { "message": "Tab-Umgebung:" },
-  "config_inheritContextualIdentityToTabsFromAnyOtherTriggerMode_default": { "message": "(keine Steuerung)" },
-  "config_inheritContextualIdentityToTabsFromAnyOtherTriggerMode_parent": { "message": "Vom übergeordneten Tab im Zweig erben" },
-  "config_inheritContextualIdentityToTabsFromAnyOtherTriggerMode_lastActive": { "message": "Vom aktuellen Tab erben" },
-
-  "config_groupTab_caption": { "message": "Automatische Gruppierung der Tabs" },
-
-  "config_tabBunchesDetectionTimeout_before": { "message": "Tabs automatisch gruppieren, die innerhalb von" },
-  "config_tabBunchesDetectionTimeout_after": { "message": "Millisekunden aus einem Lesezeichen-Ordner geöffnet wurden" },
-  "config_requireBookmarksPermission_tooltiptext": { "message": "Diese Funktion benötigt Zugriff auf die Lesezeichen. Hier klicken um die zusätzliche Berechtigung zu gewähren." },
-  "config_requestPermissions_bookmarks_autoGroupNewTabs_before": { "message": "(" },
-  "config_requestPermissions_bookmarks_autoGroupNewTabs_after": { "message": "Erkennen von zu Tabs gehörenden Lesezeichen erlauben)" },
-  "config_tabsFromSameFolderMinThresholdPercentage_before": { "message": "Alle neuen Tabs als aus einem Lesezeichen-Ordner stammend betrachten, falls mehr als " },
-  "config_tabsFromSameFolderMinThresholdPercentage_after": { "message":  "% Tabs ein entsprechendes Lesezeichen in einem Lesezeichen-Ordner haben" },
-  "config_autoGroupNewTabsFromOthers_label": { "message": "Zeitgleich geöffnete Tabs gruppieren, auch wenn sie nicht aus den Lesezeichen stammen" },
-  "config_tabBunchesDetectionDelayOnNewWindow_before": { "message": "Aber neue Tabs nicht gruppieren, die innerhalb von" },
-  "config_tabBunchesDetectionDelayOnNewWindow_after": { "message": "Millisekunden geöffnet werden, wenn ein neues Fenster geöffnet wird, als Teil von Tabs, die als \"Startseite\" geöffnet werden." },
-  "config_warnOnAutoGroupNewTabs_label": { "message": "Bestätige Gruppierung von Tabs" },
-  "config_warnOnAutoGroupNewTabsWithListing_label": { "message": "Tabs, die gruppiert werden sollen, im Bestätigungsdialog auflisten" },
-
-  "config_renderTreeInGroupTabs_label": { "message": "Zeige Baum in Gruppen-Tab" },
-
-  "config_groupTabTemporaryState_caption": { "message": "Standardzustand von Gruppen-Tabs für jede Situation" },
-  "config_groupTabTemporaryState_option_default": { "message": "Keine Option auswählen" },
-  "config_groupTabTemporaryState_option_checked_before": { "message": "Option \"" },
-  "config_groupTabTemporaryState_option_checked_after": { "message": "\" auswählen" },
-  "config_groupTabTemporaryStateForNewTabsFromBookmarks_label": { "message": "Für Tabs, die aus Lesezeichen geöffnet wurden:" },
-  "config_groupTabTemporaryStateForNewTabsFromOthers_label": { "message": "Für zeitgleich geöffnete Tabs, die nicht aus Lesezeichen geöffnet wurden:" },
-  "config_groupTabTemporaryStateForOrphanedTabs_label": { "message": "Geöffnet, um einen geschlossenen übergeordneten Tab zu ersetzen:" },
-
-  "config_inheritContextualIdentityToChildTabMode_label": { "message": "Tab-Umgebung:" },
-  "config_inheritContextualIdentityToChildTabMode_default": { "message": "(keine Steuerung)" },
-  "config_inheritContextualIdentityToChildTabMode_parent": { "message": "Vom übergeordneten Tab im Zweig erben" },
-  "config_inheritContextualIdentityToChildTabMode_lastActive": { "message": "Vom aktuellen Tab erben" },
-
-
-  "config_treeBehavior_caption": { "message": "Verhalten der Zweige" },
-
-  "config_successorTabControlLevel_caption": { "message": "Wenn der aktive Tab als letzter verbleibender untergeordneter Tab geschlossen wird" },
-  "config_successorTabControlLevel_inTree": { "message": "Zum vorherigen Tab im Zweig wechseln" },
-  "config_successorTabControlLevel_simulateDefault": { "message": "Immer zum nächsten Tab wechseln (Firefox Standardverhalten)" },
-  "config_successorTabControlLevel_never": { "message": "Den Fokus niemals steuern (Steuerung von Firefox oder anderer Erweiterungen respektieren)" },
-  "config_successorTabControlLevel_legacyDescription": { "message": "*Firefox eingebautes Verhalten für \"browser.tabs.selectOwnerOnClose\"=\"true\" hat Priorität vor dieser Einstellung." },
-  "config_simulateSelectOwnerOnClose_label": { "message": "Wenn möglich, setze den Fokus auf den öffnenden Tab, wenn der aktuelle Tab geschlossen wird (*Simulation von Firefox eingebautem Verhalten für \"browser.tabs.selectOwnerOnClose\"=\"true\", vor der obigen Einstellung)" },
-
-  "config_fixupTreeOnTabVisibilityChanged_caption": { "message": "Wenn die Sichtbarkeit von Tabs von anderen Erweiterungen geändert wird" },
-  "config_fixupTreeOnTabVisibilityChanged_fix":     { "message": "Automatisch die Baumstruktur mit den sichtbaren Tabs aktualisieren (*Empfohlen bei der Verwendung von anderen Erweiterungen um Tab-Gruppen zu wechseln)" },
-  "config_fixupTreeOnTabVisibilityChanged_keep":    { "message": "Baumstruktur inklusive versteckten Tabs beibehalten (*Empfohlen bei der Verwendung von anderen Erweiterungen, welche vorübergehend die Sichtbarkeit von Tabs ändern)" },
-
-  "config_autoCollapseExpandSubtreeOnAttach_label": { "message": "Wenn ein neuer Zweig erscheint, alle anderen automatisch einklappen" },
-  "config_autoCollapseExpandSubtreeOnSelect_label": { "message": "Wenn ein Tab ausgewählt wird, automatisch seinen Zweig ausklappen und alle anderen einklappen" },
-  "config_autoCollapseExpandSubtreeOnSelectExceptActiveTabRemove_label": { "message": "Es sei denn, dass das Auswählen des Tabs durch das Schließen des aktiven Tabs verursacht wird" },
-  "config_unfocusableCollapsedTab_label": { "message": "Wenn ein Tab unter einem eingeklappten Zweig fokussiert wird, den Zweig automatisch ausklappen" },
-  "config_autoDiscardTabForUnexpectedFocus_label": { "message": "Tabs ausstehend lassen, wenn Tabs versehentlich fokussiert werden und der Fokus sofort umgeleitet wird" },
-  "config_avoidDiscardedTabToBeActivatedIfPossible_label": { "message": "Vermeiden, dass ausstehende Tabs versehentlich aktiviert werden, wenn der aktuelle Tab geschlossen oder ein Zweig eingeklappt wird" },
-
-  "config_treeDoubleClickBehavior_caption":             { "message": "Doppelklick auf einen Tab" },
-  "config_treeDoubleClickBehavior_toggleCollapsed":     { "message": "Aus-/einklappen eines Zweigs" },
-  "config_treeDoubleClickBehavior_close":               { "message": "Tab schließen (*Simuliert Firefox eingebautes Verhalten für \"browser.tabs.closeTabByDblclick\"=\"true\")" },
-  "config_treeDoubleClickBehavior_none":                { "message": "Nichts machen" },
-
-  "config_parentTabOperationBehaviorMode_caption":           { "message": "Wenn ein übergeordneter Tab geschlossen oder verschoben wird" },
-  "config_parentTabOperationBehaviorMode_noteForPermanentlyConsistentBehaviors": { "message": "Unabhängig von diesen Einstellungen gibt es einige festgelegte Verhaltensweisen in der Seitenleiste;\n･ Schließen eines eingeklappten, übergeordneten Tabs: den gesamten Zweig schließen\n･ Verschieben eines eingeklappten, übergeordneten Tabs: den gesamten Zweig verschieben\n･ Verschieben eines ausgeklappten, übergeordneten Tabs: Verhalten wie im Bereich \"Ziehen und Ablegen\" eingestellt" },
-
-  "config_parentTabOperationBehaviorMode_parallel": { "message": "Empfohlenes Verhalten für Nutzer, welche auch die eingebaute Tableiste von Firefox verwenden" },
-  "config_closeParentBehavior_insideSidebar":       { "message": "Wenn ein übergeordneter Tab mit ausgeklapptem Zweig über die Seitenleiste geschlossen wird," },
-  "config_closeParentBehavior_outsideSidebar":      { "message": "Wenn ein übergeordneter Tab (unabhängig ob der Zweig auf- oder zugeklappt ist) über die eingebaute Tableiste, Tastenkombinationen oder andere Erweiterungen geschlossen wird," },
-  "config_moveParentBehavior_outsideSidebar":       { "message": "Wenn ein übergeordneter Tab (unabhängig ob der Zweig auf- oder zugeklappt ist) über die eingebaute Tableiste, Tastenkombinationen oder andere Erweiterungen verschoben wird," },
-
-  "config_parentTabOperationBehaviorMode_consistent":         { "message": "Empfohlenes Verhalten für Nutzer, welche die eingebaute Tableiste von Firefox nicht verwenden" },
-  "config_parentTabOperationBehaviorMode_consistent_caption": { "message": "Wenn ein übergeordneter Tab mit ausgeklapptem Zweig geschlossen/verschoben wird," },
-  "config_parentTabOperationBehaviorMode_consistent_notes":   { "message": "Tabs verhalten sich konsistent wie oben festgelegt, auch bei der eingebauten Tableiste, Tastenkombinationen oder andere Erweiterungen." },
-
-  "config_parentTabOperationBehaviorMode_custom":                { "message": "Benutzerdefiniert" },
-  "config_closeParentBehavior_insideSidebar_expanded_caption":   { "message": "Schließen: Wenn ein übergeordneter Tab mit ausgeklapptem Zweig über die Seitenleiste geschlossen wird," },
-  "config_closeParentBehavior_outsideSidebar_collapsed_caption": { "message": "Schließen: Wenn ein übergeordneter Tab mit eingeklapptem Zweig über die eingebaute Tableiste, Tastenkombinationen oder andere Erweiterungen geschlossen wird," },
-  "config_closeParentBehavior_outsideSidebar_expanded_caption":  { "message": "Schließen: Wenn ein übergeordneter Tab mit ausgeklapptem Zweig über die eingebaute Tableiste, Tastenkombinationen oder andere Erweiterungen geschlossen wird," },
-  "config_closeParentBehavior_noSidebar_collapsed_caption":      { "message": "wenn die Seitenleiste geschlossen ist," },
-  "config_closeParentBehavior_noSidebar_expanded_caption":       { "message": "wenn die Seitenleiste geschlossen ist," },
-  "config_moveParentBehavior_outsideSidebar_collapsed_caption":  { "message": "Verschieben: Wenn ein übergeordneter Tab mit eingeklapptem Zweig über die eingebaute Tableiste, Tastenkombinationen oder andere Erweiterungen verschoben wird," },
-  "config_moveParentBehavior_outsideSidebar_expanded_caption":   { "message": "Verschieben: Wenn ein übergeordneter Tab mit ausgeklapptem Zweig über die eingebaute Tableiste, Tastenkombinationen oder andere Erweiterungen verschoben wird," },
-  "config_moveParentBehavior_noSidebar_collapsed_caption":       { "message": "wenn die Seitenleiste geschlossen ist," },
-  "config_moveParentBehavior_noSidebar_expanded_caption":        { "message": "wenn die Seitenleiste geschlossen ist," },
-
-  "config_parentTabOperationBehavior_entireTree":           { "message": "Untergeordnete Tabs ebenfalls schließen" },
-  "config_closeParentBehavior_entireTree":                  { "message": "Gesamten Zweig schließen" },
-  "config_moveParentBehavior_entireTree":                   { "message": "Gesamten Zweig verschieben" },
-  "config_parentTabOperationBehavior_replaceWithGroupTab":  { "message": "Den geschlossenen/verschobenen übergeordneten Tab durch einen Platzhalter ersetzen" },
-  "config_closeParentBehavior_replaceWithGroupTab":         { "message": "Den geschlossenen übergeordneten Tab durch einen Platzhalter ersetzen" },
-  "config_moveParentBehavior_replaceWithGroupTab":          { "message": "Den verschobenen übergeordneten Tab durch einen Platzhalter ersetzen" },
-  "config_parentTabOperationBehavior_promoteFirst":         { "message": "Den geschlossenen übergeordneten Tab durch den ersten untergeordneten Tab ersetzen" },
-  "config_closeParentBehavior_promoteFirst":                { "message": "Den geschlossenen übergeordneten Tab durch den ersten untergeordneten Tab ersetzen" },
-  "config_moveParentBehavior_promoteFirst":                 { "message": "Den geschlossenen übergeordneten Tab durch den ersten untergeordneten Tab ersetzen" },
-  "config_parentTabOperationBehavior_promoteAll":           { "message": "Alle untergeordneten Tabs auf die Ebene des geschlossenen übergeordneten Tabs bringen" },
-  "config_closeParentBehavior_promoteAll":                  { "message": "Alle untergeordneten Tabs auf die Ebene des geschlossenen übergeordneten Tabs bringen" },
-  "config_moveParentBehavior_promoteAll":                   { "message": "Alle untergeordneten Tabs auf die Ebene des geschlossenen übergeordneten Tabs bringen" },
-  "config_parentTabOperationBehavior_promoteIntelligently": { "message": "Den geschlossenen Tab durch den ersten untergeordneten Tab ersetzen, wenn er sich auf der obersten Ebene befand, andernfalls alle untergeordneten Tabs auf die Ebene des geschlossenen Tabs bringen" },
-  "config_closeParentBehavior_promoteIntelligently":        { "message": "Den geschlossenen Tab durch den ersten untergeordneten Tab ersetzen, wenn er sich auf der obersten Ebene befand, andernfalls alle untergeordneten Tabs auf die Ebene des geschlossenen Tabs bringen" },
-  "config_moveParentBehavior_promoteIntelligently":         { "message": "Den geschlossenen Tab durch den ersten untergeordneten Tab ersetzen, wenn er sich auf der obersten Ebene befand, andernfalls alle untergeordneten Tabs auf die Ebene des geschlossenen Tabs bringen" },
-  "config_parentTabOperationBehavior_detach":               { "message": "Untergeordnete Tabs vom Zweig lösen" },
-  "config_closeParentBehavior_detach":                      { "message": "Untergeordnete Tabs vom Zweig lösen" },
-  "config_moveParentBehavior_detach":                       { "message": "Untergeordnete Tabs vom Zweig lösen" },
-
-  "config_warnOnCloseTabs_label": { "message": "Warnen, wenn mehrere Tabs geschlossen werden sollen" },
-  "config_warnOnCloseTabsByClosebox_label": { "message": "Warnen, wenn mehrere Tabs durch einen Klick auf eine Schließen-Schaltfläche geschlossen werden sollen" },
-  "config_warnOnCloseTabsWithListing_label": { "message": "Tabs, die geschlossen werden sollen, im Bestätigungsdialog auflisten" },
-
-  "config_insertNewChildAt_caption": { "message": "Einfügeposition neuer untergeordneter Tabs" },
-  "config_insertNewChildAt_noControl": { "message": "Keine Steuerung (das Verhalten von Firefox oder anderer Tab-Add-Ons beibehalten)" },
-  "config_insertNewChildAt_nextToLastRelatedTab": { "message": "Neben dem zuletzt untergeordneten Tab oder neben dem übergeordneten Tab" },
-  "config_insertNewChildAt_top": { "message": "Am Anfang des Zweigs, als erster untergeordneter Tab" },
-  "config_insertNewChildAt_end": { "message": "Am Ende des Zweigs" },
-
-
-  "config_drag_caption": { "message": "Ziehen und Ablegen" },
-
-  "config_tabDragBehavior_caption":       { "message": "Wenn ein übergeordneter Zweig gezogen und abgelegt wird" },
-  "config_tabDragBehavior_description":   { "message": "Aufgrund von Firefox Einschränkungen muss beim Beginn des Ziehens bekannt sein, wie Tabs beim Ablegen außerhalb der Seitenleiste von TST behandelt werden sollen." },
-  "config_tabDragBehavior_label":         { "message": "Ziehen" },
-  "config_tabDragBehaviorShift_label":    { "message": "Shift-Ziehen" },
-  "config_tabDragBehavior_label_behaviorInsideSidebar": { "message": "Verhalten innerhalb" },
-  "config_tabDragBehavior_label_behaviorOutsideSidebar": { "message": "außerhalb der Seitenleiste" },
-  "config_tabDragBehavior_moveEntireTreeAlways":         { "message": "Gesamten Zweig verschieben" },
-  "config_tabDragBehavior_detachEntireTreeAlways":       { "message": "Gesamten Zweig vom Fenster ablösen (aber unmöglich, Lesezeichen anzulegen)" },
-  "config_tabDragBehavior_bookmarkEntireTreeAlways":     { "message": "Verweise oder Lesezeichen vom gesamten Zweig erstellen (aber unmöglich, vom Fenster abzulösen)" },
-  "config_tabDragBehavior_moveSoloTabIfExpanded":        { "message": "Einzelnen Tab verschieben" },
-  "config_tabDragBehavior_detachSoloTabIfExpanded":      { "message": "Einzelnen Tab vom Fenster ablösen (aber unmöglich, Lesezeichen anzulegen)" },
-  "config_tabDragBehavior_bookmarkSoloTabIfExpanded":    { "message": "Verweis oder Lesezeichen vom einzelnen Tab erstellen (aber unmöglich, vom Fenster abzulösen)" },
-  "config_tabDragBehavior_doNothing":                    { "message": "Nichts machen" },
-  "config_tabDragBehavior_noteForDragstartOutsideSidebar": { "message": "Wenn ein übergeordneter Tab aus der eingebaute Tableiste von Firefox verschoben wird, wie im Abschnitt \"Verhalten der Zweige\" => \"Wenn ein übergeordneter Tab geschlossen oder verschoben wird\" verhalten." },
-  "config_showTabDragBehaviorNotification_label": { "message": "Zeige Benachrichtigung was geschehen wird, wenn Tabs außerhalb der Seitenleiste abgelegt werden, während ein Tab gezogen wird." },
-
-  "config_dropLinksOnTabBehavior_caption": { "message": "Wenn ein Link oder eine URL-Zeichenkette per Ziehen und Ablegen auf einen Tab abgelegt wird" },
-  "config_dropLinksOnTabBehavior_ask":     { "message": "Immer nachfragen" },
-  "config_dropLinksOnTabBehavior_load":    { "message": "In diesem Tab öffnen" },
-  "config_dropLinksOnTabBehavior_newtab":  { "message": "In einem neuen untergeordneten Tab öffnen" },
-
-  "config_insertDroppedTabsAt_caption": { "message": "Einfügeposition von Tabs, die auf übergeordnete Tabs abgelegt werden" },
-  "config_insertDroppedTabsAt_inherit": { "message": "Wie neue untergeordnete Tab behandeln" },
-  "config_insertDroppedTabsAt_first": { "message": "Am Anfang des Zweigs (neben dem übergeordneten Tab)" },
-  "config_insertDroppedTabsAt_end": { "message": "Am Ende des Zweigs" },
-
-  "config_autoExpandOnLongHoverDelay_before":  { "message": "Eingeklappten Zweig ausklappen, wenn er beim Ziehen über " },
-  "config_autoExpandOnLongHoverDelay_after":  { "message": " ms schwebt" },
-  "config_autoExpandOnLongHoverRestoreIniitalState_label":  { "message": "Solche Zweige nach dem Ziehen automatisch einklappen" },
-  "config_autoExpandIntelligently_label":  { "message": "Andere Zweige einklappen, wenn ein eingeklappter Zweig automatisch ausgeklappt wird" },
-  "config_ignoreTabDropNearSidebarArea_label":  { "message": "Tab nicht vom Fenster trennen, wenn er in der Nähe der Seitenleiste abgelegt wird (es wird empfohlen, dies zu deaktivieren, falls \"privacy.resistFingerprinting\"=\"true\" ist)" },
-
-
-  "config_more_caption": { "message": "Mehr…" },
-
-  "config_shortcuts_caption": { "message": "Tastenkombinationen" },
-
-  "config_requestPermissions_allUrls_ctrlTabTracking":   { "message": "Beim Umschalten zwischen Tabs mit der Tastatur eingeklappte Zweige nicht ausklappen und eingeklappte untergeordnete Tabs überspringen. (*Das Ausführen von Scripts auf den Webseiten muss erlaubt sein.)" },
-  "config_autoExpandOnTabSwitchingShortcutsDelay_before": { "message": "Aktiven eingeklappten Zweig ausklappen, wenn die Tab-Taste für mehr als " },
-  "config_autoExpandOnTabSwitchingShortcutsDelay_after": { "message": " ms gedrückt ist" },
-  "config_accelKey_label":   { "message": "Taste für Tastenkürzel (*Muss mit der Konfiguration von \"ui.key.accelKey\" übereinstimmen):" },
-  "config_accelKey_auto":    { "message": "Standard (macOS=⌘, andere=Strg)" },
-  "config_accelKey_alt":     { "message": "Alt" },
-  "config_accelKey_control": { "message": "Strg/Control" },
-  "config_accelKey_meta":    { "message": "Meta/⌘" },
-
-  "config_shortcuts_resetAll": { "message": "Alle Tastenkombinationen zurücksetzen" },
-
-
-  "config_advanced_caption": { "message": "Erweitert" },
-
-  "config_bookmarkTreeFolderName_before": { "message": "Ordnernamen für \"Lesezeichen für diesen Zweig erstellen\":" },
-  "config_bookmarkTreeFolderName_after": { "message": "\u200b" },
-  "config_bookmarkTreeFolderName_description": { "message": "Verfügbare Platzhalter: %TITLE% (Titel des ersten Tabs), %URL% (URL des ersten Tabs), %YEAR% (Jahr, vierstellig), %MONTH% (Monat, zweistellig), %DATE% (Tag, zweistellig)" },
-
-  "config_defaultBookmarkParentId_label_before":  { "message": "Neue Lesezeichen erstellen unter" },
-  "config_defaultBookmarkParentId_label_after":   { "message": "\u200b" },
-
-  "config_supportTabsMultiselect_label": { "message": "Verwende Schnittstelle zur Mehrfachauswahl von Tabs um den Tab-Fokus zu steuern (*hängt von der eingebauten Einstellung von Firefox \"browser.tabs.multiselect\"=\"true\" ab)" },
-
-  "config_undoMultipleTabsClose_label": { "message": "Zuletzt geschlossene Tabs wiederherstellen, wenn einer der Tabs über den \"Geschlossener Tab wiederherstellen\" Befehl wiederhergestellt wird" },
-
-  "config_scrollLines_label_before": { "message": "Bewege " },
-  "config_scrollLines_label_after":  { "message": "Zeilen auf oder ab beim \"Zeilenweise hoch oder runter scrollen\" Befehl" },
-
-  "config_userStyleRules_label": { "message": "User Style Sheet (Zusätzliche Style-Regeln für Seitenleisten-Inhalte)" },
-  "config_userStyleRules_description_before": { "message": "Für weitere Optionen siehe " },
-  "config_userStyleRules_description_link_label": { "message": "Codebeispiele im TST Wiki" },
-  "config_userStyleRules_description_after": { "message": "." },
-  "config_userStyleRules_description_link_uri": { "message": "https://github.com/piroor/treestyletab/wiki/Code-snippets-for-custom-style-rules#for-version-2x" },
-  "config_userStyleRules_themeRules_description": { "message": "Folgende Eigenschaften sind per \"var()\" basierend auf dem aktuellen Browser-Design verfügbar:" },
-  "config_userStyleRules_themeRules_description_alphaVariations": { "message": "Die Transparenz einer Farbe kann mit einem Suffix wie \"--theme-colors-tab_background_text-30\" in 10%-Schritten geändert werden (in diesem Fall 30%)" },
-  "config_userStyleRules_import": { "message": "Aus Datei laden" },
-  "config_userStyleRules_export": { "message": "Als Datei speichern" },
-  "config_userStyleRules_overwrite_title":     { "message": "Aktuelle Style-Regeln ersetzen?" },
-  "config_userStyleRules_overwrite_message":   { "message": "Sollen die aktuellen Style-Regeln durch die geladene Datei komplett ersetzt werden?" },
-  "config_userStyleRules_overwrite_overwrite": { "message": "Alles ersetzen" },
-  "config_userStyleRules_overwrite_append":    { "message": "Am Ende anfügen" },
-  "config_tooLargeUserStyleRulesCaution": { "message": "Die Style-Regeln sind zu lang! Bitte kürzen." },
-  "config_userStyleRulesTheme_label":     { "message": "Design:" },
-  "config_userStyleRulesTheme_auto":      { "message": "Auto" },
-  "config_userStyleRulesTheme_separator": { "message": "-----------------" },
-  "config_userStyleRulesTheme_default":   { "message": "Standard" },
-
-
-  "config_addons_caption": { "message": "Zusätzliche Funktionen über andere Erweiterungen" },
-
-  "config_addons_description_before": { "message": "Es existieren " },
-  "config_addons_description_link_label": { "message": "Erweiterungen, welche TST erweitern" },
-  "config_addons_description_after": { "message": ". Probiere sie aus, wenn Du mehr Funktionen in der Seitenleiste von TST haben möchtest." },
-  "helper_addons_list_link_uri": { "message": "https://github.com/piroor/treestyletab/wiki/Helper-addons-extending-functionality-of-TST" },
-
-  "config_theme_description_before": { "message": "Aktuell gibt es nur die eingebauten Designs \"Pur\", \"Seitenleiste\" und \"Hoher Kontrast\". Für weitere Designs siehe " },
-  "config_theme_description_link_label": { "message": "die Code-Beispiele im Wiki" },
-  "config_theme_description_after": { "message": " für Beispiele." },
-  "helper_theme_list_link_uri": { "message": "https://github.com/piroor/treestyletab/wiki/Code-snippets-for-custom-style-rules#restore-old-built-in-themes" },
-
-  "config_externaladdonpermissions_label": { "message": "Berechtigungen für API-Zugriffe von anderen Erweiterungen" },
-  "config_externaladdonpermissions_description": { "message": "Hier zugelassene Erweiterungen erhalten Zugriff auf detaillierte Tab-Informationen und Tabs in privaten Fenstern, <em>durch die Berechtigungen von Tree Style Tab</em>, auch wenn die Berechtigungen der Erweiterung selbst durch Firefox nicht erteilt wurden. <em>Berechtigungen nicht erteilen, wenn der Erweiterung nicht vertraut wird.</em>" },
-  "config_externalAddonPermissions_header_name": { "message": "Name der Erweiterung" },
-  "config_externalAddonPermissions_header_permissions": { "message": "Zugelassene spezielle Operationen" },
-  "config_externalAddonPermissions_header_incognito": { "message": "Benachrichtigungen von privaten Fenstern" },
-
-  "addon_containerBookmarks_label": { "message": "Container Bookmarks" },
-  "addon_containerBookmarks_uri": { "message": "https://addons.mozilla.org/firefox/addon/container-bookmarks/" },
-  "config_containerRedirectKey_label": { "message": "Redirect Key (*Bitte den gleichen Wert setzen wie in den Einstellungen der Erweiterung):" },
-
-
-  "config_debug_caption": { "message": "Entwicklung" },
-
-  "config_link_startupPage_label": { "message": "Seite für ersten Start" },
-  "config_link_groupPage_label":   { "message": "Seite für Gruppen-Tab" },
-  "config_link_tabbarPage_label":   { "message": "Seite für Tab-Leiste" },
-
-  "config_runTests_label": { "message": "Automatischen Test starten" },
-  "config_runBenchmark_label": { "message": "Benchmark starten" },
-  "config_enableLinuxBehaviors_label": { "message": "Linux-spezifisches Verhalten aktivieren" },
-  "config_enableMacOSBehaviors_label": { "message": "macOS-spezifisches Verhalten aktivieren" },
-  "config_enableWindowsBehaviors_label": { "message": "Windows-spezifisches Verhalten aktivieren" },
-  "config_debug_label": { "message": "Testmodus" },
-  "config_log_caption":               { "message": "Detaillierte Logs" },
-  "config_logTimestamp_label": { "message": "Mit Zeitstempel loggen" },
-  "config_logFor_common":     { "message": "Logs von gemeinesamen Modulen" },
-  "config_logFor_background": { "message": "Logs von Hintergrundmodulen" },
-  "config_logFor_sidebar":    { "message": "Logs von Seitenleisten-Modulen" },
-  "config_loggingQueries_label": { "message": "Abfrage von Tabs loggen" },
-  "config_loggingConnectionMessages_label": { "message": "Interne Nachrichten loggen" },
-  "config_showLogsButton_label": { "message": "Zeige Logs" },
-  "config_simulateSVGContextFill_label": { "message": "Workaround für Bug 1388193 und Bug 1421329 aktivieren um SVG-Icons zu simulieren (*Kann die CPU-Last erhöhen. Um diese Option zu deaktivieren, aktiviere \"svg.context-properties.content.enabled\" via \"about:config\", bis diese Bugs behoben sind.)" },
-  "config_staticARIALabel_label": { "message": "Festes ARIA Label für Tab-Elemente verwenden" },
-  "config_staticARIALabel_description": { "message": "*Diese Option könnte helfen, falls Tab-Elemente nach manchen Operationen von der Sprachausgabe nicht erkannt werden." },
-  "config_useCachedTree_label": { "message": "Zweig-Wiederherstellung mit Cache optimieren" },
-  "config_useCachedTree_description": { "message": "*Sollte es zu instabilem Verhalten der Baumstruktur kommen, kann es helfen, diese Einstellung zu deaktivieren und wieder zu aktivieren, um den Cache zu erneuern." },
-  "config_acceleratedTabCreation_label": { "message": "Operationen zu neu geöffneten Tabs beschleunigen (*HINWEIS: Du wirst unstabilies Verhalten rund um Tabs feststellen.)" },
-  "config_maximumAcceptableDelayForTabDuplication_before": { "message": "Das Duplizieren von Tabs abbrechen, wenn es länger als" },
-  "config_maximumAcceptableDelayForTabDuplication_after": { "message": "Millisekunden dauert." },
-  "config_delayForDuplicatedTabDetection_label_before": { "message": "Verzögerung um duplizierte Tabs zu erkennen:" },
-  "config_delayForDuplicatedTabDetection_label_after": { "message": "ms (erhöhen, wenn duplizierte Tabs nicht korrekt erkannt werden)" },
-  "config_delayForDuplicatedTabDetection_autoDetect": { "message": "Automatisch erkennen" },
-  "config_delayForDuplicatedTabDetection_test": { "message": "Testerkennung" },
-  "config_delayForDuplicatedTabDetection_test_resultMessage": { "message": "$PERCENTAGE$% erfolgreich erkannt.",
+      "NAME": {
+        "content": "$1",
+        "example": "foobar"
+      },
+      "PERMISSIONS": {
+        "content": "$2",
+        "example": "tabs"
+      }
+    }
+  },
+  "api_requestedPermissions_message_linux": {
+    "message": "⚠Die Erweiterung \"$NAME$\" bittet um zusätzliche Berechtigungen über Tree Style Tab:\n\n$PERMISSIONS$\n\nAuf die Schaltfläche klicken um die Berechtigungen zu erteilen.",
     "placeholders": {
-      "percentage": { "content": "$1", "example": "50" }
-    }},
-  "config_labelOverflowStyle_caption": { "message": "Zu lange Beschriftung von Tabs:" },
-  "config_labelOverflowStyle_fade":    { "message": "Ausblenden (bessere Sichtbarkeit)" },
-  "config_labelOverflowStyle_crop":    { "message": "Abschneiden mit \"..\" (bessere Leistung)" },
-
-  "config_requestPermissions_bookmarks": { "message": "Lesen und Erstellen von Lesezeichen zulassen" },
-  "config_requestPermissions_bookmarks_context": { "message": "Öffnen des Kontextmenüs für Lesezeichen zulassen" },
-  "config_requestPermissions_tabHide":   { "message": "Erlaube, einzelne Tabs anzuzeigen/auszublenden (*Aus- und wieder einschalten, bevor Tests ausgeführt werden, um sicherzustellen, dass die Berechtigung gewährt wurde.)" },
-
-  "config_requestPermissions_fallbackToToolbarButton_title": { "message": "Klicke auf das \"Tree Style Tab\" Symbol in der Symbolleiste" },
-  "config_requestPermissions_fallbackToToolbarButton_message": { "message": "Wegen eines Bugs in Firefox, kannst du Berechtigungen nicht in diesem Menü erteilen. Bitte klicke auf das \"Tree Style Tab\" Symbol in der Symbolleiste um Berechtigungen zu erteilen." },
-
-  "config_all_caption": { "message": "Alle Einstellungen" },
-
-  "config_terms_delimiter": { "message": " " },
-
-
-  "tabContextMenu_newTab_label":      { "message": "Neuer Ta&b" },
-
-  "tabContextMenu_reload_label":      { "message": "Tab neu la&den" },
-  "tabContextMenu_mute_label":        { "message": "Tab stu&mmschalten" },
-  "tabContextMenu_unmute_label":      { "message": "Stu&mmschaltung aufheben" },
-
-  "tabContextMenu_pin_label":         { "message": "Tab an&heften" },
-  "tabContextMenu_unpin_label":       { "message": "Ta&b ablösen" },
-  "tabContextMenu_duplicate_label":   { "message": "Tab &klonen" },
-  "tabContextMenu_selectAllTabs_label": { "message": "&Alle Tabs auswählen" },
-  "tabContextMenu_bookmark_label":    { "message": "Tab als &Lesezeichen hinzufügen" },
-  "tabContextMenu_reopenInContainer_label":             { "message": "In Tab-&Umgebung öffnen" },
-  "tabContextMenu_reopenInContainer_noContainer_label": { "message": "Keine Tab-&Umgebung" },
-  "tabContextMenu_moveTab_label":     { "message": "Tab &verschieben" },
-  "tabContextMenu_moveTabToStart_label": { "message": "An &Anfang verschieben" },
-  "tabContextMenu_moveTabToEnd_label":   { "message": "An &Ende verschieben" },
-  "tabContextMenu_tearOff_label":     { "message": "In &neues Fenster verschieben" },
-  "tabContextMenu_sendTabsToDevice_label": { "message": "Sen&de Tab an Geräte" },
-  "tabContextMenu_sendTabsToAllDevices_label": { "message": "Sen&de Tab an alle Geräte" },
-  "tabContextMenu_manageSyncDevices_label": { "message": "Geräte verwalten…" },
-  "tabContextMenu_shareTabURL_label":   { "message": "&Teilen" },
-
-
-  "tabContextMenu_closeMultipleTabs_label":  { "message": "&Mehrere Tabs schließen" },
-  "tabContextMenu_closeTabsToTop_label":  { "message": "Tabs nach &oben schließen" },
-  "tabContextMenu_closeTabsToBottom_label":  { "message": "Tabs nach un&ten schließen" },
-  "tabContextMenu_closeOther_label":  { "message": "Andere Tabs &schließen" },
-
-  "tabContextMenu_undoClose_label":   { "message": "&Geschlossenen Tab wiederherstellen" },
-  "tabContextMenu_undoClose_label_multiple": { "message": "&Geschlossene Tabs wiederherstellen" },
-  "tabContextMenu_close_label":       { "message": "Tab s&chließen" },
-
-  "tabContextMenu_reload_label_multiselected":      { "message": "Ausgewählte Tabs neu la&den" },
-  "tabContextMenu_mute_label_multiselected":        { "message": "Tabs st&ummschalten" },
-  "tabContextMenu_unmute_label_multiselected":      { "message": "Stu&mmschaltung aufheben" },
-
-  "tabContextMenu_pin_label_multiselected":         { "message": "Tabs an&heften" },
-  "tabContextMenu_unpin_label_multiselected":       { "message": "Ta&bs ablösen" },
-
-  "tabContextMenu_duplicate_label_multiselected":   { "message": "Tabs &klonen" },
-
-  "tabContextMenu_moveTab_label_multiselected": { "message": "Tabs &verschieben" },
-  "tabContextMenu_sendTabsToDevice_label_multiselected": { "message": "Sen&de %S Tabs an Gerät" },
-
-  "tabContextMenu_bookmark_label_multiselected": { "message": "&Lesezeichen für Tabs hinzufügen…" },
-  "tabContextMenu_bookmarkSelected_label":       { "message": "&Lesezeichen für ausgewählte Tabs hinzufügen…" },
-
-  "tabContextMenu_close_label_multiselected":       { "message": "Ausgewählte Tabs s&chließen" }
+      "NAME": {
+        "content": "$1",
+        "example": "foobar"
+      },
+      "PERMISSIONS": {
+        "content": "$2",
+        "example": "tabs"
+      }
+    }
+  },
+  "api_requestedPermissions_type_activeTab": {
+    "message": "Zugriff auf aktiven Tab"
+  },
+  "api_requestedPermissions_type_tabs": {
+    "message": "Zugriff auf Tabs"
+  },
+  "api_requestedPermissions_type_cookies": {
+    "message": "Erkennung der Tab-Umgebungen"
+  },
+  "guessNewOrphanTabAsOpenedByNewTabCommandTitle": {
+    "message": "Neuer Tab|Neuer privater Tab"
+  },
+  "context_menu_label": {
+    "message": "Baumstruktur"
+  },
+  "context_reloadTree_label": {
+    "message": "Zweig neu la&den"
+  },
+  "context_reloadTree_label_multiselected": {
+    "message": "Ausgewählte Zweige neu la&den"
+  },
+  "context_reloadTree_command": {
+    "message": "Zweig neu laden"
+  },
+  "context_reloadDescendants_label": {
+    "message": "&Untergeordnete Tabs neu laden"
+  },
+  "context_reloadDescendants_label_multiselected": {
+    "message": "&Untergeordnete Tabs der Auswahl neu laden"
+  },
+  "context_reloadDescendants_command": {
+    "message": "Untergeordnete Tabs neu laden"
+  },
+  "context_unblockAutoplayTree_label": {
+    "message": "Diesen Zweig wiede&rgeben"
+  },
+  "context_unblockAutoplayTree_label_multiselected": {
+    "message": "Diese Zweige wiede&rgeben"
+  },
+  "context_unblockAutoplayTree_command": {
+    "message": "Diesen Zweig wiedergeben"
+  },
+  "context_unblockAutoplayDescendants_label": {
+    "message": "Untergeordnete &wiedergeben"
+  },
+  "context_unblockAutoplayDescendants_label_multiselected": {
+    "message": "Untergeordnete von ausgewählten Tabs &wiedergeben"
+  },
+  "context_unblockAutoplayDescendants_command": {
+    "message": "Untergeordnete wiedergeben"
+  },
+  "context_closeTree_label": {
+    "message": "Zweig &schließen"
+  },
+  "context_closeTree_label_multiselected": {
+    "message": "Ausgewählte Zweige &schließen"
+  },
+  "context_closeTree_command": {
+    "message": "Zweig schließen"
+  },
+  "context_closeDescendants_label": {
+    "message": "U&ntergeordnete Tabs schließen"
+  },
+  "context_closeDescendants_label_multiselected": {
+    "message": "U&ntergeordnete Tabs der Auswahl schließen"
+  },
+  "context_closeDescendants_command": {
+    "message": "Untergeordnete Tabs schließen"
+  },
+  "context_closeOthers_label": {
+    "message": "&Alle anderen Tabs außer diesen Zweig schließen"
+  },
+  "context_closeOthers_label_multiselected": {
+    "message": "&Alle anderen Tabs außer ausgewählter Zweige schließen"
+  },
+  "context_closeOthers_command": {
+    "message": "Alle anderen Tabs außer diesen Zweig schließen"
+  },
+  "context_collapseTree_label": {
+    "message": "Di&esen Zweig zuklappen"
+  },
+  "context_collapseTree_label_multiselected": {
+    "message": "Ausgewählte Zw&eige zuklappen"
+  },
+  "context_collapseTree_command": {
+    "message": "Diesen Zweig zuklappen"
+  },
+  "context_collapseTreeRecursively_label": {
+    "message": "Diesen Zweig rekursiv zuklappen"
+  },
+  "context_collapseTreeRecursively_label_multiselected": {
+    "message": "Ausgewählte Zweige rekursiv zuklappen"
+  },
+  "context_collapseTreeRecursively_command": {
+    "message": "Diesen Zwei rekursiv zuklappen"
+  },
+  "context_collapseAll_label": {
+    "message": "Alle &zuklappen"
+  },
+  "context_collapseAll_command": {
+    "message": "Alle zuklappen"
+  },
+  "context_expandTree_label": {
+    "message": "Diesen Zweig auskla&ppen"
+  },
+  "context_expandTree_label_multiselected": {
+    "message": "Ausgewählte Zweige auskla&ppen"
+  },
+  "context_expandTree_command": {
+    "message": "Diesen Zweig ausklappen"
+  },
+  "context_expandTreeRecursively_label": {
+    "message": "Diesen Zweig rekursiv ausklappen"
+  },
+  "context_expandTreeRecursively_label_multiselected": {
+    "message": "Ausgewählte Zweige rekursiv ausklappen"
+  },
+  "context_expandTreeRecursively_command": {
+    "message": "Diesen Zweig rekursiv ausklappen"
+  },
+  "context_expandAll_label": {
+    "message": "Alle au&fklappen"
+  },
+  "context_expandAll_command": {
+    "message": "Alle aufklappen"
+  },
+  "context_bookmarkTree_label": {
+    "message": "&Lesezeichen für diesen Zweig anlegen…"
+  },
+  "context_bookmarkTree_label_multiselected": {
+    "message": "&Lesezeichen für ausgewählte Zweige anlegen…"
+  },
+  "context_bookmarkTree_command": {
+    "message": "Lesezeichen für diesen Zweig anlegen…"
+  },
+  "context_sendTreeToDevice_label": {
+    "message": "Sen&de diesen Zweig an Gerät"
+  },
+  "context_sendTreeToDevice_label_multiselected": {
+    "message": "Sen&de ausgewählte Zweige an Gerät"
+  },
+  "context_sendTreeToDevice_command": {
+    "message": "Sende diesen Zweig an Gerät"
+  },
+  "context_topLevel_prefix": {
+    "message": "Oberstes Objekt: "
+  },
+  "context_collapsed_label": {
+    "message": "Zugeklappt (für Test eines \"checkbox\" Menüs)"
+  },
+  "context_pinnedTab_label": {
+    "message": "Angeheftet (für Test eines \"radio\" Menüs)"
+  },
+  "context_unpinnedTab_label": {
+    "message": "Abgelöst (für Test eines \"radio\" Menüs)"
+  },
+  "context_openAllBookmarksWithStructure_label": {
+    "message": "&Alle als Zweig laden"
+  },
+  "context_openAllBookmarksWithStructureRecursively_label": {
+    "message": "&Alle als Zweig inklusive Unterverzeichnisse laden"
+  },
+  "config_title": {
+    "message": "Tree Style Tab Einstellungen"
+  },
+  "config_recommended_choice": {
+    "message": "(empfohlen)"
+  },
+  "config_firefoxCompatible_choice": {
+    "message": "(simuliert das Standardverhalten von Firefox)"
+  },
+  "config_showExpertOptions_label": {
+    "message": "Experteneinstellungen anzeigen"
+  },
+  "config_openOptionsInTab_label": {
+    "message": "Diese Einstellungsseite verbreitert anzeigen"
+  },
+  "config_appearance_caption": {
+    "message": "Erscheinungsbild"
+  },
+  "config_sidebarPosition_caption": {
+    "message": "Ausrichtung des Seitenleisten-Inhalts:"
+  },
+  "config_sidebarPosition_left": {
+    "message": "Rechtsbündig"
+  },
+  "config_sidebarPosition_right": {
+    "message": "Linksbündig"
+  },
+  "config_sidebarPosition_auto": {
+    "message": "Automatisch erkennen, wenn die Seitenleiste angezeigt wird"
+  },
+  "config_sidebarPosition_description": {
+    "message": "*Diese Einstellung ändert nicht die Position der Seitenleiste. Klicke dafür auf die Seitenleisten-Überschrift und dann auf \"Seitenleiste nach rechts (links) verschieben\"."
+  },
+  "config_style_caption": {
+    "message": "Design"
+  },
+  "config_style_proton": {
+    "message": "Proton"
+  },
+  "config_style_photon": {
+    "message": "Photon"
+  },
+  "config_style_sidebar": {
+    "message": "Seitenleiste"
+  },
+  "config_style_highcontrast": {
+    "message": "Hoher Kontrast"
+  },
+  "config_style_none": {
+    "message": "Keine Designvorgabe"
+  },
+  "config_style_none_info": {
+    "message": " (*Passe alles selbst über das Feld \"Erweitert\" => \"User Style Sheet\" an)"
+  },
+  "config_colorScheme_caption": {
+    "message": "Farbschema:"
+  },
+  "config_colorScheme_photon": {
+    "message": "Photon"
+  },
+  "config_colorScheme_systemColor": {
+    "message": "Systemfarben"
+  },
+  "config_maxTreeLevel_before": {
+    "message": "Tabs einrücken bis"
+  },
+  "config_maxTreeLevel_after": {
+    "message": "Stufen (*Negative Werte bedeuten \"unbegrenzt\")"
+  },
+  "config_faviconizePinnedTabs_label": {
+    "message": "Angeheftete Tabs nur mit Ihrem Symbol anzeigen"
+  },
+  "config_maxFaviconizedPinnedTabsInOneRow_label_before": {
+    "message": "Zeige "
+  },
+  "config_maxFaviconizedPinnedTabsInOneRow_label_after": {
+    "message": " oder weniger Tabs für jede Reihe (*0 oder weniger bedeutet automatische Bestimmung)"
+  },
+  "config_maxPinnedTabsRowsAreaPercentage_label_before": {
+    "message": "Maximale Höhe des Bereichs für angeheftete Tabs:"
+  },
+  "config_maxPinnedTabsRowsAreaPercentage_label_after": {
+    "message": "% der Seitenleiste"
+  },
+  "config_animation_label": {
+    "message": "Animationen aktivieren"
+  },
+  "config_animationForce_label": {
+    "message": "Animationen unabhängig von der Einstellung \"Animationen verringern\" aktivieren"
+  },
+  "config_showCollapsedDescendantsByTooltip_label": {
+    "message": "Eingeklappte untergeordnete Tabs als Tooltip anzeigen"
+  },
+  "config_shiftTabsForScrollbarDistance_label_before": {
+    "message": "Tabs um "
+  },
+  "config_shiftTabsForScrollbarDistance_label_after": {
+    "message": " verschieben, damit Tab-Schaltflächen erreichbar bleiben und nicht von der Scrollbar verdeckt werden"
+  },
+  "config_shiftTabsForScrollbarDistance_placeholder": {
+    "message": "(CSS Länge)"
+  },
+  "config_shiftTabsForScrollbarOnlyOnHover_label": {
+    "message": "Tabs nur verschieben, wenn der Mauszeiger in der Nähe der Scrollbar ist"
+  },
+  "config_suppressGapFromShownOrHiddenToolbar_caption": {
+    "message": "Den Abstand zwischen Seitenleisteninhalten in Fällen reduzieren, die durch vorübergehend angezeigte Toolbars entstehen"
+  },
+  "config_suppressGapFromShownOrHiddenToolbarOnFullScreen_label": {
+    "message": "Vollbildfenster"
+  },
+  "config_suppressGapFromShownOrHiddenToolbarOnNewTab_label": {
+    "message": "Neuer leerer Tab unter Firefox 85 und später"
+  },
+  "config_suppressGapFromShownOrHiddenToolbarOnlyOnMouseOperation_label": {
+    "message": "Nur wenn von einer Mausaktion auf der Seitenleiste ausgelöst"
+  },
+  "config_showDialogInSidebar_label": {
+    "message": "Zeige Dialoge in Seitenleiste falls möglich"
+  },
+  "config_renderHiddenTabs_label": {
+    "message": "Zeige versteckte Tabs an, die von anderen Addons versteckt wurden"
+  },
+  "config_context_caption": {
+    "message": "Kontexmenü"
+  },
+  "config_emulateDefaultContextMenu_label": {
+    "message": "Tab-Kontextmenü in der Seitenleiste simulieren"
+  },
+  "config_extraItems_tabs_caption": {
+    "message": "Zusätzliche Kontextmenü-Einträge"
+  },
+  "config_extraItems_tabs_topLevel": {
+    "message": "Oberste Ebene"
+  },
+  "config_extraItems_tabs_subMenu": {
+    "message": "Untermenü"
+  },
+  "config_extraItems_tabs_middleClick": {
+    "message": "Aktion bei Mittelklick"
+  },
+  "config_extraItems_bookmarks_caption": {
+    "message": "Zusätzliche Einträge im Lesezeichen-Kontextmenü"
+  },
+  "config_openAllBookmarksWithStructureDiscarded_label": {
+    "message": "Tabs ausstehend lassen bis sie aktiv werden"
+  },
+  "config_sendTabsToDevice_caption": {
+    "message": "Tabs über das Kontextmenü via Firefox Sync zu anderen Geräten senden"
+  },
+  "config_syncRequirements_description": {
+    "message": "Diese Funktion hängt ab von Firefox Sync und Tabs können nur an Geräte gesendet werden, auf denen TST installiert ist. Bitte Firefox Sync über die Browsereinstellungen aktivieren und TST auf den anderen Geräten installieren."
+  },
+  "config_syncDeviceInfo_name_label": {
+    "message": "Name und Bild dieses Geräts:"
+  },
+  "config_syncDeviceInfo_name_description_before": {
+    "message": "Aufgrund von Einschränkungen der WebExtensions API kann TST den Namen dieses Geräts nicht automatisch bestimmen. Bitte manuell einen beschreibenden Namen für dieses Gerät eingeben. (Es wird empfohlen, "
+  },
+  "config_syncDeviceInfo_name_description_link": {
+    "message": "den Gerätenamen von Firefox Sync"
+  },
+  "config_syncDeviceInfo_name_description_href": {
+    "message": "https://accounts.firefox.com/settings/clients"
+  },
+  "config_syncDeviceInfo_name_description_after": {
+    "message": " zu verwenden.)"
+  },
+  "config_syncDeviceExpirationDays_label_before": {
+    "message": "Geräte autmatisch ablaufen lassen, wenn sie "
+  },
+  "config_syncDeviceExpirationDays_label_after": {
+    "message": " Tage nicht verwendet wurden (\"0\" bedeutet \"kein Ablaufen\")"
+  },
+  "config_syncUnsendableUrlPattern_label": {
+    "message": "Regel zum Erkennen von Tabs, die nicht gesendet werden sollen (*Dies muss mit der Einstellung \"services.sync.engine.tabs.filteredUrls\" von Firefox synchronisiert sein):"
+  },
+  "config_otherDevices_caption": {
+    "message": "Andere aktive Geräte:"
+  },
+  "config_removeDeviceButton_label": {
+    "message": "Löschen"
+  },
+  "config_removeDeviceButton_tooltip": {
+    "message": "Dieses Gerät von der Liste löschen"
+  },
+  "config_autoAttachOnContextNewTabCommand_noControl": {
+    "message": "(keine Steuerung)"
+  },
+  "config_autoAttachOnContextNewTabCommand_independent": {
+    "message": "Eigenständiger Tab"
+  },
+  "config_autoAttachOnContextNewTabCommand_childTop": {
+    "message": "Erster Untergeordneter vom jetztigen Tab"
+  },
+  "config_autoAttachOnContextNewTabCommand_childEnd": {
+    "message": "Letzter Untergeordneter vom jetztigen Tab"
+  },
+  "config_autoAttachOnContextNewTabCommand_sibling": {
+    "message": "Nachbar vom jetztigen Tab"
+  },
+  "config_autoAttachOnContextNewTabCommand_nextSibling": {
+    "message": "Nächster Nachbar vom jetztigen Tab"
+  },
+  "config_autoAttachOnContextNewTabCommand_nextSiblingWithInheritedContainer": {
+    "message": "Nächster Nachbar des gleichen Containers"
+  },
+  "config_autoAttachOnContextNewTabCommand_after": {
+    "message": "​"
+  },
+  "config_newTabWithOwner_caption": {
+    "message": "Neue Tabs, die von existierenden Tabs geöffnet wurden"
+  },
+  "config_autoAttachOnOpenedWithOwner_before": {
+    "message": "Wenn ein neuer Tab von einem existierenden Tab geöffnet wird, öffne ihn als"
+  },
+  "config_autoAttachOnOpenedWithOwner_noControl": {
+    "message": "(keine Steuerung)"
+  },
+  "config_autoAttachOnOpenedWithOwner_independent": {
+    "message": "Eigenständiger Tab"
+  },
+  "config_autoAttachOnOpenedWithOwner_childNextToLastRelatedTab": {
+    "message": "Untergeordneter des übergeordneten Tabs, anschließend an kürzlich geöffneten untergeordneten Tab"
+  },
+  "config_autoAttachOnOpenedWithOwner_childTop": {
+    "message": "Erster Untergeordneter des übergeordneten Tabs"
+  },
+  "config_autoAttachOnOpenedWithOwner_childEnd": {
+    "message": "Letzter Untergeordneter des übergeordneten Tabs"
+  },
+  "config_autoAttachOnOpenedWithOwner_sibling": {
+    "message": "Nachbar des übergeordneten Tabs"
+  },
+  "config_autoAttachOnOpenedWithOwner_nextSibling": {
+    "message": "Nächster Nachbar des übergeordneten Tabs"
+  },
+  "config_autoAttachOnOpenedWithOwner_after": {
+    "message": "​"
+  },
+  "config_insertNewTabFromPinnedTabAt_caption": {
+    "message": "Einfügeposition von neuen untergeordneten Tabs (werden als Wurzel-Tab behandelt) für angeheftete Tabs"
+  },
+  "config_insertNewTabFromPinnedTabAt_noControl": {
+    "message": "Keine Steuerung (berücksichtigt die Entscheidung von Firefox oder anderen Erweiterungen)"
+  },
+  "config_insertNewTabFromPinnedTabAt_nextToLastRelatedTab": {
+    "message": "Neben dem zuletzt geöffneten Tab oder in der Nähe des öffnenden Tabs"
+  },
+  "config_insertNewTabFromPinnedTabAt_top": {
+    "message": "Am Anfang des Baums (nahe des öffnenden Tabs)"
+  },
+  "config_insertNewTabFromPinnedTabAt_end": {
+    "message": "Am Ende des Baums"
+  },
+  "config_autoGroupNewTabsFromPinned_label": {
+    "message": "Tabs automatisch gruppieren, wenn sie vom gleichen angehefteten Tab geöffnet werden (es wird ein neuer Gruppentab mit einem Titel wie \"Tabs von ...\" geöffnet)"
+  },
+  "config_groupTabTemporaryStateForChildrenOfPinned_label": {
+    "message": "Standardzustand der Gruppentabs, welche für Tabs des gleichen angehefteten Tabs geöffnet wurden:"
+  },
+  "config_newTab_caption": {
+    "message": "Neue Tabs, die nicht von existierenden Tabs geöffnet wurden"
+  },
+  "config_newTabButton_caption": {
+    "message": "Besondere Aktionen für die \"Neuer Tab\" Schaltfläche"
+  },
+  "config_longPressOnNewTabButton_before": {
+    "message": "Die Schaltfläche \"Neuer Tab\" lang gedrückt halten, um "
+  },
+  "config_longPressOnNewTabButton_newTabAction": {
+    "message": "auszuwählen, wo der neue Tab geöffnet werden soll"
+  },
+  "config_longPressOnNewTabButton_contextualIdentities": {
+    "message": "eine Tab-Umgebung auszuwählen"
+  },
+  "config_longPressOnNewTabButton_none": {
+    "message": "(nichts)"
+  },
+  "config_longPressOnNewTabButton_after": {
+    "message": "​"
+  },
+  "config_showNewTabActionSelector_label": {
+    "message": "Auswahl wo der neue Tab geöffnet werden soll, auf der Schaltfläche \"Neuer Tab \" anzeigen, wenn der Cursor auf die Schaltfläche zeigt"
+  },
+  "config_showContextualIdentitiesSelector_label": {
+    "message": "Auswahl der Tab-Umgebung auf der Schaltfläche \"Neuer Tab\" anzeigen, wenn der Cursor auf die Schaltfläche zeigt"
+  },
+  "config_newTabAction_caption": {
+    "message": "Grundsätzliche Steuerung für \"Neuer leerer Tab\""
+  },
+  "config_autoAttachOnNewTabCommand_before": {
+    "message": "Neuen leeren Tab als "
+  },
+  "config_autoAttachOnNewTabCommand_noControl": {
+    "message": "(keine Steuerung)"
+  },
+  "config_autoAttachOnNewTabCommand_independent": {
+    "message": "eigenständigen Tab"
+  },
+  "config_autoAttachOnNewTabCommand_sibling": {
+    "message": "Tab auf der Ebene des aktiven Tab"
+  },
+  "config_autoAttachOnNewTabCommand_nextSibling": {
+    "message": "direkten Nachbar auf der Ebene des aktiven Tab"
+  },
+  "config_autoAttachOnNewTabCommand_after": {
+    "message": "öffnen"
+  },
+  "config_guessNewOrphanTabAsOpenedByNewTabCommandUrl_before": {
+    "message": "Einen neuen Tab behandeln als sei er durch den Befehl \"Neuer leerer Tab\" geöffnet worden, wenn er mit dieser URL geöffnet wird:"
+  },
+  "config_autoAttachOnNewTabButtonMiddleClick_before": {
+    "message": "Mit der mittleren Maustaste einen neuen leeren Tab öffnen als"
+  },
+  "config_autoAttachOnNewTabButtonMiddleClick_noControl": {
+    "message": "(keine Steuerung)"
+  },
+  "config_autoAttachOnNewTabButtonMiddleClick_independent": {
+    "message": "eigenständigen Tab"
+  },
+  "config_autoAttachOnNewTabButtonMiddleClick_sibling": {
+    "message": "Tab auf der Ebene des aktiven Tab"
+  },
+  "config_autoAttachOnNewTabButtonMiddleClick_nextSibling": {
+    "message": "direkten Nachbar auf der Ebene des aktiven Tab"
+  },
+  "config_autoAttachOnNewTabButtonMiddleClick_nextSiblingWithInheritedContainer": {
+    "message": "identisch mit Strg-Klick (nächster Nachbar, gleiche Umgebung)"
+  },
+  "config_autoAttachOnNewTabButtonMiddleClick_after": {
+    "message": "​"
+  },
+  "config_autoAttachOnNewTabButtonAccelClick_before": {
+    "message": "Für Strg/⌘-Klick, neuen leeren Tab öffnen als"
+  },
+  "config_autoAttachOnNewTabButtonAccelClick_noControl": {
+    "message": "(keine Steuerung)"
+  },
+  "config_autoAttachOnNewTabButtonAccelClick_independent": {
+    "message": "eigenständigen Tab"
+  },
+  "config_autoAttachOnNewTabButtonAccelClick_sibling": {
+    "message": "Tab auf der Ebene des aktiven Tab"
+  },
+  "config_autoAttachOnNewTabButtonAccelClick_nextSibling": {
+    "message": "direkten Nachbar auf der Ebene des aktiven Tab"
+  },
+  "config_autoAttachOnNewTabButtonAccelClick_nextSiblingWithInheritedContainer": {
+    "message": "direkter Nachbar, gleiche Umgebung"
+  },
+  "config_autoAttachOnNewTabButtonAccelClick_after": {
+    "message": "​"
+  },
+  "config_autoAttachWithURL_caption": {
+    "message": "Nicht-leere neue Tabs"
+  },
+  "config_duplicateTabAction_caption": {
+    "message": "Tabs duplizieren (Mittelklick auf die \"Neu laden\"-Schaltfläche usw.)"
+  },
+  "config_autoAttachOnDuplicated_before": {
+    "message": "Den Tab duplizieren als"
+  },
+  "config_autoAttachOnDuplicated_noControl": {
+    "message": "(keine Steuerung)"
+  },
+  "config_autoAttachOnDuplicated_independent": {
+    "message": "eigenständigen Tab"
+  },
+  "config_autoAttachOnDuplicated_sibling": {
+    "message": "Tab auf der Ebene des aktiven Tab"
+  },
+  "config_autoAttachOnDuplicated_nextSibling": {
+    "message": "direkten Nachbar auf der Ebene des aktiven Tab"
+  },
+  "config_autoAttachOnDuplicated_after": {
+    "message": "​"
+  },
+  "config_fromExternal_caption": {
+    "message": "Neuer Tab außerhalb von Firefox"
+  },
+  "config_autoAttachOnOpenedFromExternal_before": {
+    "message": "Öffnen als"
+  },
+  "config_autoAttachOnOpenedFromExternal_noControl": {
+    "message": "(keine Steuerung)"
+  },
+  "config_autoAttachOnOpenedFromExternal_independent": {
+    "message": "unabhängigen Tab"
+  },
+  "config_autoAttachOnOpenedFromExternal_childTop": {
+    "message": "Erster Untergeordneter des jetztigen Tabs"
+  },
+  "config_autoAttachOnOpenedFromExternal_childEnd": {
+    "message": "Letzter Untergeordneter des jetztigen Tabs"
+  },
+  "config_autoAttachOnOpenedFromExternal_sibling": {
+    "message": "Tab auf der Ebene des aktiven Tab"
+  },
+  "config_autoAttachOnOpenedFromExternal_nextSibling": {
+    "message": "direkten Nachbar auf der Ebene des aktiven Tab"
+  },
+  "config_autoAttachOnOpenedFromExternal_after": {
+    "message": "​"
+  },
+  "config_inheritContextualIdentityToTabsFromExternalMode_label": {
+    "message": "Tab-Umgebung:"
+  },
+  "config_inheritContextualIdentityToTabsFromExternalMode_default": {
+    "message": "(keine Steuerung)"
+  },
+  "config_inheritContextualIdentityToTabsFromExternalMode_parent": {
+    "message": "Vom übergeordneten Tab im Zweig erben"
+  },
+  "config_inheritContextualIdentityToTabsFromExternalMode_lastActive": {
+    "message": "Vom aktuellen Tab erben"
+  },
+  "config_sameSiteOrphan_caption": {
+    "message": "Neuer Tab mit der gleichen Webseite wie der aktuelle Tab über die Adressleiste, Lesezeichen, Verlauf oder anderes"
+  },
+  "config_autoAttachSameSiteOrphan_before": {
+    "message": "Öffnen als"
+  },
+  "config_autoAttachSameSiteOrphan_noControl": {
+    "message": "(keine Steuerung)"
+  },
+  "config_autoAttachSameSiteOrphan_independent": {
+    "message": "unabhängigen Tab"
+  },
+  "config_autoAttachSameSiteOrphan_childTop": {
+    "message": "Erster Untergeordneter des jetztigen Tabs"
+  },
+  "config_autoAttachSameSiteOrphan_childEnd": {
+    "message": "Letzter Untergeordneter des jetztigen Tabs"
+  },
+  "config_autoAttachSameSiteOrphan_sibling": {
+    "message": "Tab auf der Ebene des aktiven Tab"
+  },
+  "config_autoAttachSameSiteOrphan_nextSibling": {
+    "message": "direkten Nachbar auf der Ebene des aktiven Tab"
+  },
+  "config_autoAttachSameSiteOrphan_after": {
+    "message": "​"
+  },
+  "config_inheritContextualIdentityToSameSiteOrphanMode_label": {
+    "message": "Tab-Umgebung:"
+  },
+  "config_inheritContextualIdentityToSameSiteOrphanMode_default": {
+    "message": "(keine Steuerung)"
+  },
+  "config_inheritContextualIdentityToSameSiteOrphanMode_parent": {
+    "message": "Vom übergeordneten Tab im Zweig erben"
+  },
+  "config_inheritContextualIdentityToSameSiteOrphanMode_lastActive": {
+    "message": "Vom aktuellen Tab erben"
+  },
+  "config_anyOtherTrigger_caption": {
+    "message": "Tabs aus einem anderen Grund"
+  },
+  "config_autoAttachOnAnyOtherTrigger_before": {
+    "message": "Öffnen als"
+  },
+  "config_autoAttachOnAnyOtherTrigger_noControl": {
+    "message": "(keine Steuerung)"
+  },
+  "config_autoAttachOnAnyOtherTrigger_independent": {
+    "message": "unabhängigen Tab"
+  },
+  "config_autoAttachOnAnyOtherTrigger_childTop": {
+    "message": "Erster Untergeordneter des jetztigen Tabs"
+  },
+  "config_autoAttachOnAnyOtherTrigger_childEnd": {
+    "message": "Letzter Untergeordneter des jetztigen Tabs"
+  },
+  "config_autoAttachOnAnyOtherTrigger_sibling": {
+    "message": "Tab auf der Ebene des aktiven Tab"
+  },
+  "config_autoAttachOnAnyOtherTrigger_nextSibling": {
+    "message": "direkten Nachbar auf der Ebene des aktiven Tab"
+  },
+  "config_autoAttachOnAnyOtherTrigger_after": {
+    "message": "​"
+  },
+  "config_autoAttachOnAnyOtherTrigger_caution": {
+    "message": "*ACHTUNG: Diese Option birgt die Gefahr, andere Erweiterungen zu behindern."
+  },
+  "config_inheritContextualIdentityToTabsFromAnyOtherTriggerMode_label": {
+    "message": "Tab-Umgebung:"
+  },
+  "config_inheritContextualIdentityToTabsFromAnyOtherTriggerMode_default": {
+    "message": "(keine Steuerung)"
+  },
+  "config_inheritContextualIdentityToTabsFromAnyOtherTriggerMode_parent": {
+    "message": "Vom übergeordneten Tab im Zweig erben"
+  },
+  "config_inheritContextualIdentityToTabsFromAnyOtherTriggerMode_lastActive": {
+    "message": "Vom aktuellen Tab erben"
+  },
+  "config_inheritContextualIdentityToUnopenableURLTabs_label": {
+    "message": "Tab im geerbten Container wiederöffnen, auch wenn es eine Adresse enthält, die wegen Berechtigungen des Addons nicht geöffnet werden kann"
+  },
+  "config_groupTab_caption": {
+    "message": "Automatische Gruppierung der Tabs"
+  },
+  "config_tabBunchesDetectionTimeout_before": {
+    "message": "Tabs automatisch gruppieren, die innerhalb von"
+  },
+  "config_tabBunchesDetectionTimeout_after": {
+    "message": "Millisekunden aus einem Lesezeichen-Ordner geöffnet wurden"
+  },
+  "config_autoGroupNewTabsFromBookmarks_label": {
+    "message": "Gruppiere Tabs unter dem Tab mit den Namen wie \"... und weiteren\""
+  },
+  "config_restoreTreeForTabsFromBookmarks_label": {
+    "message": "Baumstruktur wiederherstellen"
+  },
+  "config_requireBookmarksPermission_tooltiptext": {
+    "message": "Diese Funktion benötigt Zugriff auf die Lesezeichen. Hier klicken um die zusätzliche Berechtigung zu gewähren."
+  },
+  "config_requestPermissions_bookmarks_autoGroupNewTabs_before": {
+    "message": "("
+  },
+  "config_requestPermissions_bookmarks_autoGroupNewTabs_after": {
+    "message": "Erkennen von zu Tabs gehörenden Lesezeichen erlauben)"
+  },
+  "config_tabsFromSameFolderMinThresholdPercentage_before": {
+    "message": "Alle neuen Tabs als aus einem Lesezeichen-Ordner stammend betrachten, falls mehr als "
+  },
+  "config_tabsFromSameFolderMinThresholdPercentage_after": {
+    "message": "% Tabs ein entsprechendes Lesezeichen in einem Lesezeichen-Ordner haben"
+  },
+  "config_autoGroupNewTabsFromOthers_label": {
+    "message": "Zeitgleich geöffnete Tabs gruppieren, auch wenn sie nicht aus den Lesezeichen stammen"
+  },
+  "config_tabBunchesDetectionDelayOnNewWindow_before": {
+    "message": "Aber neue Tabs nicht gruppieren, die innerhalb von"
+  },
+  "config_tabBunchesDetectionDelayOnNewWindow_after": {
+    "message": "Millisekunden geöffnet werden, wenn ein neues Fenster geöffnet wird, als Teil von Tabs, die als \"Startseite\" geöffnet werden."
+  },
+  "config_warnOnAutoGroupNewTabs_label": {
+    "message": "Bestätige Gruppierung von Tabs"
+  },
+  "config_warnOnAutoGroupNewTabsWithListing_label": {
+    "message": "Tabs, die gruppiert werden sollen, im Bestätigungsdialog auflisten"
+  },
+  "config_renderTreeInGroupTabs_label": {
+    "message": "Zeige Baum in Gruppen-Tab"
+  },
+  "config_groupTabTemporaryState_caption": {
+    "message": "Standardzustand von Gruppen-Tabs für jede Situation"
+  },
+  "config_groupTabTemporaryState_option_default": {
+    "message": "Keine Option auswählen"
+  },
+  "config_groupTabTemporaryState_option_checked_before": {
+    "message": "Option \""
+  },
+  "config_groupTabTemporaryState_option_checked_after": {
+    "message": "\" auswählen"
+  },
+  "config_groupTabTemporaryStateForNewTabsFromBookmarks_label": {
+    "message": "Für Tabs, die aus Lesezeichen geöffnet wurden:"
+  },
+  "config_groupTabTemporaryStateForNewTabsFromOthers_label": {
+    "message": "Für zeitgleich geöffnete Tabs, die nicht aus Lesezeichen geöffnet wurden:"
+  },
+  "config_groupTabTemporaryStateForOrphanedTabs_label": {
+    "message": "Geöffnet, um einen geschlossenen übergeordneten Tab zu ersetzen:"
+  },
+  "config_inheritContextualIdentityToChildTabMode_label": {
+    "message": "Tab-Umgebung:"
+  },
+  "config_inheritContextualIdentityToChildTabMode_default": {
+    "message": "(keine Steuerung)"
+  },
+  "config_inheritContextualIdentityToChildTabMode_parent": {
+    "message": "Vom übergeordneten Tab im Zweig erben"
+  },
+  "config_inheritContextualIdentityToChildTabMode_lastActive": {
+    "message": "Vom aktuellen Tab erben"
+  },
+  "config_treeBehavior_caption": {
+    "message": "Verhalten der Zweige"
+  },
+  "config_successorTabControlLevel_caption": {
+    "message": "Wenn der aktive Tab als letzter verbleibender untergeordneter Tab geschlossen wird"
+  },
+  "config_successorTabControlLevel_inTree": {
+    "message": "Zum vorherigen Tab im Zweig wechseln"
+  },
+  "config_successorTabControlLevel_simulateDefault": {
+    "message": "Immer zum nächsten Tab wechseln (Firefox Standardverhalten)"
+  },
+  "config_successorTabControlLevel_never": {
+    "message": "Den Fokus niemals steuern (Steuerung von Firefox oder anderer Erweiterungen respektieren)"
+  },
+  "config_successorTabControlLevel_legacyDescription": {
+    "message": "*Firefox eingebautes Verhalten für \"browser.tabs.selectOwnerOnClose\"=\"true\" hat Priorität vor dieser Einstellung."
+  },
+  "config_simulateSelectOwnerOnClose_label": {
+    "message": "Wenn möglich, setze den Fokus auf den öffnenden Tab, wenn der aktuelle Tab geschlossen wird (*Simulation von Firefox eingebautem Verhalten für \"browser.tabs.selectOwnerOnClose\"=\"true\", vor der obigen Einstellung)"
+  },
+  "config_fixupTreeOnTabVisibilityChanged_caption": {
+    "message": "Wenn die Sichtbarkeit von Tabs von anderen Erweiterungen geändert wird"
+  },
+  "config_fixupTreeOnTabVisibilityChanged_fix": {
+    "message": "Automatisch die Baumstruktur mit den sichtbaren Tabs aktualisieren (*Empfohlen bei der Verwendung von anderen Erweiterungen um Tab-Gruppen zu wechseln)"
+  },
+  "config_fixupTreeOnTabVisibilityChanged_keep": {
+    "message": "Baumstruktur inklusive versteckten Tabs beibehalten (*Empfohlen bei der Verwendung von anderen Erweiterungen, welche vorübergehend die Sichtbarkeit von Tabs ändern)"
+  },
+  "config_autoCollapseExpandSubtreeOnAttach_label": {
+    "message": "Wenn ein neuer Zweig erscheint, alle anderen automatisch einklappen"
+  },
+  "config_autoCollapseExpandSubtreeOnSelect_label": {
+    "message": "Wenn ein Tab ausgewählt wird, automatisch seinen Zweig ausklappen und alle anderen einklappen"
+  },
+  "config_autoCollapseExpandSubtreeOnSelectExceptActiveTabRemove_label": {
+    "message": "Es sei denn, dass das Auswählen des Tabs durch das Schließen des aktiven Tabs verursacht wird"
+  },
+  "config_unfocusableCollapsedTab_label": {
+    "message": "Wenn ein Tab unter einem eingeklappten Zweig fokussiert wird, den Zweig automatisch ausklappen"
+  },
+  "config_autoDiscardTabForUnexpectedFocus_label": {
+    "message": "Tabs ausstehend lassen, wenn Tabs versehentlich fokussiert werden und der Fokus sofort umgeleitet wird"
+  },
+  "config_avoidDiscardedTabToBeActivatedIfPossible_label": {
+    "message": "Vermeiden, dass ausstehende Tabs versehentlich aktiviert werden, wenn der aktuelle Tab geschlossen oder ein Zweig eingeklappt wird"
+  },
+  "config_treeDoubleClickBehavior_caption": {
+    "message": "Doppelklick auf einen Tab"
+  },
+  "config_treeDoubleClickBehavior_toggleCollapsed": {
+    "message": "Aus-/einklappen eines Zweigs"
+  },
+  "config_treeDoubleClickBehavior_close": {
+    "message": "Tab schließen (*Simuliert Firefox eingebautes Verhalten für \"browser.tabs.closeTabByDblclick\"=\"true\")"
+  },
+  "config_treeDoubleClickBehavior_close_note": {
+    "message": " (*simuliere das eigene Browserverhalten wie bei \"browser.tabs.closeTabByDblclick\"=\"true\")"
+  },
+  "config_treeDoubleClickBehavior_none": {
+    "message": "Nichts machen"
+  },
+  "config_parentTabOperationBehaviorMode_caption": {
+    "message": "Wenn ein übergeordneter Tab geschlossen oder verschoben wird"
+  },
+  "config_parentTabOperationBehaviorMode_noteForPermanentlyConsistentBehaviors": {
+    "message": "Unabhängig von diesen Einstellungen gibt es einige festgelegte Verhaltensweisen in der Seitenleiste;\n･ Schließen eines eingeklappten, übergeordneten Tabs: den gesamten Zweig schließen\n･ Verschieben eines eingeklappten, übergeordneten Tabs: den gesamten Zweig verschieben\n･ Verschieben eines ausgeklappten, übergeordneten Tabs: Verhalten wie im Bereich \"Ziehen und Ablegen\" eingestellt"
+  },
+  "config_parentTabOperationBehaviorMode_parallel": {
+    "message": "Empfohlenes Verhalten für Nutzer, welche auch die eingebaute Tableiste von Firefox verwenden"
+  },
+  "config_closeParentBehavior_insideSidebar": {
+    "message": "Wenn ein übergeordneter Tab mit ausgeklapptem Zweig über die Seitenleiste geschlossen wird,"
+  },
+  "config_closeParentBehavior_outsideSidebar": {
+    "message": "Wenn ein übergeordneter Tab (unabhängig ob der Zweig auf- oder zugeklappt ist) über die eingebaute Tableiste, Tastenkombinationen oder andere Erweiterungen geschlossen wird,"
+  },
+  "config_moveParentBehavior_outsideSidebar": {
+    "message": "Wenn ein übergeordneter Tab (unabhängig ob der Zweig auf- oder zugeklappt ist) über die eingebaute Tableiste, Tastenkombinationen oder andere Erweiterungen verschoben wird,"
+  },
+  "config_parentTabOperationBehaviorMode_consistent": {
+    "message": "Empfohlenes Verhalten für Nutzer, welche die eingebaute Tableiste von Firefox nicht verwenden"
+  },
+  "config_parentTabOperationBehaviorMode_consistent_caption": {
+    "message": "Wenn ein übergeordneter Tab mit ausgeklapptem Zweig geschlossen/verschoben wird,"
+  },
+  "config_parentTabOperationBehaviorMode_consistent_notes": {
+    "message": "Tabs verhalten sich konsistent wie oben festgelegt, auch bei der eingebauten Tableiste, Tastenkombinationen oder andere Erweiterungen."
+  },
+  "config_parentTabOperationBehaviorMode_custom": {
+    "message": "Benutzerdefiniert"
+  },
+  "config_closeParentBehavior_insideSidebar_expanded_caption": {
+    "message": "Schließen: Wenn ein übergeordneter Tab mit ausgeklapptem Zweig über die Seitenleiste geschlossen wird,"
+  },
+  "config_closeParentBehavior_outsideSidebar_collapsed_caption": {
+    "message": "Schließen: Wenn ein übergeordneter Tab mit eingeklapptem Zweig über die eingebaute Tableiste, Tastenkombinationen oder andere Erweiterungen geschlossen wird,"
+  },
+  "config_closeParentBehavior_outsideSidebar_expanded_caption": {
+    "message": "Schließen: Wenn ein übergeordneter Tab mit ausgeklapptem Zweig über die eingebaute Tableiste, Tastenkombinationen oder andere Erweiterungen geschlossen wird,"
+  },
+  "config_closeParentBehavior_noSidebar_collapsed_caption": {
+    "message": "wenn die Seitenleiste geschlossen ist,"
+  },
+  "config_closeParentBehavior_noSidebar_expanded_caption": {
+    "message": "wenn die Seitenleiste geschlossen ist,"
+  },
+  "config_moveParentBehavior_outsideSidebar_collapsed_caption": {
+    "message": "Verschieben: Wenn ein übergeordneter Tab mit eingeklapptem Zweig über die eingebaute Tableiste, Tastenkombinationen oder andere Erweiterungen verschoben wird,"
+  },
+  "config_moveParentBehavior_outsideSidebar_expanded_caption": {
+    "message": "Verschieben: Wenn ein übergeordneter Tab mit ausgeklapptem Zweig über die eingebaute Tableiste, Tastenkombinationen oder andere Erweiterungen verschoben wird,"
+  },
+  "config_moveParentBehavior_noSidebar_collapsed_caption": {
+    "message": "wenn die Seitenleiste geschlossen ist,"
+  },
+  "config_moveParentBehavior_noSidebar_expanded_caption": {
+    "message": "wenn die Seitenleiste geschlossen ist,"
+  },
+  "config_parentTabOperationBehavior_entireTree": {
+    "message": "Untergeordnete Tabs ebenfalls schließen"
+  },
+  "config_closeParentBehavior_entireTree": {
+    "message": "Gesamten Zweig schließen"
+  },
+  "config_moveParentBehavior_entireTree": {
+    "message": "Gesamten Zweig verschieben"
+  },
+  "config_parentTabOperationBehavior_replaceWithGroupTab": {
+    "message": "Den geschlossenen/verschobenen übergeordneten Tab durch einen Platzhalter ersetzen"
+  },
+  "config_closeParentBehavior_replaceWithGroupTab": {
+    "message": "Den geschlossenen übergeordneten Tab durch einen Platzhalter ersetzen"
+  },
+  "config_moveParentBehavior_replaceWithGroupTab": {
+    "message": "Den verschobenen übergeordneten Tab durch einen Platzhalter ersetzen"
+  },
+  "config_parentTabOperationBehavior_promoteFirst": {
+    "message": "Den geschlossenen übergeordneten Tab durch den ersten untergeordneten Tab ersetzen"
+  },
+  "config_closeParentBehavior_promoteFirst": {
+    "message": "Den geschlossenen übergeordneten Tab durch den ersten untergeordneten Tab ersetzen"
+  },
+  "config_moveParentBehavior_promoteFirst": {
+    "message": "Den geschlossenen übergeordneten Tab durch den ersten untergeordneten Tab ersetzen"
+  },
+  "config_parentTabOperationBehavior_promoteAll": {
+    "message": "Alle untergeordneten Tabs auf die Ebene des geschlossenen übergeordneten Tabs bringen"
+  },
+  "config_closeParentBehavior_promoteAll": {
+    "message": "Alle untergeordneten Tabs auf die Ebene des geschlossenen übergeordneten Tabs bringen"
+  },
+  "config_moveParentBehavior_promoteAll": {
+    "message": "Alle untergeordneten Tabs auf die Ebene des geschlossenen übergeordneten Tabs bringen"
+  },
+  "config_parentTabOperationBehavior_promoteIntelligently": {
+    "message": "Den geschlossenen Tab durch den ersten untergeordneten Tab ersetzen, wenn er sich auf der obersten Ebene befand, andernfalls alle untergeordneten Tabs auf die Ebene des geschlossenen Tabs bringen"
+  },
+  "config_closeParentBehavior_promoteIntelligently": {
+    "message": "Den geschlossenen Tab durch den ersten untergeordneten Tab ersetzen, wenn er sich auf der obersten Ebene befand, andernfalls alle untergeordneten Tabs auf die Ebene des geschlossenen Tabs bringen"
+  },
+  "config_moveParentBehavior_promoteIntelligently": {
+    "message": "Den geschlossenen Tab durch den ersten untergeordneten Tab ersetzen, wenn er sich auf der obersten Ebene befand, andernfalls alle untergeordneten Tabs auf die Ebene des geschlossenen Tabs bringen"
+  },
+  "config_parentTabOperationBehavior_detach": {
+    "message": "Untergeordnete Tabs vom Zweig lösen"
+  },
+  "config_closeParentBehavior_detach": {
+    "message": "Untergeordnete Tabs vom Zweig lösen"
+  },
+  "config_moveParentBehavior_detach": {
+    "message": "Untergeordnete Tabs vom Zweig lösen"
+  },
+  "config_warnOnCloseTabs_label": {
+    "message": "Warnen, wenn mehrere Tabs geschlossen werden sollen"
+  },
+  "config_warnOnCloseTabsByClosebox_label": {
+    "message": "Warnen, wenn mehrere Tabs durch einen Klick auf eine Schließen-Schaltfläche geschlossen werden sollen"
+  },
+  "config_warnOnCloseTabsWithListing_label": {
+    "message": "Tabs, die geschlossen werden sollen, im Bestätigungsdialog auflisten"
+  },
+  "config_insertNewChildAt_caption": {
+    "message": "Einfügeposition neuer untergeordneter Tabs"
+  },
+  "config_insertNewChildAt_noControl": {
+    "message": "Keine Steuerung (das Verhalten von Firefox oder anderer Tab-Add-Ons beibehalten)"
+  },
+  "config_insertNewChildAt_nextToLastRelatedTab": {
+    "message": "Neben dem zuletzt untergeordneten Tab oder neben dem übergeordneten Tab"
+  },
+  "config_insertNewChildAt_top": {
+    "message": "Am Anfang des Zweigs, als erster untergeordneter Tab"
+  },
+  "config_insertNewChildAt_end": {
+    "message": "Am Ende des Zweigs"
+  },
+  "config_drag_caption": {
+    "message": "Ziehen und Ablegen"
+  },
+  "config_tabDragBehavior_caption": {
+    "message": "Wenn ein übergeordneter Zweig gezogen und abgelegt wird"
+  },
+  "config_tabDragBehavior_description": {
+    "message": "Aufgrund von Firefox Einschränkungen muss beim Beginn des Ziehens bekannt sein, wie Tabs beim Ablegen außerhalb der Seitenleiste von TST behandelt werden sollen."
+  },
+  "config_tabDragBehavior_label": {
+    "message": "Ziehen"
+  },
+  "config_tabDragBehaviorShift_label": {
+    "message": "Shift-Ziehen"
+  },
+  "config_tabDragBehavior_label_behaviorInsideSidebar": {
+    "message": "Verhalten innerhalb"
+  },
+  "config_tabDragBehavior_label_behaviorOutsideSidebar": {
+    "message": "außerhalb der Seitenleiste"
+  },
+  "config_tabDragBehavior_moveEntireTreeAlways": {
+    "message": "Gesamten Zweig verschieben"
+  },
+  "config_tabDragBehavior_detachEntireTreeAlways": {
+    "message": "Gesamten Zweig vom Fenster ablösen (aber unmöglich, Lesezeichen anzulegen)"
+  },
+  "config_tabDragBehavior_bookmarkEntireTreeAlways": {
+    "message": "Verweise oder Lesezeichen vom gesamten Zweig erstellen (aber unmöglich, vom Fenster abzulösen)"
+  },
+  "config_tabDragBehavior_moveSoloTabIfExpanded": {
+    "message": "Einzelnen Tab verschieben"
+  },
+  "config_tabDragBehavior_detachSoloTabIfExpanded": {
+    "message": "Einzelnen Tab vom Fenster ablösen (aber unmöglich, Lesezeichen anzulegen)"
+  },
+  "config_tabDragBehavior_bookmarkSoloTabIfExpanded": {
+    "message": "Verweis oder Lesezeichen vom einzelnen Tab erstellen (aber unmöglich, vom Fenster abzulösen)"
+  },
+  "config_tabDragBehavior_doNothing": {
+    "message": "Nichts machen"
+  },
+  "config_tabDragBehavior_noteForDragstartOutsideSidebar": {
+    "message": "Wenn ein übergeordneter Tab aus der eingebaute Tableiste von Firefox verschoben wird, wie im Abschnitt \"Verhalten der Zweige\" => \"Wenn ein übergeordneter Tab geschlossen oder verschoben wird\" verhalten."
+  },
+  "config_showTabDragBehaviorNotification_label": {
+    "message": "Zeige Benachrichtigung was geschehen wird, wenn Tabs außerhalb der Seitenleiste abgelegt werden, während ein Tab gezogen wird."
+  },
+  "config_dropLinksOnTabBehavior_caption": {
+    "message": "Wenn ein Link oder eine URL-Zeichenkette per Ziehen und Ablegen auf einen Tab abgelegt wird"
+  },
+  "config_dropLinksOnTabBehavior_ask": {
+    "message": "Immer nachfragen"
+  },
+  "config_dropLinksOnTabBehavior_load": {
+    "message": "In diesem Tab öffnen"
+  },
+  "config_dropLinksOnTabBehavior_newtab": {
+    "message": "In einem neuen untergeordneten Tab öffnen"
+  },
+  "config_insertDroppedTabsAt_caption": {
+    "message": "Einfügeposition von Tabs, die auf übergeordnete Tabs abgelegt werden"
+  },
+  "config_insertDroppedTabsAt_inherit": {
+    "message": "Wie neue untergeordnete Tab behandeln"
+  },
+  "config_insertDroppedTabsAt_first": {
+    "message": "Am Anfang des Zweigs (neben dem übergeordneten Tab)"
+  },
+  "config_insertDroppedTabsAt_end": {
+    "message": "Am Ende des Zweigs"
+  },
+  "config_autoExpandOnLongHoverDelay_before": {
+    "message": "Eingeklappten Zweig ausklappen, wenn er beim Ziehen über "
+  },
+  "config_autoExpandOnLongHoverDelay_after": {
+    "message": " ms schwebt"
+  },
+  "config_autoExpandOnLongHoverRestoreIniitalState_label": {
+    "message": "Solche Zweige nach dem Ziehen automatisch einklappen"
+  },
+  "config_autoExpandIntelligently_label": {
+    "message": "Andere Zweige einklappen, wenn ein eingeklappter Zweig automatisch ausgeklappt wird"
+  },
+  "config_ignoreTabDropNearSidebarArea_label": {
+    "message": "Tab nicht vom Fenster trennen, wenn er in der Nähe der Seitenleiste abgelegt wird (es wird empfohlen, dies zu deaktivieren, falls \"privacy.resistFingerprinting\"=\"true\" ist)"
+  },
+  "config_more_caption": {
+    "message": "Mehr…"
+  },
+  "config_shortcuts_caption": {
+    "message": "Tastenkombinationen"
+  },
+  "config_requestPermissions_allUrls_ctrlTabTracking": {
+    "message": "Beim Umschalten zwischen Tabs mit der Tastatur eingeklappte Zweige nicht ausklappen und eingeklappte untergeordnete Tabs überspringen. (*Das Ausführen von Scripts auf den Webseiten muss erlaubt sein.)"
+  },
+  "config_autoExpandOnTabSwitchingShortcutsDelay_before": {
+    "message": "Aktiven eingeklappten Zweig ausklappen, wenn die Tab-Taste für mehr als "
+  },
+  "config_autoExpandOnTabSwitchingShortcutsDelay_after": {
+    "message": " ms gedrückt ist"
+  },
+  "config_accelKey_label": {
+    "message": "Taste für Tastenkürzel (*Muss mit der Konfiguration von \"ui.key.accelKey\" übereinstimmen):"
+  },
+  "config_accelKey_auto": {
+    "message": "Standard (macOS=⌘, andere=Strg)"
+  },
+  "config_accelKey_alt": {
+    "message": "Alt"
+  },
+  "config_accelKey_control": {
+    "message": "Strg/Control"
+  },
+  "config_accelKey_meta": {
+    "message": "Meta/⌘"
+  },
+  "config_shortcuts_resetAll": {
+    "message": "Alle Tastenkombinationen zurücksetzen"
+  },
+  "config_advanced_caption": {
+    "message": "Erweitert"
+  },
+  "config_bookmarkTreeFolderName_before": {
+    "message": "Ordnernamen für \"Lesezeichen für diesen Zweig erstellen\":"
+  },
+  "config_bookmarkTreeFolderName_after": {
+    "message": "​"
+  },
+  "config_bookmarkTreeFolderName_description": {
+    "message": "Verfügbare Platzhalter: %TITLE% (Titel des ersten Tabs), %URL% (URL des ersten Tabs), %YEAR% (Jahr, vierstellig), %MONTH% (Monat, zweistellig), %DATE% (Tag, zweistellig)\nVerfügbare Platzhalter: %TITLE% (Titel des ersten Tabs), %URL% (URL des ersten Tabs), %YEAR% (Jahr, vierstellig), %SHORT_YEAR% (Jahr, zweistellig), %MONTH% (Monat, zweistellig), %DATE% (Tag, zweistellig), %HOURS% (Stunden, zweistelling), %MINUTES% (Minute, zweistelling), %SECONDS% (Sekunden, zweistelling), %MILLISECONDS% (Millisekunden, dreistelling), %GROUP% (Titel des ersten Tabs, falls es ein Gruppentab ist - ansonsten leer), %ANY(Wert1, Wert2, ...)% (der erste erfolgreiche Wert aus der Liste)"
+  },
+  "config_defaultBookmarkParentId_label_before": {
+    "message": "Neue Lesezeichen erstellen unter"
+  },
+  "config_defaultBookmarkParentId_label_after": {
+    "message": "​"
+  },
+  "config_supportTabsMultiselect_label": {
+    "message": "Verwende Schnittstelle zur Mehrfachauswahl von Tabs um den Tab-Fokus zu steuern (*hängt von der eingebauten Einstellung von Firefox \"browser.tabs.multiselect\"=\"true\" ab)"
+  },
+  "config_undoMultipleTabsClose_label": {
+    "message": "Zuletzt geschlossene Tabs wiederherstellen, wenn einer der Tabs über den \"Geschlossener Tab wiederherstellen\" Befehl wiederhergestellt wird"
+  },
+  "config_scrollLines_label_before": {
+    "message": "Bewege "
+  },
+  "config_scrollLines_label_after": {
+    "message": "Zeilen auf oder ab beim \"Zeilenweise hoch oder runter scrollen\" Befehl"
+  },
+  "config_userStyleRules_label": {
+    "message": "User Style Sheet (Zusätzliche Stilregeln für Inhalte von Tree Style Tab, z.B. die Seitenleiste)"
+  },
+  "config_userStyleRules_description_before": {
+    "message": "Für weitere Optionen siehe "
+  },
+  "config_userStyleRules_description_link_label": {
+    "message": "Codebeispiele im TST-Wiki"
+  },
+  "config_userStyleRules_description_after": {
+    "message": "."
+  },
+  "config_userStyleRules_description_link_uri": {
+    "message": "https://github.com/piroor/treestyletab/wiki/Code-snippets-for-custom-style-rules#for-version-2x"
+  },
+  "config_userStyleRules_themeRules_description": {
+    "message": "Folgende Eigenschaften sind per \"var()\" basierend auf dem aktuellen Browser-Design verfügbar:"
+  },
+  "config_userStyleRules_themeRules_description_alphaVariations": {
+    "message": "Die Transparenz einer Farbe kann mit einem Suffix wie \"--theme-colors-tab_background_text-30\" in 10%-Schritten geändert werden (in diesem Fall 30%)"
+  },
+  "config_userStyleRules_import": {
+    "message": "Aus Datei laden"
+  },
+  "config_userStyleRules_export": {
+    "message": "Als Datei speichern"
+  },
+  "config_userStyleRules_overwrite_title": {
+    "message": "Aktuelle Style-Regeln ersetzen?"
+  },
+  "config_userStyleRules_overwrite_message": {
+    "message": "Sollen die aktuellen Style-Regeln durch die geladene Datei komplett ersetzt werden?"
+  },
+  "config_userStyleRules_overwrite_overwrite": {
+    "message": "Alles ersetzen"
+  },
+  "config_userStyleRules_overwrite_append": {
+    "message": "Am Ende anfügen"
+  },
+  "config_tooLargeUserStyleRulesCaution": {
+    "message": "Die Style-Regeln sind zu lang! Bitte kürzen."
+  },
+  "config_userStyleRulesTheme_label": {
+    "message": "Design:"
+  },
+  "config_userStyleRulesTheme_auto": {
+    "message": "Auto"
+  },
+  "config_userStyleRulesTheme_separator": {
+    "message": "-----------------"
+  },
+  "config_userStyleRulesTheme_default": {
+    "message": "Standard"
+  },
+  "config_addons_caption": {
+    "message": "Zusätzliche Funktionen über andere Erweiterungen"
+  },
+  "config_addons_description_before": {
+    "message": "Es existieren "
+  },
+  "config_addons_description_link_label": {
+    "message": "Erweiterungen, welche TST erweitern"
+  },
+  "config_addons_description_after": {
+    "message": ". Probiere sie aus, wenn Du mehr Funktionen in der Seitenleiste von TST haben möchtest."
+  },
+  "helper_addons_list_link_uri": {
+    "message": "https://github.com/piroor/treestyletab/wiki/Helper-addons-extending-functionality-of-TST"
+  },
+  "config_theme_description_before": {
+    "message": "Aktuell gibt es nur die eingebauten Designs \"Pur\", \"Seitenleiste\" und \"Hoher Kontrast\". Für weitere Designs siehe "
+  },
+  "config_theme_description_link_label": {
+    "message": "die Codebeispiele im Wiki"
+  },
+  "config_theme_description_after": {
+    "message": " für Beispiele."
+  },
+  "helper_theme_list_link_uri": {
+    "message": "https://github.com/piroor/treestyletab/wiki/Code-snippets-for-custom-style-rules#restore-old-built-in-themes"
+  },
+  "config_externaladdonpermissions_label": {
+    "message": "Berechtigungen für API-Zugriffe von anderen Erweiterungen"
+  },
+  "config_externaladdonpermissions_description": {
+    "message": "Hier zugelassene Erweiterungen erhalten Zugriff auf detaillierte Tab-Informationen und Tabs in privaten Fenstern, <em>durch die Berechtigungen von Tree Style Tab</em>, auch wenn die Berechtigungen der Erweiterung selbst durch Firefox nicht erteilt wurden. <em>Berechtigungen nicht erteilen, wenn der Erweiterung nicht vertraut wird.</em>"
+  },
+  "config_externalAddonPermissions_header_name": {
+    "message": "Name der Erweiterung"
+  },
+  "config_externalAddonPermissions_header_permissions": {
+    "message": "Zugelassene spezielle Operationen"
+  },
+  "config_externalAddonPermissions_header_incognito": {
+    "message": "Benachrichtigungen von privaten Fenstern"
+  },
+  "addon_containerBookmarks_label": {
+    "message": "Container Bookmarks"
+  },
+  "addon_containerBookmarks_uri": {
+    "message": "https://addons.mozilla.org/firefox/addon/container-bookmarks/"
+  },
+  "config_containerRedirectKey_label": {
+    "message": "Redirect Key (*Bitte den gleichen Wert setzen wie in den Einstellungen der Erweiterung):"
+  },
+  "config_debug_caption": {
+    "message": "Entwicklung"
+  },
+  "config_link_startupPage_label": {
+    "message": "Seite für ersten Start"
+  },
+  "config_link_groupPage_label": {
+    "message": "Seite für Gruppen-Tab"
+  },
+  "config_link_tabbarPage_label": {
+    "message": "Seite für Tab-Leiste"
+  },
+  "config_runTests_label": {
+    "message": "Automatischen Test starten"
+  },
+  "config_runTestsParameters_label": {
+    "message": " / Tests zum ausführen (Liste der Namen oder reguläre Ausdrücke, wie \"testInheritMutedState,/^testHidden/,...\"):"
+  },
+  "config_runBenchmark_label": {
+    "message": "Benchmark starten"
+  },
+  "config_enableLinuxBehaviors_label": {
+    "message": "Linux-spezifisches Verhalten aktivieren"
+  },
+  "config_enableMacOSBehaviors_label": {
+    "message": "macOS-spezifisches Verhalten aktivieren"
+  },
+  "config_enableWindowsBehaviors_label": {
+    "message": "Windows-spezifisches Verhalten aktivieren"
+  },
+  "config_debug_label": {
+    "message": "Testmodus"
+  },
+  "config_log_caption": {
+    "message": "Detaillierte Logs"
+  },
+  "config_logTimestamp_label": {
+    "message": "Mit Zeitstempel loggen"
+  },
+  "config_logFor_common": {
+    "message": "Logs von gemeinesamen Modulen"
+  },
+  "config_logFor_background": {
+    "message": "Logs von Hintergrundmodulen"
+  },
+  "config_logFor_sidebar": {
+    "message": "Logs von Seitenleisten-Modulen"
+  },
+  "config_loggingQueries_label": {
+    "message": "Abfrage von Tabs loggen"
+  },
+  "config_loggingConnectionMessages_label": {
+    "message": "Interne Nachrichten loggen"
+  },
+  "config_showLogsButton_label": {
+    "message": "Zeige Logs"
+  },
+  "config_simulateSVGContextFill_label": {
+    "message": "Workaround für Bug 1388193 und Bug 1421329 aktivieren um SVG-Icons zu simulieren (*Kann die CPU-Last erhöhen. Um diese Option zu deaktivieren, aktiviere \"svg.context-properties.content.enabled\" via \"about:config\", bis diese Bugs behoben sind.)"
+  },
+  "config_staticARIALabel_label": {
+    "message": "Festes ARIA Label für Tab-Elemente verwenden"
+  },
+  "config_staticARIALabel_description": {
+    "message": "*Diese Option könnte helfen, falls Tab-Elemente nach manchen Operationen von der Sprachausgabe nicht erkannt werden."
+  },
+  "config_useCachedTree_label": {
+    "message": "Zweig-Wiederherstellung mit Cache optimieren"
+  },
+  "config_useCachedTree_description": {
+    "message": "*Sollte es zu instabilem Verhalten der Baumstruktur kommen, kann es helfen, diese Einstellung zu deaktivieren und wieder zu aktivieren, um den Cache zu erneuern."
+  },
+  "config_persistCachedTree_label": {
+    "message": "Baumcache abspeichern"
+  },
+  "config_persistCachedTree_description": {
+    "message": "*Der Ladevorgang beim Start des Browsers kann optimiert werden, aber die Größe der Browsersitzung wird erhöht, und die Festplatte mehr beansprucht."
+  },
+  "config_acceleratedTabCreation_label": {
+    "message": "Operationen zu neu geöffneten Tabs beschleunigen (*HINWEIS: Du wirst unstabilies Verhalten rund um Tabs feststellen.)"
+  },
+  "config_maximumAcceptableDelayForTabDuplication_before": {
+    "message": "Das Duplizieren von Tabs abbrechen, wenn es länger als"
+  },
+  "config_maximumAcceptableDelayForTabDuplication_after": {
+    "message": "Millisekunden andauert."
+  },
+  "config_delayForDuplicatedTabDetection_label_before": {
+    "message": "Verzögerung um duplizierte Tabs zu erkennen:"
+  },
+  "config_delayForDuplicatedTabDetection_label_after": {
+    "message": "ms (erhöhen, wenn duplizierte Tabs nicht korrekt erkannt werden)"
+  },
+  "config_delayForDuplicatedTabDetection_autoDetect": {
+    "message": "Automatisch erkennen"
+  },
+  "config_delayForDuplicatedTabDetection_test": {
+    "message": "Testerkennung"
+  },
+  "config_delayForDuplicatedTabDetection_test_resultMessage": {
+    "message": "$PERCENTAGE$% erfolgreich erkannt.",
+    "placeholders": {
+      "percentage": {
+        "content": "$1",
+        "example": "50"
+      }
+    }
+  },
+  "config_labelOverflowStyle_caption": {
+    "message": "Zu lange Beschriftung von Tabs:"
+  },
+  "config_labelOverflowStyle_fade": {
+    "message": "Ausblenden (bessere Sichtbarkeit)"
+  },
+  "config_labelOverflowStyle_crop": {
+    "message": "Abschneiden mit \"..\" (bessere Leistung)"
+  },
+  "config_requestPermissions_bookmarks": {
+    "message": "Lesen und Erstellen von Lesezeichen zulassen"
+  },
+  "config_requestPermissions_bookmarks_context": {
+    "message": "Öffnen des Kontextmenüs für Lesezeichen zulassen"
+  },
+  "config_requestPermissions_tabHide": {
+    "message": "Erlaube, einzelne Tabs anzuzeigen/auszublenden (*Aus- und wieder einschalten, bevor Tests ausgeführt werden, um sicherzustellen, dass die Berechtigung gewährt wurde.)"
+  },
+  "config_requestPermissions_fallbackToToolbarButton_title": {
+    "message": "Klicke auf das \"Tree Style Tab\" Symbol in der Symbolleiste"
+  },
+  "config_requestPermissions_fallbackToToolbarButton_message": {
+    "message": "Wegen eines Bugs in Firefox, kannst du Berechtigungen nicht in diesem Menü erteilen. Bitte klicke auf das \"Tree Style Tab\" Symbol in der Symbolleiste um Berechtigungen zu erteilen."
+  },
+  "config_all_caption": {
+    "message": "Alle Einstellungen"
+  },
+  "config_terms_delimiter": {
+    "message": " "
+  },
+  "tabContextMenu_newTab_label": {
+    "message": "Neuer Ta&b"
+  },
+  "tabContextMenu_reload_label": {
+    "message": "Tab neu la&den"
+  },
+  "tabContextMenu_unblockAutoplay_label": {
+    "message": "Tab wiede&rgeben"
+  },
+  "tabContextMenu_mute_label": {
+    "message": "Tab stu&mmschalten"
+  },
+  "tabContextMenu_unmute_label": {
+    "message": "Stu&mmschaltung aufheben"
+  },
+  "tabContextMenu_pin_label": {
+    "message": "Tab an&heften"
+  },
+  "tabContextMenu_unpin_label": {
+    "message": "Ta&b ablösen"
+  },
+  "tabContextMenu_duplicate_label": {
+    "message": "Tab &klonen"
+  },
+  "tabContextMenu_selectAllTabs_label": {
+    "message": "&Alle Tabs auswählen"
+  },
+  "tabContextMenu_bookmark_label": {
+    "message": "Tab als &Lesezeichen hinzufügen"
+  },
+  "tabContextMenu_reopenInContainer_label": {
+    "message": "In Tab-&Umgebung öffnen"
+  },
+  "tabContextMenu_reopenInContainer_noContainer_label": {
+    "message": "Keine Tab-&Umgebung"
+  },
+  "tabContextMenu_moveTab_label": {
+    "message": "Tab &verschieben"
+  },
+  "tabContextMenu_moveTabToStart_label": {
+    "message": "An &Anfang verschieben"
+  },
+  "tabContextMenu_moveTabToEnd_label": {
+    "message": "An &Ende verschieben"
+  },
+  "tabContextMenu_tearOff_label": {
+    "message": "In &neues Fenster verschieben"
+  },
+  "tabContextMenu_sendTabsToDevice_label": {
+    "message": "Sen&de Tab an Geräte"
+  },
+  "tabContextMenu_sendTabsToAllDevices_label": {
+    "message": "Sen&de Tab an alle Geräte"
+  },
+  "tabContextMenu_manageSyncDevices_label": {
+    "message": "Geräte verwalten…"
+  },
+  "tabContextMenu_shareTabURL_label": {
+    "message": "&Teilen"
+  },
+  "tabContextMenu_shareTabURL_more_label": {
+    "message": "Mehr…"
+  },
+  "tabContextMenu_closeMultipleTabs_label": {
+    "message": "&Mehrere Tabs schließen"
+  },
+  "tabContextMenu_closeTabsToTop_label": {
+    "message": "Tabs nach &oben schließen"
+  },
+  "tabContextMenu_closeTabsToBottom_label": {
+    "message": "Tabs nach un&ten schließen"
+  },
+  "tabContextMenu_closeOther_label": {
+    "message": "Andere Tabs &schließen"
+  },
+  "tabContextMenu_undoClose_label": {
+    "message": "&Geschlossenen Tab wiederherstellen"
+  },
+  "tabContextMenu_undoClose_label_multiple": {
+    "message": "&Geschlossene Tabs wiederherstellen"
+  },
+  "tabContextMenu_close_label": {
+    "message": "Tab s&chließen"
+  },
+  "tabContextMenu_reload_label_multiselected": {
+    "message": "Ausgewählte Tabs neu la&den"
+  },
+  "tabContextMenu_unblockAutoplay_label_multiselected": {
+    "message": "Tab wiede&rgeben"
+  },
+  "tabContextMenu_mute_label_multiselected": {
+    "message": "Tabs st&ummschalten"
+  },
+  "tabContextMenu_unmute_label_multiselected": {
+    "message": "Stu&mmschaltung aufheben"
+  },
+  "tabContextMenu_pin_label_multiselected": {
+    "message": "Tabs an&heften"
+  },
+  "tabContextMenu_unpin_label_multiselected": {
+    "message": "Ta&bs ablösen"
+  },
+  "tabContextMenu_duplicate_label_multiselected": {
+    "message": "Tabs &klonen"
+  },
+  "tabContextMenu_moveTab_label_multiselected": {
+    "message": "Tabs &verschieben"
+  },
+  "tabContextMenu_sendTabsToDevice_label_multiselected": {
+    "message": "Sen&de %S Tabs an Gerät"
+  },
+  "tabContextMenu_reloadSelected_label": {
+    "message": "Ausgewählten Tab neula&den"
+  },
+  "tabContextMenu_reloadSelected_label_multiselected": {
+    "message": "Ausgewählte Tabs neula&den"
+  },
+  "tabContextMenu_bookmark_label_multiselected": {
+    "message": "&Lesezeichen für ausgewählte Tabs hinzufügen…"
+  },
+  "tabContextMenu_bookmarkSelected_label": {
+    "message": "&Lesezeichen für ausgewählten Tab hinzufügen…"
+  },
+  "tabContextMenu_bookmarkSelected_label_multiselected": {
+    "message": "&Lesezeichen für ausgewählte Tabs hinzufügen…"
+  },
+  "tabContextMenu_close_label_multiselected": {
+    "message": "Ausgewählte Tabs s&chließen"
+  }
 }

--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -135,7 +135,7 @@
       "progress": { "content": "$1", "example": "50" }
     }},
 
-  "blank_allUrlsPermissionRequiredMessage": { "message": "This message is here due to Firefox tried to restore a dialog which is provided by Tree Style Tab addon. Please grant the \"Access your data for all websites\" permission via the \"Permissions\" tab of Tree Style Tab's details page in the Add-on Manager, if this message is not wanted to appear anymore." },
+  "blank_allUrlsPermissionRequiredMessage": { "message": "This message is here due to Firefox tried to restore a dialog which is provided by Tree Style Tab addon. Please grant the \"Access your data for all websites\" permission via the \"Permissions\" tab of Tree Style Tab's details page in the Add-on Manager, if you don't want this message to appear anymore." },
 
   "warnOnCloseTabs_title":     { "message": "Close tabs?" },
   "warnOnCloseTabs_message":   { "message": "You are about to close $NUMBER$ tabs. Are you sure you want to continue?",
@@ -637,7 +637,7 @@
 
   "config_treeDoubleClickBehavior_caption":             { "message": "Double-click on a tab" },
   "config_treeDoubleClickBehavior_toggleCollapsed":     { "message": "Collapse/expand tree" },
-  "config_treeDoubleClickBehavior_toggleSticky":        { "message": "Stick to tab bar adges / Unstick from tab bar edges" },
+  "config_treeDoubleClickBehavior_toggleSticky":        { "message": "Stick to tab bar edges / Unstick from tab bar edges" },
   "config_treeDoubleClickBehavior_close":               { "message": "Close tab" },
   "config_treeDoubleClickBehavior_close_note":          { "message": " (*simulation of the browser's built-in behavior for \"browser.tabs.closeTabByDblclick\"=\"true\")" },
   "config_treeDoubleClickBehavior_none":                { "message": "Do nothing" },
@@ -751,7 +751,7 @@
 
   "config_bookmarkTreeFolderName_before": { "message": "Folder name for \"Bookmark this Tree\":" },
   "config_bookmarkTreeFolderName_after": { "message": "\u200b" },
-  "config_bookmarkTreeFolderName_description": { "message": "Available placeholders: %TITLE% (title of the first tab), %URL% (URL of the first tab), %YEAR% (year, four digits), %SHORT_YEAR% (year, two digits), %MONTH% (month, two digits), %DATE% (date, two digits), %HOURS% (hours, two digits), %MINUTES% (minutes, two digits), %SECONDS% (seconds, two digits), %MILLISECONDS% (milliseconds, trhee digits), %GROUP% (title of the first tab if it is group tab - otherwise blank), %ANY(value1, value2, ...)% (the first effective value from the given list)" },
+  "config_bookmarkTreeFolderName_description": { "message": "Available placeholders: %TITLE% (title of the first tab), %URL% (URL of the first tab), %YEAR% (year, four digits), %SHORT_YEAR% (year, two digits), %MONTH% (month, two digits), %DATE% (date, two digits), %HOURS% (hours, two digits), %MINUTES% (minutes, two digits), %SECONDS% (seconds, two digits), %MILLISECONDS% (milliseconds, three digits), %GROUP% (title of the first tab if it is group tab - otherwise blank), %ANY(value1, value2, ...)% (the first effective value from the given list)" },
 
   "config_defaultBookmarkParentId_label_before":  { "message": "Create new bookmarks under" },
   "config_defaultBookmarkParentId_label_after":   { "message": "\u200b" },

--- a/webextensions/_locales/ru/messages.json
+++ b/webextensions/_locales/ru/messages.json
@@ -1,829 +1,2270 @@
 {
-  "extensionName": { "message": "Tree Style Tab" },
-  "extensionDescription": { "message": "Показывает вкладки вертикальным древовидным списком." },
-
-  "sidebarTitle": { "message": "Tree Style Tab" },
-  "sidebarToggleDescription": { "message": "Переключить боковую панель \"Tree Style Tab\" " },
-
-  "command_tabMoveUp":             { "message": "Переместить текущую вкладку вверх" },
-  "command_treeMoveUp":            { "message": "Переместить текущее дерево вверх" },
-  "command_tabMoveDown":           { "message": "Переместить текущую вкладку вниз" },
-  "command_treeMoveDown":          { "message": "Переместить текущее дерево вниз" },
-  "command_focusPrevious":         { "message": "Перейти к предыдущей вкладке (развернуть дерево)" },
-  "command_focusPreviousSilently": { "message": "Перейти к предыдущей вкладке (не разворачивать дерево)" },
-  "command_focusNext":             { "message": "Перейти к следующей вкладке (развернуть дерево)" },
-  "command_focusNextSilently":     { "message": "Перейти к следующей вкладке (не разворачивать дерево)" },
-  "command_focusParent":           { "message": "Перейти к родительской вкладке" },
-  "command_focusFirstChild":       { "message": "Перейти к первой дочерней вкладке" },  
-  "command_focusLastChild":        { "message": "Фокус на последнюю дочернюю вкладку" },
-  "command_focusPreviousSibling":  { "message": "Фокус на предыдущую одноуровневую вкладку" },
-  "command_focusNextSibling":      { "message": "Фокус на следующую одноуровневую вкладку" },
-  "command_tabbarUp":              { "message": "Листать вкладки вверх построчно" },
-  "command_tabbarPageUp":          { "message": "Листать вкладки вверх постранично" },
-  "command_tabbarHome":            { "message": "Листать вкладки вверх" },
-  "command_tabbarDown":            { "message": "Листать вкладки вниз построчно" },
-  "command_tabbarPageDown":        { "message": "Листать вкладки вниз постранично" },
-  "command_tabbarEnd":             { "message": "Листать вкладки вниз" },
-  "command_toggleSubPanel":        { "message": "Переключить суб-панель" },
-  "command_switchSubPanel":        { "message": "Переключить содержимое суб-панели" },
-  "command_increaseSubPanel":      { "message": "Увеличить размер суб-панели" },
-  "command_decreaseSubPanel":      { "message": "Уменьшить размер суб-панели" },
-
-  "tab_closebox_aria_label": { "message": "Закрыть вкладку #$ID$",
+  "extensionName": {
+    "message": "Tree Style Tab"
+  },
+  "extensionDescription": {
+    "message": "Показывает вкладки вертикальным древовидным списком."
+  },
+  "sidebarTitle": {
+    "message": "Tree Style Tab"
+  },
+  "sidebarToggleDescription": {
+    "message": "Переключить боковую панель \"Tree Style Tab\" "
+  },
+  "command_tabMoveUp": {
+    "message": "Переместить текущую вкладку выше"
+  },
+  "command_treeMoveUp": {
+    "message": "Переместить текущее дерево выше"
+  },
+  "command_tabMoveDown": {
+    "message": "Переместить текущую вкладку ниже"
+  },
+  "command_treeMoveDown": {
+    "message": "Переместить текущее дерево ниже"
+  },
+  "command_focusPrevious": {
+    "message": "Перейти к предыдущей вкладке (развернуть дерево)"
+  },
+  "command_focusPreviousSilently": {
+    "message": "Перейти к предыдущей вкладке (не разворачивать дерево)"
+  },
+  "command_focusNext": {
+    "message": "Перейти к следующей вкладке (развернуть дерево)"
+  },
+  "command_focusNextSilently": {
+    "message": "Перейти к следующей вкладке (не разворачивать дерево)"
+  },
+  "command_focusParent": {
+    "message": "Перейти к родительской вкладке"
+  },
+  "command_focusFirstChild": {
+    "message": "Перейти к первой дочерней вкладке"
+  },
+  "command_focusLastChild": {
+    "message": "Перейти на последнюю дочернюю вкладку"
+  },
+  "command_focusPreviousSibling": {
+    "message": "Перейти на предыдущую одноуровневую вкладку"
+  },
+  "command_focusNextSibling": {
+    "message": "Фокус на следующую одноуровневую вкладку"
+  },
+  "command_tabbarUp": {
+    "message": "Листать вкладки вверх построчно"
+  },
+  "command_tabbarPageUp": {
+    "message": "Листать вкладки вверх постранично"
+  },
+  "command_tabbarHome": {
+    "message": "Листать вкладки в самый верх"
+  },
+  "command_tabbarDown": {
+    "message": "Листать вкладки вниз построчно"
+  },
+  "command_tabbarPageDown": {
+    "message": "Листать вкладки вниз постранично"
+  },
+  "command_tabbarEnd": {
+    "message": "Листать вкладки в самый низ"
+  },
+  "command_toggleTreeCollapsed": {
+    "message": "Переключить сворачивание дерева"
+  },
+  "command_toggleTreeCollapsedRecursively": {
+    "message": "Переключить рекурсивное сворачивание дерева"
+  },
+  "command_toggleSubPanel": {
+    "message": "Переключить суб-панель"
+  },
+  "command_switchSubPanel": {
+    "message": "Переключить содержимое суб-панели"
+  },
+  "command_increaseSubPanel": {
+    "message": "Увеличить размер суб-панели"
+  },
+  "command_decreaseSubPanel": {
+    "message": "Уменьшить размер суб-панели"
+  },
+  "tab_closebox_aria_label": {
+    "message": "Закрыть вкладку #$ID$",
     "placeholders": {
-      "id": { "content": "$1", "example": "1" }
-    }},
-  "tab_closebox_tab_tooltip": { "message": "Закрыть вкладку" },
-  "tab_closebox_tab_tooltip_multiselected": { "message": "Закрыть вкладки" },
-  "tab_closebox_tree_tooltip": { "message": "Закрыть дерево" },
-  "tab_soundButton_aria_label": { "message": "Выключить звук вкладки #$ID$",
+      "id": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "tab_closebox_tab_tooltip": {
+    "message": "Закрыть вкладку"
+  },
+  "tab_closebox_tab_tooltip_multiselected": {
+    "message": "Закрыть вкладки"
+  },
+  "tab_closebox_tree_tooltip": {
+    "message": "Закрыть дерево"
+  },
+  "tab_soundButton_aria_label": {
+    "message": "Выключить звук вкладки #$ID$",
     "placeholders": {
-      "id": { "content": "$1", "example": "1" }
-    }},
-  "tab_soundButton_muted_tooltip": { "message": "Включить звук вкладки" },
-  "tab_soundButton_muted_tooltip_multiselected": { "message": "Включить звук вкладок" },
-  "tab_soundButton_playing_tooltip": { "message": "Выключить звук вкладки" },
-  "tab_soundButton_playing_tooltip_multiselected": { "message": "Выключить звук вкладок" },
-  "tab_twisty_aria_label": { "message": "Свернуть/развернуть дерево #$ID$",
+      "id": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "tab_sharingState_sharingCamera_tooltip": {
+    "message": "Дается доступ к камере"
+  },
+  "tab_sharingState_sharingMicrophone_tooltip": {
+    "message": "Дается доступ к микрофону"
+  },
+  "tab_sharingState_sharingScreen_tooltip": {
+    "message": "Дается доступ к окну или экрану"
+  },
+  "tab_soundButton_muted_tooltip": {
+    "message": "Включить звук вкладки"
+  },
+  "tab_soundButton_muted_tooltip_multiselected": {
+    "message": "Включить звук вкладок"
+  },
+  "tab_soundButton_playing_tooltip": {
+    "message": "Выключить звук вкладки"
+  },
+  "tab_soundButton_playing_tooltip_multiselected": {
+    "message": "Выключить звук вкладок"
+  },
+  "tab_soundButton_autoplayBlocked_tooltip": {
+    "message": "Воспроизведение вкладки"
+  },
+  "tab_soundButton_autoplayBlocked_tooltip_multiselected": {
+    "message": "Воспроизведение вкладок"
+  },
+  "tab_twisty_aria_label": {
+    "message": "Свернуть/развернуть дерево #$ID$",
     "placeholders": {
-      "id": { "content": "$1", "example": "1" }
-    }},
-  "tab_twisty_expanded_tooltip": { "message": "Свернуть дерево" },
-  "tab_twisty_collapsed_tooltip": { "message": "Развернуть дерево" },
-  "tab_tree_tooltip": { "message": "$TREE$\n  ...и больше $COUNT$ вкладок",
+      "id": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "tab_twisty_expanded_tooltip": {
+    "message": "Свернуть дерево"
+  },
+  "tab_twisty_collapsed_tooltip": {
+    "message": "Развернуть дерево"
+  },
+  "tab_tree_tooltip": {
+    "message": "$TREE$\n  ...и больше $COUNT$ вкладок",
     "placeholders": {
-      "tree": { "content": "$1", "example": "* Tree\n  * Style\n    * Tab" },
-      "count": { "content": "$2", "example": "3" }
-    }},
-  "tabbar_newTabButton_tooltip": { "message": "Открыть новую вкладку" },
-
-  "tabbar_newTabAction_tooltip":           { "message": "Открыть новую вкладку как…" },
-  "tabbar_newTabAction_independent_label": { "message": "Отдельную вкладку" },
-  "tabbar_newTabAction_independent_command": { "message": "Отдельную вкладку" },
-  "tabbar_newTabAction_child_label":       { "message": "Дочернюю вкладку" },
-  "tabbar_newTabAction_child_command":       { "message": "Дочернюю вкладку" },
-  "tabbar_newTabAction_sibling_label":     { "message": "Одноуровневую вкладку" },
-  "tabbar_newTabAction_sibling_command":     { "message": "Одноуровневую вкладку" },
-  "tabbar_newTabAction_nextSibling_label": { "message": "Следующую одноуровневую вкладку" },
-  "tabbar_newTabAction_nextSibling_command": { "message": "Следующую одноуровневую вкладку" },
-
-  "tabbar_newTabWithContexualIdentity_tooltip": { "message": "Новая вкладка контейнера" },
-  "tabbar_newTabWithContexualIdentity_default": { "message": "Переоткрыть &без контейнера" },
-
-  "groupTab_label": { "message": "$TITLE$ и больше",
+      "tree": {
+        "content": "$1",
+        "example": "* Tree\n  * Style\n    * Tab"
+      },
+      "count": {
+        "content": "$2",
+        "example": "3"
+      }
+    }
+  },
+  "tabbar_newTabButton_tooltip": {
+    "message": "Открыть новую вкладку"
+  },
+  "tabbar_newTabAction_tooltip": {
+    "message": "Открыть новую вкладку как…"
+  },
+  "tabbar_newTabAction_independent_label": {
+    "message": "Отдельную вкладку"
+  },
+  "tabbar_newTabAction_independent_command": {
+    "message": "Отдельную вкладку"
+  },
+  "tabbar_newTabAction_child_label": {
+    "message": "Дочернюю вкладку"
+  },
+  "tabbar_newTabAction_child_command": {
+    "message": "Дочернюю вкладку"
+  },
+  "tabbar_newTabAction_childTop_command": {
+    "message": "Первая дочерняя вкладка"
+  },
+  "tabbar_newTabAction_childEnd_command": {
+    "message": "Последняя дочерняя вкладка"
+  },
+  "tabbar_newTabAction_sibling_label": {
+    "message": "Одноуровневую вкладку"
+  },
+  "tabbar_newTabAction_sibling_command": {
+    "message": "Одноуровневую вкладку"
+  },
+  "tabbar_newTabAction_nextSibling_label": {
+    "message": "Следующую одноуровневую вкладку"
+  },
+  "tabbar_newTabAction_nextSibling_command": {
+    "message": "Следующую одноуровневую вкладку"
+  },
+  "tabbar_newTabWithContexualIdentity_tooltip": {
+    "message": "Новая вкладка контейнера"
+  },
+  "tabbar_newTabWithContexualIdentity_default": {
+    "message": "Переоткрыть &без контейнера"
+  },
+  "groupTab_label": {
+    "message": "$TITLE$ и больше",
     "placeholders": {
-      "title": { "content": "$1", "example": "title" }
-    }},
-  "groupTab_label_default": { "message": "Группа" },
-  "groupTab_temporary_label": { "message": "Закрыть эту вкладку, когда не останется дочерних вкладок" },
-  "groupTab_temporaryAggressive_label": { "message": "Закрыть эту вкладку, когда одна или нет дочерних вкладок" },
-  "groupTab_fromPinnedTab_label": { "message": "Вкладки с $TITLE$",
+      "title": {
+        "content": "$1",
+        "example": "title"
+      }
+    }
+  },
+  "groupTab_label_default": {
+    "message": "Группа"
+  },
+  "groupTab_temporary_label": {
+    "message": "Закрыть эту вкладку, когда не останется дочерних вкладок"
+  },
+  "groupTab_temporaryAggressive_label": {
+    "message": "Закрыть эту вкладку, когда дочерних вкладок нету или одна"
+  },
+  "groupTab_fromPinnedTab_label": {
+    "message": "Вкладки с $TITLE$",
     "placeholders": {
-      "title": { "content": "$1", "example": "title" }
-    }},
-  "groupTab_options_label": { "message": "Вы можете отключить открытие вкладки этого типа." },
-  "groupTab_options_dismiss": { "message": "Отключить подсказку" },
-
-  "bookmarkFolder_label_default": { "message": "%ANY(\"%GROUP%\", \"$TITLE$ и больше\")% (%YEAR%.%MONTH%.%DATE%)",
+      "title": {
+        "content": "$1",
+        "example": "title"
+      }
+    }
+  },
+  "groupTab_options_label": {
+    "message": "Вы можете отключить открытие вкладки этого типа."
+  },
+  "groupTab_options_dismiss": {
+    "message": "Отключить подсказку"
+  },
+  "bookmarkFolder_label_default": {
+    "message": "%ANY(\"%GROUP%\", \"$TITLE$ и больше\")% (%YEAR%.%MONTH%.%DATE%)",
     "placeholders": {
-      "title": { "content": "$1", "example": "Title" }
-    }},
-
-  "bookmark_notification_notPermitted_title": { "message": "Ошибка разрешений" },
-  "bookmark_notification_notPermitted_message": { "message": "Нет разрешения на создание закладок. Нажмите здесь, чтобы предоставить разрешения." },
-  "bookmark_notification_notPermitted_message_linux": { "message": "Не удалось получить разрешение на создание закладок. Нажмите кнопку, чтобы предоставить дополнительные разрешения." },
-
-  "bookmarkContext_notification_notPermitted_title": { "message": "Ошибка разрешения" },
-  "bookmarkContext_notification_notPermitted_message": { "message": "Нет разрешения на открытие контекстного меню закладок. Нажмите здесь, чтобы предоставить дополнительное разрешение." },
-  "bookmarkContext_notification_notPermitted_message_linux": { "message": "Не удалось получить разрешение на открытие контекстного меню закладок. Нажмите кнопку, чтобы предоставить дополнительные разрешения." },
-
-  "dropLinksOnTabBehavior_message": { "message": "Как это открыть?" },
-  "dropLinksOnTabBehavior_save":    { "message": "Всегда выбирать этот вариант" },
-  "dropLinksOnTabBehavior_load":    { "message": "Загрузить в этой вкладке" },
-  "dropLinksOnTabBehavior_newtab":  { "message": "Открыть новую дочернюю вкладку" },
-
-  "tabDragBehaviorNotification_message_duration_single":  { "message": "8s" },
-  "tabDragBehaviorNotification_message_duration_both":  { "message": "16s" },
-  "tabDragBehaviorNotification_message_base":  { "message": "Перетягивание за пределы боковой панели $RESULT$.",
+      "title": {
+        "content": "$1",
+        "example": "Title"
+      }
+    }
+  },
+  "bookmark_notification_notPermitted_title": {
+    "message": "Ошибка разрешения"
+  },
+  "bookmark_notification_notPermitted_message": {
+    "message": "Нет разрешения на создание закладок. Нажмите здесь, чтобы предоставить разрешения."
+  },
+  "bookmark_notification_notPermitted_message_linux": {
+    "message": "Не удалось получить разрешение на создание закладок. Нажмите кнопку, чтобы предоставить дополнительные разрешения."
+  },
+  "bookmarkContext_notification_notPermitted_title": {
+    "message": "Ошибка разрешения"
+  },
+  "bookmarkContext_notification_notPermitted_message": {
+    "message": "Нет разрешения на открытие контекстного меню закладок. Нажмите здесь, чтобы предоставить дополнительные разрешения."
+  },
+  "bookmarkContext_notification_notPermitted_message_linux": {
+    "message": "Не удалось получить разрешение на открытие контекстного меню закладок. Нажмите кнопку, чтобы предоставить дополнительные разрешения."
+  },
+  "dropLinksOnTabBehavior_message": {
+    "message": "Как это открыть?"
+  },
+  "dropLinksOnTabBehavior_save": {
+    "message": "Всегда выбирать этот вариант"
+  },
+  "dropLinksOnTabBehavior_load": {
+    "message": "Загрузить в этой вкладке"
+  },
+  "dropLinksOnTabBehavior_newtab": {
+    "message": "Открыть новую дочернюю вкладку"
+  },
+  "tabDragBehaviorNotification_message_duration_single": {
+    "message": "8с"
+  },
+  "tabDragBehaviorNotification_message_duration_both": {
+    "message": "16с"
+  },
+  "tabDragBehaviorNotification_message_base": {
+    "message": "Перетягивание за пределы боковой панели $RESULT$.",
     "placeholders": {
-      "result": { "content": "$1", "example": "something happen" }
-    }},
-  "tabDragBehaviorNotification_message_inverted_base_with_shift":  { "message": "C зажатым Shift $RESULT$.",
+      "result": {
+        "content": "$1",
+        "example": "something happen"
+      }
+    }
+  },
+  "tabDragBehaviorNotification_message_inverted_base_with_shift": {
+    "message": "C зажатым Shift будет $RESULT$.",
     "placeholders": {
-      "result": { "content": "$1", "example": "something happen" }
-    }},
-  "tabDragBehaviorNotification_message_inverted_base_without_shift":  { "message": "Без Shift'a $RESULT$.",
+      "result": {
+        "content": "$1",
+        "example": "something happen"
+      }
+    }
+  },
+  "tabDragBehaviorNotification_message_inverted_base_without_shift": {
+    "message": "Без Shift'a будет $RESULT$.",
     "placeholders": {
-      "result": { "content": "$1", "example": "something happen" }
-    }},
-  "tabDragBehaviorNotification_message_tree_tearoff":  { "message": "отсоеденит вкладки от окна" },
-  "tabDragBehaviorNotification_message_tab_tearoff":   { "message": "отсоеденит вкладку от окна" },
-  "tabDragBehaviorNotification_message_tree_bookmark": { "message": "создаст ссылку или закладку там где вы отпустите вкладки" },
-  "tabDragBehaviorNotification_message_tab_bookmark":  { "message": "создаст ссылку или закладку там где вы отпустите вкладку" },
-
-  "warnOnCloseTabs_title":     { "message": "Закрыть вкладки?" },
-  "warnOnCloseTabs_message":   { "message": "Вы пытаетесь закрыть $NUMBER$ вкладок. Хотите продолжить?",
+      "result": {
+        "content": "$1",
+        "example": "something happen"
+      }
+    }
+  },
+  "tabDragBehaviorNotification_message_tree_tearoff": {
+    "message": "отсоединит вкладки от окна"
+  },
+  "tabDragBehaviorNotification_message_tab_tearoff": {
+    "message": "отсоединит вкладку от окна"
+  },
+  "tabDragBehaviorNotification_message_tree_bookmark": {
+    "message": "создаст ссылку или закладку там где вы отпустите вкладки"
+  },
+  "tabDragBehaviorNotification_message_tab_bookmark": {
+    "message": "создаст ссылку или закладку там где вы отпустите вкладку"
+  },
+  "tabsHighlightingNotification_message": {
+    "message": "Подсвечивание вкладок... $PROGRESS$ %",
     "placeholders": {
-      "NUMBER": { "content": "$1", "example": "10" }
-    }},
-  "warnOnCloseTabs_warnAgain": { "message": "Предупреждать при закрытии нескольких вкладок" },
-  "warnOnCloseTabs_close":     { "message": "Закрыть вкладки" },
-  "warnOnCloseTabs_cancel":    { "message": "Отмена" },
-
-  "warnOnCloseTabs_fromOutside_title":     { "message": "Закрыть с дочерними?" },
-  "warnOnCloseTabs_fromOutside_message":   { "message": "Закрытая вкладка имела $NUMBER$ дочерних. Их тоже закрыть?\n( * Отмена восстановит закрытую родительскую вкладку.)",
+      "progress": {
+        "content": "$1",
+        "example": "50"
+      }
+    }
+  },
+  "blank_allUrlsPermissionRequiredMessage": {
+    "message": "Это сообщение показывается, потому что Firefox попытался восстановить окно, которое создается расширением Tree Style Tab. Пожалуйста, разрешите \"Доступ к данным всех вебсайтов\" через вкладку \"Разрешения\" у расширения Tree Style Tab в Менеджере Расширений, если не хотите повторного появления этого сообщения."
+  },
+  "warnOnCloseTabs_title": {
+    "message": "Закрыть вкладки?"
+  },
+  "warnOnCloseTabs_message": {
+    "message": "Вы пытаетесь закрыть $NUMBER$ вкладок. Хотите продолжить?",
     "placeholders": {
-      "NUMBER": { "content": "$1", "example": "10" }
-    }},
-
-  "warnOnCloseTabs_notification_message": { "message": "Если нет, то нажмите здесь, чтобы отменить операцию.\nИначе остальные вкладки закроются через $TIMEOUT$ секунд.",
+      "NUMBER": {
+        "content": "$1",
+        "example": "10"
+      }
+    }
+  },
+  "warnOnCloseTabs_warnAgain": {
+    "message": "Предупреждать при закрытии нескольких вкладок"
+  },
+  "warnOnCloseTabs_close": {
+    "message": "Закрыть вкладки"
+  },
+  "warnOnCloseTabs_cancel": {
+    "message": "Отмена"
+  },
+  "warnOnCloseTabs_fromOutside_title": {
+    "message": "Закрыть с дочерними?"
+  },
+  "warnOnCloseTabs_fromOutside_message": {
+    "message": "Закрытая вкладка имела $NUMBER$ дочерних. Их тоже закрыть?\n( * Отмена восстановит закрытую родительскую вкладку.)",
     "placeholders": {
-      "TIMEOUT": { "content": "$1", "example": "10" }
-    }},
-  "warnOnCloseTabs_notification_message_linux": { "message": "Если нет, то нажмите кнопку, чтобы отменить операцию.\nИначе остальные вкладки закроются через $TIMEOUT$ секунд.",
+      "NUMBER": {
+        "content": "$1",
+        "example": "10"
+      }
+    }
+  },
+  "warnOnCloseTabs_notification_message": {
+    "message": "Если нет, то нажмите здесь, чтобы отменить операцию.\nИначе остальные вкладки закроются через $TIMEOUT$ секунд.",
     "placeholders": {
-      "TIMEOUT": { "content": "$1", "example": "10" }
-    }},
-
-  "warnOnAutoGroupNewTabs_title":     { "message": "Группировать вкладки?" },
-  "warnOnAutoGroupNewTabs_message":   { "message": "$NUMBER$ вкладок открываются одновременно. Сгруппировать их в дерево?",
+      "TIMEOUT": {
+        "content": "$1",
+        "example": "10"
+      }
+    }
+  },
+  "warnOnCloseTabs_notification_message_linux": {
+    "message": "Если нет, то нажмите кнопку, чтобы отменить операцию.\nИначе остальные вкладки закроются через $TIMEOUT$ секунд.",
     "placeholders": {
-      "NUMBER": { "content": "$1", "example": "10" }
-    }},
-  "warnOnAutoGroupNewTabs_warnAgain": { "message": "Справшивать при открытии нескольких вкладок" },
-  "warnOnAutoGroupNewTabs_close":     { "message": "Группировать" },
-  "warnOnAutoGroupNewTabs_cancel":    { "message": "Не группировать" },
-
-  "bookmarkDialog_dialogTitle_single":   { "message": "Новая закладка" },
-  "bookmarkDialog_dialogTitle_multiple": { "message": "Новые закладки" },
-  "bookmarkDialog_title":    { "message": "Заголовок . :" },
-  "bookmarkDialog_title_accessKey": { "message": "n" },
-  "bookmarkDialog_url":      { "message": "Адрес:" },
-  "bookmarkDialog_url_accessKey": { "message": "l" },
-  "bookmarkDialog_parentId": { "message": "Папка . . . . . :" },
-  "bookmarkDialog_saveContainerRedirectKey": { "message": "Сохранить информацию о контейнере для закладок из контейнера" },
-  "bookmarkDialog_accept":   { "message": "Сохранить" },
-  "bookmarkDialog_cancel":   { "message": "Отмена" },
-
-  "bookmarkFolderChooser_unspecified":   { "message": "(не определено)" },
-  "bookmarkFolderChooser_blank":         { "message": "(без имени)" },
-  "bookmarkFolderChooser_useThisFolder": { "message": "Использовать эту папку" },
-
-  "syncDeviceDefaultName": { "message": "$BROWSER$ on $PLATFORM$",
+      "TIMEOUT": {
+        "content": "$1",
+        "example": "10"
+      }
+    }
+  },
+  "warnOnAutoGroupNewTabs_title": {
+    "message": "Группировать вкладки?"
+  },
+  "warnOnAutoGroupNewTabs_message": {
+    "message": "$NUMBER$ вкладок открываются одновременно. Сгруппировать их в дерево?",
     "placeholders": {
-      "PLATFORM": { "content": "$1", "example": "Firefox" },
-      "BROWSER":  { "content": "$2", "example": "Windows" }
-    }},
-  "syncDeviceMissingDeviceName": { "message": "безымянное устройство" },
-  "syncDeviceUnknownDevice":     { "message": "неизвестное устройство" },
-  "syncAvailable_notification_title":   { "message": "Теперь вкладки можно отправлять на другие устройства с TST." },
-  "syncAvailable_notification_message": { "message": "Вкладки можно переносить между вашими устройствами. Нажмите кнопку, чтобы присвоить этому устройству уникальное имя." },
-  "syncAvailable_notification_message_linux": { "message": "Вкладки можно переносить между вашими устройствами. Нажмите кнопку, чтобы присоить этому устройству уникальное имя." },
-  "sentTabs_notification_title":            { "message": "\u200b" },
-  "sentTabs_notification_message":          { "message": "Вкладки отправлены на $DEVICE$",
+      "NUMBER": {
+        "content": "$1",
+        "example": "10"
+      }
+    }
+  },
+  "warnOnAutoGroupNewTabs_warnAgain": {
+    "message": "Справшивать при открытии нескольких вкладок"
+  },
+  "warnOnAutoGroupNewTabs_close": {
+    "message": "Группировать"
+  },
+  "warnOnAutoGroupNewTabs_cancel": {
+    "message": "Не группировать"
+  },
+  "bookmarkDialog_dialogTitle_single": {
+    "message": "Новая закладка"
+  },
+  "bookmarkDialog_dialogTitle_multiple": {
+    "message": "Новые закладки"
+  },
+  "bookmarkDialog_title": {
+    "message": "Заголовок:"
+  },
+  "bookmarkDialog_title_accessKey": {
+    "message": "n"
+  },
+  "bookmarkDialog_url": {
+    "message": "Адрес:"
+  },
+  "bookmarkDialog_url_accessKey": {
+    "message": "l"
+  },
+  "bookmarkDialog_parentId": {
+    "message": "Папка:"
+  },
+  "bookmarkDialog_saveContainerRedirectKey": {
+    "message": "Сохранить информацию о контейнере для закладок из контейнера"
+  },
+  "bookmarkDialog_accept": {
+    "message": "Сохранить"
+  },
+  "bookmarkDialog_cancel": {
+    "message": "Отмена"
+  },
+  "bookmarkFolderChooser_unspecified": {
+    "message": "(не задано)"
+  },
+  "bookmarkFolderChooser_blank": {
+    "message": "(без имени)"
+  },
+  "bookmarkFolderChooser_useThisFolder": {
+    "message": "Использовать эту папку"
+  },
+  "syncDeviceDefaultName": {
+    "message": "$BROWSER$ on $PLATFORM$",
     "placeholders": {
-      "DEVICE": { "content": "$1", "example": "Firefox на устройстве X" }
-    }},
-  "sentTabs_notification_title_multiple":   { "message": "\u200b" },
-  "sentTabs_notification_message_multiple": { "message": "Вкладки отправлены на $DEVICE$",
+      "PLATFORM": {
+        "content": "$1",
+        "example": "Firefox"
+      },
+      "BROWSER": {
+        "content": "$2",
+        "example": "Windows"
+      }
+    }
+  },
+  "syncDeviceMissingDeviceName": {
+    "message": "безымянное устройство"
+  },
+  "syncDeviceUnknownDevice": {
+    "message": "неизвестное устройство"
+  },
+  "syncAvailable_notification_title": {
+    "message": "Теперь вкладки можно отправлять на другие устройства с TST."
+  },
+  "syncAvailable_notification_message": {
+    "message": "Вкладки можно переносить между вашими устройствами. Нажмите кнопку, чтобы присвоить этому устройству уникальное имя."
+  },
+  "syncAvailable_notification_message_linux": {
+    "message": "Вкладки можно переносить между вашими устройствами. Нажмите кнопку, чтобы присоить этому устройству уникальное имя."
+  },
+  "sentTabs_notification_title": {
+    "message": "​"
+  },
+  "sentTabs_notification_message": {
+    "message": "Вкладки отправлены на $DEVICE$",
     "placeholders": {
-      "DEVICE": { "content": "$1", "example": "Firefox на устройстве X" }
-    }},
-  "sentTabsToAllDevices_notification_title":            { "message": "\u200b" },
-  "sentTabsToAllDevices_notification_message":          { "message": "Вкладка отправлена на все устройства" },
-  "sentTabsToAllDevices_notification_title_multiple":   { "message": "\u200b" },
-  "sentTabsToAllDevices_notification_message_multiple": { "message": "Вкладки отправлены на все устройства" },
-  "receiveTabs_notification_title":            { "message": "Вкладка из $DEVICE$",
+      "DEVICE": {
+        "content": "$1",
+        "example": "Firefox on Device X"
+      }
+    }
+  },
+  "sentTabs_notification_title_multiple": {
+    "message": "​"
+  },
+  "sentTabs_notification_message_multiple": {
+    "message": "Вкладки отправлены на $DEVICE$",
     "placeholders": {
-      "DEVICE": { "content": "$1", "example": "Firefox на устройстве X" }
-    }},
-  "receiveTabs_notification_message":          { "message": "$URL$",
+      "DEVICE": {
+        "content": "$1",
+        "example": "Firefox on Device X"
+      }
+    }
+  },
+  "sentTabsToAllDevices_notification_title": {
+    "message": "​"
+  },
+  "sentTabsToAllDevices_notification_message": {
+    "message": "Вкладка отправлена на все устройства"
+  },
+  "sentTabsToAllDevices_notification_title_multiple": {
+    "message": "​"
+  },
+  "sentTabsToAllDevices_notification_message_multiple": {
+    "message": "Вкладки отправлены на все устройства"
+  },
+  "receiveTabs_notification_title": {
+    "message": "Вкладка из $DEVICE$",
     "placeholders": {
-      "URL": { "content": "$1", "example": "http://example.com/" }
-    }},
-  "receiveTabs_notification_title_multiple":   { "message": "Вкладки из $DEVICE$",
+      "DEVICE": {
+        "content": "$1",
+        "example": "Firefox on Device X"
+      }
+    }
+  },
+  "receiveTabs_notification_message": {
+    "message": "$URL$",
     "placeholders": {
-      "DEVICE": { "content": "$1", "example": "Firefox на устройстве X" }
-    }},
-  "receiveTabs_notification_message_multiple": { "message": "$URL$\nи $REST$ других вкладок",
+      "URL": {
+        "content": "$1",
+        "example": "http://example.com/"
+      }
+    }
+  },
+  "receiveTabs_notification_title_multiple": {
+    "message": "Вкладки из $DEVICE$",
     "placeholders": {
-      "URL": { "content": "$1", "example": "http://example.com/" },
-      "ALL": { "content": "$2", "example": "4" },
-      "REST": { "content": "$3", "example": "3" }
-    }},
-
-  "sidebarPositionRighsideNotification_message":   { "message": "TST определил положение панели как \"Справа\". Хотите переключить вид панели для этого положения?" },
-  "sidebarPositionRighsideNotification_rightside": { "message": "Применить вид для положения Справа" },
-  "sidebarPositionRighsideNotification_leftside":  { "message": "Сохранить вид для положения Слева" },
-
-  "sidebarPositionOptionNotification_title":   { "message": "Внешний вид для положения панели сохранен" },
-  "sidebarPositionOptionNotification_message": { "message": "Это можно изменить в секцим настроек TST \"Внешний вид\"." },
-
-  "startup_notification_title_installed":   { "message": "Новым пользователям Tree Style Tab" },
-  "startup_notification_message_installed": { "message": "Дополнительные разрешения требуются для взаимодействия с пользователем. Щелкните здесь, чтобы предоставить их." },
-  "startup_notification_message_installed_linux": { "message": "Для более естественного взаимодействия с пользователем требуются некоторые дополнительные разрешения. Нажмите кнопку, чтобы предоставить их." },
-  "startup_notification_title_updated":     { "message": "Изменения в Tree Style Tab" },
-  "startup_notification_message_updated":   { "message": "Изменения могут повлиять на ваши предпочтения. Щелкните здесь, чтобы увидеть описания." },
-  "startup_notification_message_updated_linux":   { "message": "Некоторые изменения могут повлиять на ваши предпочтения. Нажмите кнопку, чтобы посмотреть список изменений." },
-
-  "message_startup_description_1": { "message": "Tree Style Tab возрожден на основе технологий WebExtensions для Firefox 57 и более поздних версий. Вертикальная панель вкладок доступна в качестве одной из боковых панелей. Если вы ещё не видите её, нажмите " },
-  "message_startup_description_key": { "message": "кнопку \"F1\" " },
-  "message_startup_description_2": { "message": " либо " },
-  "message_startup_description_3": { "message": " кнопку на панели инструментов, чтобы активировать боковую панель." },
-  "message_startup_description_sync_before": { "message": "Вкладки можно отправлять через Firefox Sync только на устройства с установленным TST. Сначала активируйте Firefox Sync в настройках Firefox и установите TST на другие устройства." },
-  "message_startup_description_sync_link":   { "message": "Имя устройства нужно настраивать вручную" },
-  "message_startup_description_sync_after":  { "message": "." },
-
-  "message_startup_history_before":     { "message": "Измененное поведение может быть (или нет) восстановлено с помощью вариантов обхода. См. детали в " },
-  "message_startup_history_uri":        { "message": "https://addons.mozilla.org/firefox/addon/tree-style-tab/versions/" },
-  "message_startup_history_link_label": { "message": "истории изменений" },
-  "message_startup_history_after":      { "message": "." },
-
-  "message_startup_requestPermissions_description": { "message": "⚠Есть некоторые функции, требующие дополнительных разрешений. Если вы хотите активировать их, получите разрешения вручную." },
-  "message_startup_requestPermissions_bookmarks": { "message": "\"Это дерево в закладки…\" в контекстном меню на вкладках (нужен доступ к закладкам.)" },
-  "message_startup_requestPermissions_allUrls":   { "message": "Не разворачивать свернутое дерево и пропускать свернутые дочерние вкладки при переключении фокуса вкладок горячими клавишами. / Don't restore blank window which was for a closed dialog, by actions to restore closed tabs." },
-
-  "message_startup_userChromeCss_notify": { "message": "Как скрыть верхнюю панель вкладок и заголовок боковой панели?" },
-  "message_startup_userChromeCss_description_1": { "message": "Из-за ограничений WebExtensions, TST не может контролировать верхнюю панель вкладок и заголовок боковой панели. Если вам нужно настроить их, см. " },
-  "message_startup_userChromeCss_description_link_label": { "message": "примеры настройки с помощью userChrome.css" },
-  "message_startup_userChromeCss_description_link_uri": { "message": "https://github.com/piroor/treestyletab/wiki/Code-snippets-for-custom-style-rules#for-userchromecss" },
-  "message_startup_userChromeCss_description_2": { "message": ". Но " },
-  "message_startup_userChromeCss_description_note": { "message": "учтите, что это низкоуровневые настройки, и они могут вызвать проблемы в будущих версиях Firefox. Используйте их на свой страх и риск, если уверены, что сможете потом решить проблемы самостоятельно" },
-  "message_startup_userChromeCss_description_3": { "message": "." },
-
-  "api_requestedPermissions_title": { "message": "Запрос дополнительных разрешений" },
-  "api_requestedPermissions_message": { "message": "⚠Аддон \"$NAME$\" запрашивает выполнение операции:\n\n$PERMISSIONS$\n\nЧерез API Tree Style Tab. Нажмите здесь, чтобы предоставить разрешение.",
+      "DEVICE": {
+        "content": "$1",
+        "example": "Firefox on Device X"
+      }
+    }
+  },
+  "receiveTabs_notification_message_multiple": {
+    "message": "$URL$\nи $REST$ других вкладок",
     "placeholders": {
-      "NAME":        { "content": "$1", "example": "foobar" },
-      "PERMISSIONS": { "content": "$2", "example": "tabs" }
-    }},
-  "api_requestedPermissions_message_linux": { "message": "⚠Аддон \"$NAME$\" запрашивает выполнение операции:\n\n$PERMISSIONS$\n\nЧерез API Tree Style Tab. Нажмите кнопку, чтобы предоставить разрешение.",
+      "URL": {
+        "content": "$1",
+        "example": "http://example.com/"
+      },
+      "ALL": {
+        "content": "$2",
+        "example": "4"
+      },
+      "REST": {
+        "content": "$3",
+        "example": "3"
+      }
+    }
+  },
+  "sidebarPositionRighsideNotification_message": {
+    "message": "TST определил положение панели как \"Справа\". Хотите переключить вид панели для этого положения?"
+  },
+  "sidebarPositionRighsideNotification_rightside": {
+    "message": "Применить вид для положения Справа"
+  },
+  "sidebarPositionRighsideNotification_leftside": {
+    "message": "Сохранить вид для положения Слева"
+  },
+  "sidebarPositionOptionNotification_title": {
+    "message": "Внешний вид для положения панели сохранен"
+  },
+  "sidebarPositionOptionNotification_message": {
+    "message": "Это можно изменить в секцим настроек TST \"Внешний вид\"."
+  },
+  "startup_notification_title_installed": {
+    "message": "Новым пользователям Tree Style Tab"
+  },
+  "startup_notification_message_installed": {
+    "message": "Дополнительные разрешения требуются для взаимодействия с пользователем. Щелкните здесь, чтобы предоставить их."
+  },
+  "startup_notification_message_installed_linux": {
+    "message": "Для более естественного взаимодействия с пользователем требуются некоторые дополнительные разрешения. Нажмите кнопку, чтобы предоставить их."
+  },
+  "startup_notification_title_updated": {
+    "message": "Изменения в Tree Style Tab"
+  },
+  "startup_notification_message_updated": {
+    "message": "Изменения могут повлиять на ваши предпочтения. Щелкните здесь, чтобы увидеть описания."
+  },
+  "startup_notification_message_updated_linux": {
+    "message": "Некоторые изменения могут повлиять на ваши предпочтения. Нажмите кнопку, чтобы посмотреть список изменений."
+  },
+  "message_startup_description_1": {
+    "message": "Вертикальную панель вкладок Tree Style Tab можно выбрать в качестве одной из боковых панелей. Если вы ещё не видите её, нажмите "
+  },
+  "message_startup_description_key": {
+    "message": "кнопку \"F1\" "
+  },
+  "message_startup_description_2": {
+    "message": " либо "
+  },
+  "message_startup_description_3": {
+    "message": " кнопку на панели инструментов, чтобы активировать боковую панель."
+  },
+  "message_startup_description_sync_before": {
+    "message": "Вкладки можно отправлять через Firefox Sync только на устройства с установленным TST. Сначала активируйте Firefox Sync в настройках Firefox и установите TST на другие устройства."
+  },
+  "message_startup_description_sync_link": {
+    "message": "Имя устройства нужно настраивать вручную"
+  },
+  "message_startup_description_sync_after": {
+    "message": "."
+  },
+  "message_startup_history_before": {
+    "message": "Измененное поведение может быть (или нет) восстановлено с помощью обходного решения. См. детали в "
+  },
+  "message_startup_history_uri": {
+    "message": "https://addons.mozilla.org/firefox/addon/tree-style-tab/versions/"
+  },
+  "message_startup_history_link_label": {
+    "message": "истории изменений"
+  },
+  "message_startup_history_after": {
+    "message": "."
+  },
+  "message_startup_requestPermissions_description": {
+    "message": "⚠Есть некоторые функции, требующие дополнительных разрешений. Если вы хотите их активировать, дайте разрешения вручную."
+  },
+  "message_startup_requestPermissions_bookmarks": {
+    "message": "\"Это дерево в закладки…\" в контекстном меню на вкладках (нужен доступ к закладкам.)"
+  },
+  "message_startup_requestPermissions_allUrls": {
+    "message": "Не разворачивать свернутое дерево и пропускать свернутые дочерние вкладки при переключении фокуса вкладок горячими клавишами. / Don't restore blank window which was for a closed dialog, by actions to restore closed tabs."
+  },
+  "message_startup_requestPermissions_clipboardRead": {
+    "message": "Разрешить открывать новую вкладку по ссылке из буфера обмена, при нажатии колесиком мышки на кнопке \"Новая вкладка\" (*может понадобится активация \"dom.events.asyncClipboard.clipboardItem\")"
+  },
+  "message_startup_userChromeCss_notify": {
+    "message": "Как скрывать верхнюю панель вкладок и заголовок боковой панели?"
+  },
+  "message_startup_userChromeCss_description_1": {
+    "message": "Из-за ограничений WebExtensions, TST не может контролировать верхнюю панель вкладок и заголовок боковой панели. Если вам нужно настроить их, см. "
+  },
+  "message_startup_userChromeCss_description_link_label": {
+    "message": "примеры настройки с помощью userChrome.css"
+  },
+  "message_startup_userChromeCss_description_link_uri": {
+    "message": "https://github.com/piroor/treestyletab/wiki/Code-snippets-for-custom-style-rules#for-userchromecss"
+  },
+  "message_startup_userChromeCss_description_2": {
+    "message": ". Но "
+  },
+  "message_startup_userChromeCss_description_note": {
+    "message": "учтите, что это очень низкоуровневые настройки, и они могут вызвать проблемы в будущих версиях Firefox. Используйте их на свой страх и риск, если уверены, что сможете потом решить проблемы самостоятельно"
+  },
+  "message_startup_userChromeCss_description_3": {
+    "message": "."
+  },
+  "api_requestedPermissions_title": {
+    "message": "Запрос дополнительных разрешений"
+  },
+  "api_requestedPermissions_message": {
+    "message": "⚠Аддон \"$NAME$\" запрашивает выполнение операции:\n\n$PERMISSIONS$\n\nЧерез API Tree Style Tab. Нажмите здесь, если вы разрешаете.",
     "placeholders": {
-      "NAME":        { "content": "$1", "example": "foobar" },
-      "PERMISSIONS": { "content": "$2", "example": "tabs" }
-    }},
-  "api_requestedPermissions_type_activeTab": { "message": "Доступ к активной вкладке браузера" },
-  "api_requestedPermissions_type_tabs":      { "message": "Доступ к вкладкам браузера" },
-  "api_requestedPermissions_type_cookies":   { "message": "Обнаружение контейнера вкладок браузера" },
-
-
-  "context_menu_label": { "message": "Дерево вкладок" },
-
-  "context_reloadTree_label": { "message": "Обновить это дерево" },
-  "context_reloadTree_label_multiselected": { "message": "Обновить эти деревья" },
-  "context_reloadTree_command": { "message": "Обновить это дерево" },
-  "context_reloadDescendants_label": { "message": "Обновить дочерние" },
-  "context_reloadDescendants_label_multiselected": { "message": "Обновить дочерние этих вкладок" },
-  "context_reloadDescendants_command": { "message": "Обновить дочерние" },
-  "context_closeTree_label": { "message": "Закрыть это дерево" },
-  "context_closeTree_label_multiselected": { "message": "Закрыть эти деревья" },
-  "context_closeTree_command": { "message": "Закрыть это дерево" },
-  "context_closeDescendants_label": { "message": "Закрыть дочерние" },
-  "context_closeDescendants_label_multiselected": { "message": "Закрыть дочерние этих вкладок" },
-  "context_closeDescendants_command": { "message": "Закрыть дочерние" },
-  "context_closeOthers_label": { "message": "Закрыть все, кроме этого дерева" },
-  "context_closeOthers_label_multiselected": { "message": "Закрыть другие, кроме этих деревьев" },
-  "context_closeOthers_command": { "message": "Закрыть все, кроме этого дерева" },
-  "context_collapseTree_label": { "message": "Свернуть это дерево" },
-  "context_collapseTree_label_multiselected": { "message": "Свернуть эти деревья" },
-  "context_collapseTree_command": { "message": "Свернуть это дерево" },
-  "context_collapseTreeRecursively_label": { "message": "Свернуть это дерево рекурсивно" },
-  "context_collapseTreeRecursively_label_multiselected": { "message": "Свернуть эти деревья рекурсивно" },
-  "context_collapseTreeRecursively_command": { "message": "Свернуть это дерево рекурсивн" },
-  "context_collapseAll_label": { "message": "Свернуть все" },
-  "context_collapseAll_command": { "message": "Свернуть все" },
-  "context_expandTree_label": { "message": "Развернуть это дерево" },
-  "context_expandTree_label_multiselected": { "message": "Развернуть эти деревья" },
-  "context_expandTree_command": { "message": "Развернуть это дерево" },
-  "context_expandTreeRecursively_label": { "message": "Развернуть это дерево рекурсивно" },
-  "context_expandTreeRecursively_label_multiselected": { "message": "Развернуть эти деревья рекурсивно" },
-  "context_expandTreeRecursively_command": { "message": "Развернуть это дерево рекурсивно" },
-  "context_expandAll_label": { "message": "Развернуть все" },
-  "context_expandAll_command": { "message": "Развернуть все" },
-  "context_bookmarkTree_label": { "message": "В закладки это дерево…" },
-  "context_bookmarkTree_label_multiselected": { "message": "В закладки эти деревья…" },
-  "context_bookmarkTree_command": { "message": "В закладки это дерево…" },
-  "context_sendTreeToDevice_label": { "message": "Отправить это дерево на устройство" },
-  "context_sendTreeToDevice_label_multiselected": { "message": "Отправить выбранные деревья на устройство" },
-  "context_sendTreeToDevice_command": { "message": "Отправить это дерево на устройство" },
-  "context_topLevel_prefix": { "message": "Верхний элемент: " },
-
-  "context_collapsed_label": { "message": "Свернут (проверка меню типа флажок)" },
-  "context_pinnedTab_label": { "message": "Прикреплен (проверка меню типа переключатель)" },
-  "context_unpinnedTab_label": { "message": "Откреплен (проверка меню типа переключатель)" },
-
-  "context_openAllBookmarksWithStructure_label": { "message": "Открыть все как дерево" },
-  "context_openAllBookmarksWithStructureRecursively_label": { "message": "Открыть все с подпапками" },
-
-
-  "config_title": { "message": "Настройки Tree Style Tab в новой вкладке" },
-
-  "config_recommended_choice": { "message": "(Рекомендуется)" },
-  "config_firefoxCompatible_choice": { "message": "(имитация поведения Firefox)" },
-
-  "config_showExpertOptions_label": { "message": "Режим эксперта" },
-  "config_openOptionsInTab_label": { "message": "Открыть эту страницу в широком представлении " },
-
-  "config_appearance_caption": { "message": "Внешний вид" },
-
-  "config_sidebarPosition_caption": { "message": "Позиция содержимого боковой панели:" },
-  "config_sidebarPosition_left": { "message": "Слева" },
-  "config_sidebarPosition_right": { "message": "Справа" },
-  "config_sidebarPosition_auto": { "message": "Автоопределение" },
-  "config_sidebarPosition_description": { "message": "* Эта настройка не меняет положение боковой панели. Если нужно переместить саму панель, то в меню заголовка боковой панели выберите \"Переместить боковую панель...\"." },
-
-  "config_style_caption": { "message": "Тема" },
-  "config_style_proton": { "message": "Протон" },
-  "config_style_photon": { "message": "Фотон" },
-  "config_style_sidebar": { "message": "Сайдбар" },
-  "config_style_highcontrast": { "message": "Контраст" },
-  "config_style_none": { "message": "Без стиля" },
-  "config_style_none_info": { "message": " ( * Украсьте все самостоятельно используя \"Расширенные настройки\" => \"Дополнительные стили боковой панели\")" },
-
-  "config_colorScheme_caption": { "message": "Цветовая схема:" },
-  "config_colorScheme_photon": { "message": "Фотон" },
-  "config_colorScheme_systemColor": { "message": "Системные цвета" },
-
-  "config_maxTreeLevel_before": { "message": "Отступ вкладок до" },
-  "config_maxTreeLevel_after": { "message": "уровней ( * Отрицательное значение = \"бесконечно\")" },
-
-  "config_faviconizePinnedTabs_label": { "message": "Показывать закрепленные вкладки как значок" },
-  "config_maxFaviconizedPinnedTabsInOneRow_label_before": { "message": "Показать " },
-  "config_maxFaviconizedPinnedTabsInOneRow_label_after": { "message": " или меньше вкладок на строку ( * 0 или \"-\" авторасчет)" },
-  "config_maxPinnedTabsRowsAreaPercentage_label_before": { "message": "Максимум высоты области закрепленных вкладок:" },
-  "config_maxPinnedTabsRowsAreaPercentage_label_after":  { "message": "% от боковой панели" },
-  "config_animation_label": { "message": "Включить эффекты анимации" },
-  "config_animationForce_label": { "message": "Включить анимацию независимо от настроек браузера" },
-  "config_showCollapsedDescendantsByTooltip_label": { "message": "Показывать свернутые дочерние элементы в подсказке вкладки" },
-  "config_shiftTabsForScrollbarDistance_label_before": { "message": "Сдвигать вкладки в сторону на " },
-  "config_shiftTabsForScrollbarDistance_label_after": { "message": " чтобы кнопки на вкладках не перекрывались скролбаром" },
-  "config_shiftTabsForScrollbarDistance_placeholder": { "message": "(CSS length)" },
-  "config_shiftTabsForScrollbarOnlyOnHover_label": { "message": "Сдвигать вкладки только если курсор рядом со скролбаром" },
-  "config_suppressGapFromShownOrHiddenToolbar_caption": { "message": "Исправлять глюки сайдбара при отображении/скрытии других панелей, для:" },
-  "config_suppressGapFromShownOrHiddenToolbarOnFullScreen_label": { "message": "Полноэкранных окон" },
-  "config_suppressGapFromShownOrHiddenToolbarOnNewTab_label": { "message": "Пустых новых вкладок (Firefox 85 и новее)" },
-  "config_suppressGapFromShownOrHiddenToolbarOnlyOnMouseOperation_label": { "message": "Только при щелчках на боковой панели." },
-  "config_showDialogInSidebar_label": { "message": "Показать диалоги на боковой панели, если возможно" },
-
-
-  "config_context_caption": { "message": "Контекстное меню" },
-  "config_emulateDefaultContextMenu_label": { "message": "Имитация контекстного меню вкладок на боковой панели" },
-  "config_extraItems_tabs_caption": { "message": "Дополнительные пункты контекстного меню" },
-  "config_extraItems_tabs_topLevel": { "message": "Основное меню" },
-  "config_extraItems_tabs_subMenu": { "message": "Вложенное меню" },
-  "config_extraItems_tabs_middleClick": { "message": "Действие щелчка СКМ" },
-  "config_extraItems_bookmarks_caption": { "message": "Пункты контекстного меню закладок" },
-  "config_openAllBookmarksWithStructureDiscarded_label": { "message": "Открывать незагруженными" },
-  "config_suppressGroupTabForStructuredTabsFromBookmarks_label": { "message": "Отмена групповой вкладки верхнего уровня, если вкладки уже организованы в дерево" },
-
-  "config_sendTabsToDevice_caption": { "message": "Отправляйте вкладки на другие устройства через контекстное меню используя Firefox Sync" },
-  "config_syncRequirements_description": { "message": "Эта функция зависит от Firefox Sync. Вкладки можно отправлять только на устройства с установленным TST. Сначала активируйте Firefox Sync в настройках Firefox и установите TST на другие устройства." },
-  "config_syncDeviceInfo_name_label": { "message": "Название и значок этого устройства:" },
-  "config_syncDeviceInfo_name_description_before": { "message": "TST не может определить имя устройства, из-за ограничений API WebExtensions. Установите имя(id) для этого устройства вручную. (Рекомендуется копировать " },
-  "config_syncDeviceInfo_name_description_link": { "message": "имя устройства из Firefox Sync" },
-  "config_syncDeviceInfo_name_description_href": { "message": "https://accounts.firefox.com/settings/clients" },
-  "config_syncDeviceInfo_name_description_after": { "message": ".)" },
-  "config_syncDeviceExpirationDays_label_before": { "message": "Автоисключение неиспользуемых устройств, если они не подключались более " },
-  "config_syncDeviceExpirationDays_label_after": { "message": " дней (\"0\" - \"не исключать\")" },
-  "config_syncUnsendableUrlPattern_label": { "message": "Правило соответствия для неотправляемых URL вкладок ( * Это должно быть синхронизировано с параметром \"services.sync.engine.tabs.filteredUrls\" Firefox:" },
-  "config_otherDevices_caption": { "message": "Активные другие устройства:" },
-  "config_removeDeviceButton_label": { "message": "Удалить" },
-  "config_removeDeviceButton_tooltip": { "message": "Удалить это устройство из списка" },
-
-
-  "config_newTabWithOwner_caption": { "message": "Вкладки, открытые из существующих вкладок" },
-
-  "config_autoAttachOnOpenedWithOwner_before": { "message": "Если вкладка открывается из существующей вкладки, открыть ее как - " },
-  "config_autoAttachOnOpenedWithOwner_noControl": { "message": "(не контролируется)" },
-  "config_autoAttachOnOpenedWithOwner_independent": { "message": "независимая вкладка" },
-  "config_autoAttachOnOpenedWithOwner_child": { "message": "дочернюю вкладку" },
-  "config_autoAttachOnOpenedWithOwner_childNextToLastRelatedTab": { "message": "дочерняя вкладка, рядом с недавно открытой дочерней" },
-  "config_autoAttachOnOpenedWithOwner_sibling": { "message": "одноуровневую вкладку" },
-  "config_autoAttachOnOpenedWithOwner_nextSibling": { "message": "следующую одноуровневую" },
-  "config_autoAttachOnOpenedWithOwner_after": { "message": "\u200b" },
-
-  "config_insertNewTabFromPinnedTabAt_caption": { "message": "Позиция новых дочерних вкладок открытых из закрепленных (будут отображаться как корневые)" },
-  "config_insertNewTabFromPinnedTabAt_noControl": { "message": "Не контролируется (решает Firefox или другие аддоны)" },
-  "config_insertNewTabFromPinnedTabAt_nextToLastRelatedTab": { "message": "После недавно открытой дочерней или рядом с родителем" },
-  "config_insertNewTabFromPinnedTabAt_top": { "message": "Добавить в начало дерева (рядом с родителем)" },
-  "config_insertNewTabFromPinnedTabAt_end": { "message": "Добавить в конец дерева" },
-
-  "config_autoGroupNewTabsFromPinned_label": { "message": "Автогруппировка вкладок, открытых с одной закрепленной вкладки (с вкладкой группы с заголовком типа \"Вкладки из ...\")" },
-  "config_groupTabTemporaryStateForChildrenOfPinned_label": { "message": "Состояние по умолчанию вкладки группы для вкладок, открытых с одной закрепленной вкладки:" },
-
-
-  "config_newTab_caption": { "message": "Вкладки, открытые НЕ из существующих вкладок" },
-
-  "config_newTabButton_caption": { "message": "Специальные действия для кнопки \"Новая вкладка\" " },
-  "config_longPressOnNewTabButton_before":               { "message": "Длительное нажатие кнопки \"Новая вкладка\", чтобы " },
-  "config_longPressOnNewTabButton_newTabAction":         { "message": "указать, где откроется новая вкладка" },
-  "config_longPressOnNewTabButton_contextualIdentities": { "message": "выбрать контейнер" },
-  "config_longPressOnNewTabButton_none":                 { "message": "(ничего)" },
-  "config_longPressOnNewTabButton_after":                { "message": "\u200b" },
-  "config_showNewTabActionSelector_label":               { "message": "Показывать кнопку выбора позиции на кнопке \"Новая вкладка\" " },
-  "config_showContextualIdentitiesSelector_label":       { "message": "Показывать кнопку выбора контейнера на кнопке \"Новая вкладка\" " },
-
-  "config_newTabAction_caption": { "message": "Управляющие элементы \"Новой вкладкой\" (кнопки панели, горячие клавиши и прочее)" },
-  "config_autoAttachOnNewTabCommand_before": { "message": "Открыть новую пустую вкладку как" },
-  "config_autoAttachOnNewTabCommand_noControl": { "message": "(не контролируется)" },
-  "config_autoAttachOnNewTabCommand_independent": { "message": "независимую вкладку" },
-  "config_autoAttachOnNewTabCommand_child": { "message": "дочернюю текущей" },
-  "config_autoAttachOnNewTabCommand_sibling": { "message": "одноуровневую вкладку" },
-  "config_autoAttachOnNewTabCommand_nextSibling": { "message": "следующую одноуровневую" },
-  "config_autoAttachOnNewTabCommand_after": { "message": "\u200b" },
-  "config_guessNewOrphanTabAsOpenedByNewTabCommandUrl_before": { "message": "Считать недавно открытой вкладку, открытую действием \"Новая вкладка\", если она открывается с URL: " },
-  "config_guessNewOrphanTabAsOpenedByNewTabCommandUrl_after": { "message": "( * Вы можете перечислить несколько URL разделяя их \"|\")" },
-
-  "config_autoAttachOnNewTabButtonMiddleClick_before": { "message": "Щелчком СКМ, открыть новую пустую вкладку как" },
-  "config_autoAttachOnNewTabButtonMiddleClick_noControl": { "message": "(не контролируется)" },
-  "config_autoAttachOnNewTabButtonMiddleClick_independent": { "message": "независимую вкладку" },
-  "config_autoAttachOnNewTabButtonMiddleClick_child": { "message": "дочернюю текущей" },
-  "config_autoAttachOnNewTabButtonMiddleClick_sibling": { "message": "одноуровневую вкладку" },
-  "config_autoAttachOnNewTabButtonMiddleClick_nextSibling": { "message": "следующую одноуровневую" },
-  "config_autoAttachOnNewTabButtonMiddleClick_nextSiblingWithInheritedContainer": { "message": "тоже что и с Ctrl (следующую одноуровневую, тот же контейнер)" },
-  "config_autoAttachOnNewTabButtonMiddleClick_after": { "message": "\u200b" },
-
-  "config_autoAttachOnNewTabButtonAccelClick_before": { "message": "Щелчком ЛКМ+Ctrl, открыть новую пустую вкладку как" },
-  "config_autoAttachOnNewTabButtonAccelClick_noControl": { "message": "(не контролируется)" },
-  "config_autoAttachOnNewTabButtonAccelClick_independent": { "message": "независимую вкладку" },
-  "config_autoAttachOnNewTabButtonAccelClick_child": { "message": "дочернюю текущей" },
-  "config_autoAttachOnNewTabButtonAccelClick_sibling": { "message": "одноуровневую вкладку" },
-  "config_autoAttachOnNewTabButtonAccelClick_nextSibling": { "message": "следующую одноуровневую" },
-  "config_autoAttachOnNewTabButtonAccelClick_nextSiblingWithInheritedContainer": { "message": "следующую одноуровневую, тот же контейнер" },
-  "config_autoAttachOnNewTabButtonAccelClick_after": { "message": "\u200b" },
-
-  "config_autoAttachWithURL_caption": { "message": "Непустые новые вкладки" },
-
-  "config_duplicateTabAction_caption": { "message": "Дублировать вкладки (щелчком СКМ на кнопке \"Перезагрузить\" и т.п.)" },
-
-  "config_autoAttachOnDuplicated_before": { "message": "Дублировать вкладку как" },
-  "config_autoAttachOnDuplicated_noControl": { "message": "(не контролируется)" },
-  "config_autoAttachOnDuplicated_independent": { "message": "независимую вкладку" },
-  "config_autoAttachOnDuplicated_child": { "message": "дочернюю текущей" },
-  "config_autoAttachOnDuplicated_sibling": { "message": "одноуровневую вкладку" },
-  "config_autoAttachOnDuplicated_nextSibling": { "message": "следующую одноуровневую" },
-  "config_autoAttachOnDuplicated_after": { "message": "\u200b" },
-
-  "config_fromExternal_caption": { "message": "Новая вкладка передается извне Firefox" },
-  "config_autoAttachOnOpenedFromExternal_before": { "message": "Открыть как" },
-  "config_autoAttachOnOpenedFromExternal_noControl": { "message": "(не контролируется)" },
-  "config_autoAttachOnOpenedFromExternal_independent": { "message": "независимую вкладку" },
-  "config_autoAttachOnOpenedFromExternal_child": { "message": "дочернюю текущей" },
-  "config_autoAttachOnOpenedFromExternal_sibling": { "message": "одноуровневую вкладку" },
-  "config_autoAttachOnOpenedFromExternal_nextSibling": { "message": "следующую одноуровневую" },
-  "config_autoAttachOnOpenedFromExternal_after": { "message": "\u200b" },
-  "config_inheritContextualIdentityToTabsFromExternalMode_label": { "message": "Контейнер:" },
-  "config_inheritContextualIdentityToTabsFromExternalMode_default": { "message": "(не контролируется)" },
-  "config_inheritContextualIdentityToTabsFromExternalMode_parent": { "message": "Наследовать от родительской вкладки в дереве" },
-  "config_inheritContextualIdentityToTabsFromExternalMode_lastActive": { "message": "Наследовать от текущей вкладки" },
-
-  "config_sameSiteOrphan_caption": { "message": "Если новая вкладка открывается с сайтом, как в текущей вкладке -" },
-  "config_autoAttachSameSiteOrphan_before": { "message": "Открыть ее как " },
-  "config_autoAttachSameSiteOrphan_noControl": { "message": "(не контролируется)" },
-  "config_autoAttachSameSiteOrphan_independent": { "message": "независимую вкладку" },
-  "config_autoAttachSameSiteOrphan_child": { "message": "дочернюю текущей" },
-  "config_autoAttachSameSiteOrphan_sibling": { "message": "одноуровневую вкладку" },
-  "config_autoAttachSameSiteOrphan_nextSibling": { "message": "следующую одноуровневую" },
-  "config_autoAttachSameSiteOrphan_after": { "message": "\u200b" },
-  "config_inheritContextualIdentityToSameSiteOrphanMode_label": { "message": "Контейнер:" },
-  "config_inheritContextualIdentityToSameSiteOrphanMode_default": { "message": "(не контролируется)" },
-  "config_inheritContextualIdentityToSameSiteOrphanMode_parent": { "message": "Наследовать от родительской вкладки в дереве" },
-  "config_inheritContextualIdentityToSameSiteOrphanMode_lastActive": { "message": "Наследовать от текущей вкладки" },
-
-  "config_anyOtherTrigger_caption": { "message": "Вкладки из любого другого триггера" },
-  "config_autoAttachOnAnyOtherTrigger_before": { "message": "Открыть как" },
-  "config_autoAttachOnAnyOtherTrigger_noControl": { "message": "(не контролируется)" },
-  "config_autoAttachOnAnyOtherTrigger_independent": { "message": "независимую вкладку" },
-  "config_autoAttachOnAnyOtherTrigger_child": { "message": "дочернюю текущей" },
-  "config_autoAttachOnAnyOtherTrigger_sibling": { "message": "одноуровневую вкладку" },
-  "config_autoAttachOnAnyOtherTrigger_nextSibling": { "message": "следующую одноуровневую" },
-  "config_autoAttachOnAnyOtherTrigger_after": { "message": "\u200b" },
-  "config_autoAttachOnAnyOtherTrigger_caution": { "message": " * ВНИМАНИЕ: этот параметр может нарушить работу других аддонов." },
-  "config_inheritContextualIdentityToTabsFromAnyOtherTriggerMode_label": { "message": "Контейнер:" },
-  "config_inheritContextualIdentityToTabsFromAnyOtherTriggerMode_default": { "message": "(не контролируется)" },
-  "config_inheritContextualIdentityToTabsFromAnyOtherTriggerMode_parent": { "message": "Наследовать от родительской вкладки в дереве" },
-  "config_inheritContextualIdentityToTabsFromAnyOtherTriggerMode_lastActive": { "message": "Наследовать от текущей вкладки" },
-
-  "config_groupTab_caption": { "message": "Автогруппировка вкладок" },
-
-  "config_tabBunchesDetectionTimeout_before": { "message": "Обнаружение вкладок, открытых из закладок в течение" },
-  "config_tabBunchesDetectionTimeout_after": { "message": "мс, и:" },
-  "config_autoGroupNewTabsFromBookmarks_label": { "message": "Группировать вкладки с заголовком типа \"... и больше\"" },
-  "config_restoreTreeForTabsFromBookmarks_label": { "message": "Восстановить структуру дерева" },
-  "config_requireBookmarksPermission_tooltiptext": { "message": "Эта функция требует права доступа к закладкам. Нажмите здесь, чтобы запросить необходимое разрешение." },
-  "config_requestPermissions_bookmarks_autoGroupNewTabs_before": { "message": "(" },
-  "config_requestPermissions_bookmarks_autoGroupNewTabs_after": { "message": "Разрешить обнаруживать закладки, соответствующие вкладкам)" },
-  "config_tabsFromSameFolderMinThresholdPercentage_before": { "message": "Рассматривать все новые вкладки как открытые из одной папки закладок, если более " },
-  "config_tabsFromSameFolderMinThresholdPercentage_after": { "message": "% вкладок имеют соответствующую закладку в общей папке закладок" },
-  "config_autoGroupNewTabsFromOthers_label": { "message": "Автогруппировать вкладки, открытые одновременно не из закладок" },
-  "config_tabBunchesDetectionDelayOnNewWindow_before": { "message": "Автогруппировать вкладки открытые в течении" },
-  "config_tabBunchesDetectionDelayOnNewWindow_after": { "message": "мс, при открытии нового окна, в составе вкладок открытых как \"домашняя страница\"." },
-  "config_warnOnAutoGroupNewTabs_label": { "message": "Подтверждать группировку вкладок" },
-  "config_warnOnAutoGroupNewTabsWithListing_label": { "message": "Группировать список вкладок в диалоге подтверждения" },
-
-  "config_renderTreeInGroupTabs_label": { "message": "Отрисовывать дерево во вкладке группы" },
-
-  "config_groupTabTemporaryState_caption": { "message": "Состояние (по умолчанию) группы вкладок для разных контекстов" },
-  "config_groupTabTemporaryState_option_default": { "message": "Не проверять" },
-  "config_groupTabTemporaryState_option_checked_before": { "message": "Проверять \"" },
-  "config_groupTabTemporaryState_option_checked_after": { "message": "\"" },
-  "config_groupTabTemporaryStateForNewTabsFromBookmarks_label": { "message": "Для открытых из закладок:" },
-  "config_groupTabTemporaryStateForNewTabsFromOthers_label": { "message": "Для открытых одновременно не из закладок:" },
-  "config_groupTabTemporaryStateForOrphanedTabs_label": { "message": "Открытую для замены закрытой родительской вкладки::" },
-
-  "config_inheritContextualIdentityToChildTabMode_label": { "message": "Контейнер:" },
-  "config_inheritContextualIdentityToChildTabMode_default": { "message": "(не контролируется)" },
-  "config_inheritContextualIdentityToChildTabMode_parent": { "message": "Наследовать от родительской вкладки в дереве" },
-  "config_inheritContextualIdentityToChildTabMode_lastActive": { "message": "Наследовать от текущей вкладки" },
-
-
-  "config_treeBehavior_caption": { "message": "Поведение дерева" },
-
-  "config_successorTabControlLevel_caption": { "message": "Если текущая вкладка закрывается как последняя дочерняя" },
-  "config_successorTabControlLevel_inTree": { "message": "Перейти на предыдущую вкладку дерева" },
-  "config_successorTabControlLevel_simulateDefault": { "message": "Перейти на следующую вкладку (как в Firefox)" },
-  "config_successorTabControlLevel_never": { "message": "Не контролировать фокус (решает Firefox или другие аддоны)" },
-  "config_successorTabControlLevel_legacyDescription": { "message": "* Поведение Firefox \"browser.tabs.selectOwnerOnClose\"=\"true\" сработает раньше этой конфигурации." },
-  "config_simulateSelectOwnerOnClose_label": { "message": "Переместить фокус на вкладку, из которой открыта закрываемая ( * имитация \"browser.tabs.selectOwnerOnClose\"=\"true\", приорететно для настроек выше)" },
-
-  "config_fixupTreeOnTabVisibilityChanged_caption": { "message": "Если видимость вкладок изменяется другими аддонами" },
-  "config_fixupTreeOnTabVisibilityChanged_fix":     { "message": "Исправить древья с видимыми вкладками ( * Рекомендуется, если есть другие аддоны для переключения групп вкладок)" },
-  "config_fixupTreeOnTabVisibilityChanged_keep":    { "message": "Сохранить деревья включая скрытые вкладки ( * Рекомендуется, если есть другие аддоны для скрытия групп вкладок)" },
-
-  "config_autoCollapseExpandSubtreeOnAttach_label": { "message": "Если появляется новое дерево, автосвернуть остальные" },
-  "config_autoCollapseExpandSubtreeOnSelect_label": { "message": "Если вкладка получает фокус, развернуть её дерево и автосвернуть другие" },
-  "config_autoCollapseExpandSubtreeOnSelectExceptActiveTabRemove_label": { "message": "За исключением фокуса, вызванного закрытием текущей вкладки" },
-  "config_unfocusableCollapsedTab_label": { "message": "Если свернутая вкладка получает фокус, авторазвернуть ее дерево" },
-  "config_autoDiscardTabForUnexpectedFocus_label": { "message": "Удерживать вкладки выгружеными при кратковременном фокусе" },
-  "config_avoidDiscardedTabToBeActivatedIfPossible_label": { "message": "Избегать активации выгруженных при закрытии текущей или сворачивании дерева" },
-
-  "config_treeDoubleClickBehavior_caption":             { "message": "Двойной щелчок" },
-  "config_treeDoubleClickBehavior_toggleCollapsed":     { "message": "Свернуть/развернуть дерево" },
-  "config_treeDoubleClickBehavior_close":               { "message": "Закрыть вкладку ( * имитация \"browser.tabs.closeTabByDblclick\"=\"true\")" },
-  "config_treeDoubleClickBehavior_none":                { "message": "Ничего не делать" },
-
-  "config_parentTabOperationBehaviorMode_caption":           { "message": "Если родительская вкладка закрыта или перемещена" },
-  "config_parentTabOperationBehaviorMode_noteForPermanentlyConsistentBehaviors": { "message": "Независимо от того, как вы настроили этот раздел, в боковой панели есть несколько констант поведения:\n･ Закрытие родительской вкладки вместе со свернутым деревом: Закрыть все дерево\n･ Перемещение родительской вкладки вместе со свернутым деревом: Переместить все дерево\n･ Перемещение родительской вкладки вместе с развернутым деревом: Ведет себя в соответствии с настройками раздела \"Перетягивание\" " },
-
-  "config_parentTabOperationBehaviorMode_parallel": { "message": "Рекомендуется тем, кто все еще использует нативную панель вкладок Firefox" },
-  "config_closeParentBehavior_insideSidebar":       { "message": "Если родительская вкладка с развернутым деревом закрывается через боковую панель," },
-  "config_closeParentBehavior_outsideSidebar":      { "message": "Если родительская вкладка (независимо от состояния ее дерева) закрывается в нативной панели вкладок Firefox, сочетанием клавиш или другим аддоном," },
-  "config_moveParentBehavior_outsideSidebar":       { "message": "Если родительская вкладка (независимо от состояния ее дерева) перемещается в нативной панели вкладок Firefox, сочетанием клавиш или другим аддоном," },
-
-  "config_parentTabOperationBehaviorMode_consistent":             { "message": "Рекомендуется для тех, кто не используют нативную панель вкладок Firefox" },
-  "config_parentTabOperationBehaviorMode_consistent_caption":    { "message": "Независимо от видимости боковой панели, для любой операции:" },
-  "config_parentTabOperationBehaviorMode_consistent_notes":       { "message": "Вкладки ведут себя так, как указано выше, даже при действиях в нативной панели вкладок Firefox, по сочетанию клавиш или из других аддонов." },
-
-  "config_parentTabOperationBehaviorMode_custom":                { "message": "Свое" },
-  "config_closeParentBehavior_insideSidebar_expanded_caption":   { "message": "Закрыть: Если родительская вкладка с развернутым деревом закрывается через боковую панель," },
-  "config_closeParentBehavior_outsideSidebar_collapsed_caption": { "message": "Закрыть: Если родительская вкладка со свернутым деревом закрывается в нативной панели вкладок Firefox, сочетанием клавиш или из другого аддона," },
-  "config_closeParentBehavior_outsideSidebar_expanded_caption":  { "message": "Закрыть: Если родительская вкладка с развернутым деревом закрывается в нативной панели вкладок Firefox, сочетанием клавиш или из другого аддона," },
-  "config_closeParentBehavior_noSidebar_collapsed_caption":      { "message": "если боковая панель закрыта," },
-  "config_closeParentBehavior_noSidebar_expanded_caption":       { "message": "если боковая панель закрыта," },
-  "config_moveParentBehavior_outsideSidebar_collapsed_caption":  { "message": "Переместить: Если родительская вкладка со свернутым деревом перемещается в нативной панели вкладок Firefox, сочетанием клавиш или из другого аддона," },
-  "config_moveParentBehavior_outsideSidebar_expanded_caption":   { "message": "Переместить: Если родительская вкладка с развернутым деревом перемещается в нативной панели вкладок Firefox, сочетанием клавиш или из другого аддона," },
-  "config_moveParentBehavior_noSidebar_collapsed_caption":       { "message": "если боковая панель закрыта," },
-  "config_moveParentBehavior_noSidebar_expanded_caption":        { "message": "если боковая панель закрыта," },
-
-  "config_parentTabOperationBehavior_entireTree":                { "message": "Закрыть / переместить все дерево" },
-  "config_closeParentBehavior_entireTree":                  { "message": "Закрыть все дерево" },
-  "config_moveParentBehavior_entireTree":                   { "message": "Переместить все дерево" },
-  "config_parentTabOperationBehavior_replaceWithGroupTab":  { "message": "Заменить закрытую/перемещенную родительскую вкладку вкладкой группы" },
-  "config_closeParentBehavior_replaceWithGroupTab":         { "message": "Заменить закрытую родительскую вкладку вкладкой группы" },
-  "config_moveParentBehavior_replaceWithGroupTab":          { "message": "Заменить перемещенную родительскую вкладку вкладкой группы" },
-  "config_parentTabOperationBehavior_promoteFirst":         { "message": "Назначить первую дочернюю вкладку новой родительской" },
-  "config_closeParentBehavior_promoteFirst":                { "message": "Назначить первую дочернюю вкладку новой родительской" },
-  "config_moveParentBehavior_promoteFirst":                 { "message": "Назначить первую дочернюю вкладку новой родительской" },
-  "config_parentTabOperationBehavior_promoteAll":           { "message": "Назначить все дочерние вкладки на уровень закрытой родительской вкладки" },
-  "config_closeParentBehavior_promoteAll":                  { "message": "Назначить все дочерние вкладки на уровень закрытой родительской вкладки" },
-  "config_moveParentBehavior_promoteAll":                   { "message": "Назначить все дочерние вкладки на уровень закрытой родительской вкладки" },
-  "config_parentTabOperationBehavior_promoteIntelligently": { "message": "Повысить первую дочернюю, если закрыта корневая, иначе повысить все дочерние" },
-  "config_closeParentBehavior_promoteIntelligently":        { "message": "Повысить первую дочернюю, если закрыта корневая, иначе повысить все дочерние" },
-  "config_moveParentBehavior_promoteIntelligently":         { "message": "Повысить первую дочернюю, если закрыта корневая, иначе повысить все дочерние" },
-  "config_parentTabOperationBehavior_detach":               { "message": "Освободить все дочерние вкладки из дерева" },
-  "config_closeParentBehavior_detach":                      { "message": "Освободить все дочерние вкладки из дерева" },
-  "config_moveParentBehavior_detach":                       { "message": "Освободить все дочерние вкладки из дерева" },
-
-  "config_warnOnCloseTabs_label": { "message": "Предупреждать при закрытии нескольких вкладок" },
-  "config_warnOnCloseTabsByClosebox_label": { "message": "Предупреждать при закрытии нескольких вкладок по крестику закрытия вкладки (свернутое дерево)" },
-  "config_warnOnCloseTabsWithListing_label": { "message": "Список закрывающихся вкладок в диалоге подтверждения" },
-
-  "config_insertNewChildAt_caption": { "message": "Место появления новых дочерних вкладок" },
-  "config_insertNewChildAt_noControl": { "message": "Не контролируется (решает Firefox или другие аддоны)" },
-  "config_insertNewChildAt_nextToLastRelatedTab": { "message": "После недавно открытой дочерней или после родителя" },
-  "config_insertNewChildAt_top": { "message": "Добавить в начало дерева, как первую дочернюю" },
-  "config_insertNewChildAt_end": { "message": "Добавить в конец дерева" },
-
-
-  "config_drag_caption": { "message": "Перетягивание" },
-
-  "config_tabDragBehavior_caption":       { "message": "Если дерево перетягивается за границы панели вкладок" },
-  "config_tabDragBehavior_description":   { "message": "Из-за ограничений Firefox, вам необходимо заранее определить, как обрабатывать вкладки, перетягиваемые за границы панели TST." },
-  "config_tabDragBehavior_label":         { "message": "Перетягивание" },
-  "config_tabDragBehaviorShift_label":    { "message": "Перетягивание с Shift" },
-  "config_tabDragBehavior_label_behaviorInsideSidebar":  { "message": "Поведение внутри" },
-  "config_tabDragBehavior_label_behaviorOutsideSidebar": { "message": "вне боковой панели" },
-  "config_tabDragBehavior_moveEntireTreeAlways":         { "message": "Перемещение дерева" },
-  "config_tabDragBehavior_detachEntireTreeAlways":       { "message": "Отсоединить дерево от окна (невозможно создать закладку)" },
-  "config_tabDragBehavior_bookmarkEntireTreeAlways":     { "message": "Создать закладки или сслыки (невозможно отсоединить от окна)" },
-  "config_tabDragBehavior_moveSoloTabIfExpanded":        { "message": "Перемещение вкладки" },
-  "config_tabDragBehavior_detachSoloTabIfExpanded":      { "message": "Отсоеденить вкладку от окна (невозможно создать закладку)" },
-  "config_tabDragBehavior_bookmarkSoloTabIfExpanded":    { "message": "Создать закладку или ссылку (невозможно отсоединить от окна)" },
-  "config_tabDragBehavior_doNothing":                    { "message": "Ничего не делать" },
-  "config_tabDragBehavior_noteForDragstartOutsideSidebar": { "message": "Если родительские вкладки перетаскиваются из нативной панели вкладок Firefox, они будут вести себя как нстроено в разделе \"Поведение дерева\" => \"Если родительская вкладка закрыта или перемещена\"." },
-  "config_showTabDragBehaviorNotification_label": { "message": "Показывать напоминание о том, что произойдет после отпускания вкладки за пределами боковой панели" },
-
-  "config_dropLinksOnTabBehavior_caption": { "message": "При перетягивании ссылки или URL на вкладку" },
-  "config_dropLinksOnTabBehavior_ask":     { "message": "Всегда спрашивать что делать" },
-  "config_dropLinksOnTabBehavior_load":    { "message": "Загрузить во вкладке" },
-  "config_dropLinksOnTabBehavior_newtab":  { "message": "Открыть новую дочернюю вкладку" },
-  "config_simulateTabsLoadInBackgroundInverted_label": { "message": "При открытии ссылки в новой вкладке, переключатся на эту вкладку (* имитация параметра Firefox \"Переключаться на открываемую ссылку, изображение или медиа\" (\"browser.tabs.loadInBackground\"))" },
-
-  "config_insertDroppedTabsAt_caption": { "message": "Позиция вставки дочерних элементов, перетянутых на родителя" },
-  "config_insertDroppedTabsAt_inherit": { "message": "Рассматривать как новые дочерние, открытые из родителя" },
-  "config_insertDroppedTabsAt_first": { "message": "Добавить в начало дерева (сразу за родителем)" },
-  "config_insertDroppedTabsAt_end": { "message": "Добавить в конец дерева" },
-
-  "config_autoExpandOnLongHoverDelay_before":  { "message": "Развернуть свернутое дерево при наведении указателя мыши более " },
-  "config_autoExpandOnLongHoverDelay_after":  { "message": "мс при перетягивании" },
-  "config_autoExpandOnLongHoverRestoreIniitalState_label":  { "message": "Автосворачивать такие деревья после завершения перетягивания" },
-  "config_autoExpandIntelligently_label":  { "message": "Свернуть другие деревья, когда свернутое дерево авторазворачивается" },
-  "config_ignoreTabDropNearSidebarArea_label":  { "message": "Не отделять вкладку от окна, если она отпущена в области боковой панели (снимите, если \"privacy.resistFingerprinting\"=\"true\")" },
-
-
-  "config_more_caption": { "message": "Больше..." },
-
-  "config_shortcuts_caption": { "message": "Горячие клавиши" },
-
-  "config_requestPermissions_allUrls_ctrlTabTracking":   { "message": "Не разворачивать свернутое дерево и пропускать свернутые потомки, переключая фокус вкладок сочетаниями клавиш. ( * Вы должны разрешить выполнение сценариев на веб-страницах.)" },
-  "config_autoExpandOnTabSwitchingShortcutsDelay_before": { "message": "Развернуть активное свернутое дерево при удержании клавиши Tab " },
-  "config_autoExpandOnTabSwitchingShortcutsDelay_after": { "message": "мс" },
-  "config_accelKey_label":   { "message": "Модификатор сочетания клавиш ( * необходимо сопоставить с \"ui.key.accelKey\"):" },
-  "config_accelKey_auto":    { "message": "По умолчанию (macOS=⌘, другие=Ctrl)" },
-  "config_accelKey_alt":     { "message": "Alt" },
-  "config_accelKey_control": { "message": "Ctrl/Control" },
-  "config_accelKey_meta":    { "message": "Meta/⌘" },
-
-  "config_shortcuts_resetAll": { "message": "Сбросить ВСЁ" },
-
-
-  "config_advanced_caption": { "message": "Расширенные настройки" },
-
-  "config_bookmarkTreeFolderName_before": { "message": "Имя папки для \"Это дерево в закладки…\":" },
-  "config_bookmarkTreeFolderName_after": { "message": "\u200b" },
-  "config_bookmarkTreeFolderName_description": { "message": "Доступные шаблоны: %TITLE% (заголовок первой вкладки), %URL% (адрес первой вкладки), %YEAR% (год, 4 символа), %SHORT_YEAR% (год, 2 символа), %MONTH% (месяц, 2 символа), %DATE% (число, два символа), %HOURS% (часов, два символа), %MINUTES% (минут, два символа), %SECONDS% (секунд, два символа), %MILLISECONDS% (мс, три символа), %GROUP% (заголовок первой вкладки, если это вкладка группы - иначе пусто), %ANY(значение1, значение2, ...)% (первое эффективное значение из заданного списка)" },
-
-  "config_defaultBookmarkParentId_label_before":  { "message": "Создать новую закладку в" },
-  "config_defaultBookmarkParentId_label_after":   { "message": "\u200b" },
-
-  "config_supportTabsMultiselect_label": { "message": "Использовать интерфейс API выбора нескольких вкладок  ( * зависит от \"browser.tabs.multiselect\"=\"true\")" },
-
-  "config_undoMultipleTabsClose_label": { "message": "Восстановить набор закрытых вкладок, когда одна из них восстанавливается командой \"Восстановить закрытую вкладку\"" },
-
-  "config_scrollLines_label_before": { "message": "Прокручивать вверх или вниз на " },
-  "config_scrollLines_label_after":  { "message": "строк командами \"Листать вкладки вверх/вниз построчно\" " },
-
-  "config_userStyleRules_label": { "message": "Дополнительные стили боковой панели" },
-  "config_userStyleRules_description_before": { "message": "Смотрите " },
-  "config_userStyleRules_description_link_label": { "message": "примеры кода и описания на TST-вики" },
-  "config_userStyleRules_description_after": { "message": " ." },
-  "config_userStyleRules_description_link_uri": { "message": "https://github.com/piroor/treestyletab/wiki/Code-snippets-for-custom-style-rules#for-version-2x" },
-  "config_userStyleRules_themeRules_description": { "message": "Следующие свойства также доступны через \"var()\", в зависимости от текущей темы браузера" },
-  "config_userStyleRules_themeRules_description_alphaVariations": { "message": "Вы можете изменить непрозрачность цвета с помощью цифрового суффикса, например, \"--theme-colors-tab_background_text-30\", означает непрозрачность 30%." },
-  "config_userStyleRules_import": { "message": "Загрузить из файла" },
-  "config_userStyleRules_export": { "message": "Сохранить в файл" },
-  "config_userStyleRules_overwrite_title":     { "message": "Заменить текущие правила стиля?" },
-  "config_userStyleRules_overwrite_message":   { "message": "Заменить все текущие правила стиля загруженным файлом?" },
-  "config_userStyleRules_overwrite_overwrite": { "message": "Заменить все" },
-  "config_userStyleRules_overwrite_append":    { "message": "Добавить в конец" },
-  "config_tooLargeUserStyleRulesCaution": { "message": "Слишком длинный код стиля! Нужно сократить." },
-  "config_userStyleRulesTheme_label":     { "message": "Тема:" },
-  "config_userStyleRulesTheme_auto":      { "message": "Авто" },
-  "config_userStyleRulesTheme_separator": { "message": "-----------------" },
-  "config_userStyleRulesTheme_default":   { "message": "По умолчанию" },
-
-
-  "config_addons_caption": { "message": "Дополнительные функции через другие аддоны" },
-
-  "config_addons_description_before": { "message": "Имеются " },
-  "config_addons_description_link_label": { "message": "аддоны, расширяющие возможности TST" },
-  "config_addons_description_after": { "message": ". Посмотрите их, если вам нужно больше функций для панели TST." },
-  "helper_addons_list_link_uri": { "message": "https://github.com/piroor/treestyletab/wiki/Helper-addons-extending-functionality-of-TST" },
-
-  "config_theme_description_before": { "message": "В настоящее время доступны только три встроенные темы \"Простая\", \"Сайдбар\" и \"Контраст\". Если вы хотите использовать не встроенную тему, см. " },
-  "config_theme_description_link_label": { "message": "'Восстановление старых встроенных тем'" },
-  "config_theme_description_after": { "message": " как пример." },
-  "helper_theme_list_link_uri": { "message": "https://github.com/piroor/treestyletab/wiki/Code-snippets-for-custom-style-rules#restore-old-built-in-themes" },
-
-  "config_externaladdonpermissions_label": { "message": "Разрешения для вызова API из других аддонов" },
-  "config_externaladdonpermissions_description": { "message": "Аддоны, разрешенные здесь, смогут получить доступ к данным вкладок или вкладкам в приватных окнах, <em>через разрешения TreeStyleTab<em>, даже если сам аддон не имеет таких разрешений.. <em>Пожалуйста, не давйте разрешений недоверенным аддонам.</em>" },
-  "config_externalAddonPermissions_header_name": { "message": "Название аддона" },
-  "config_externalAddonPermissions_header_permissions": { "message": "Разрешенные специальные операции" },
-  "config_externalAddonPermissions_header_incognito": { "message": "Уведомлять из приватных окон" },
-
-  "addon_containerBookmarks_label": { "message": "Закладки с контейнером" },
-  "addon_containerBookmarks_uri": { "message": "https://addons.mozilla.org/firefox/addon/container-bookmarks/" },
-  "config_containerRedirectKey_label": { "message": "Ключ перенаправления ( * установите значение как в параметрах Container Bookmarks):" },
-
-
-  "config_debug_caption": { "message": "Разработка" },
-
-  "config_link_startupPage_label": { "message": "Стартовая страница Tree Style Tab" },
-  "config_link_groupPage_label":   { "message": "Страница группы вкладок Tree Style Tab" },
-  "config_link_tabbarPage_label":   { "message": "Панель Tree Style Tab во вкладке" },
-
-  "config_runTests_label": { "message": "Запустить автоматические тесты" },
-  "config_runBenchmark_label": { "message": "Запустить бенчмарк" },
-  "config_enableLinuxBehaviors_label": { "message": "Активация специфического поведения Linux" },
-  "config_enableMacOSBehaviors_label": { "message": "Активация специфического поведения macOS" },
-  "config_enableWindowsBehaviors_label": { "message": "Активация специфического поведения Windows" },
-  "config_debug_label": { "message": "Режим отладки" },
-  "config_log_caption":               { "message": "Детальное логирование" },
-  "config_logTimestamp_label": { "message": "Лог с отметками времени" },
-  "config_logFor_common":     { "message": "Запись логов из общих модулей" },
-  "config_logFor_background": { "message": "Запись логов из фоновых модулей" },
-  "config_logFor_sidebar":    { "message": "Запись логов из модулей боковой панели" },
-  "config_loggingQueries_label": { "message": "Лог запросов вкладок" },
-  "config_loggingConnectionMessages_label": { "message": "Лог внутренних сообщений" },
-  "config_showLogsButton_label": { "message": "Показать журналы" },
-  "config_simulateSVGContextFill_label": { "message": "Активировать обходной путь для бага 1388193 и бага 1421329 для симуляции SVG иконок ( * Это может увеличить нагрузку на процессор. Для деактивации переключите \"svg.context-properties.content.enabled\" в \"about:config\", пока эти баги не будут исправлены.)" },
-  "config_staticARIALabel_label": { "message": "Использовать статическую метку ARIA для вкладок" },
-  "config_staticARIALabel_description": { "message": " * Попробуйте отметить это, если ваша система распознавания речи пропускает вкладки после некоторых операций с ними." },
-  "config_useCachedTree_label": { "message": "Оптимизация восстановления дерева с помощью кэша" },
-  "config_useCachedTree_description": { "message": "* Попробуйте снять флажок и установить повторно, чтобы обновить кэш, если поведение дерева нестабильно." },
-  "config_acceleratedTabCreation_label": { "message": "Ускорение операций с повторно открытыми вкладками ( * ПРИМЕЧАНИЕ: Возможно вы увидите нестабильную работу вкладок.)" },
-  "config_maximumAcceptableDelayForTabDuplication_before": { "message": "Отменить дублирование вкладок, когда это продолжается" },
-  "config_maximumAcceptableDelayForTabDuplication_after": { "message": "миллисекунд или больше." },
-  "config_delayForDuplicatedTabDetection_label_before": { "message": "Задержка обнаружения дублей вкладок:" },
-  "config_delayForDuplicatedTabDetection_label_after": { "message": "мс (увеличьте значение, если дубли вкладок не обнаруживаются правильно)" },
-  "config_delayForDuplicatedTabDetection_autoDetect": { "message": "Автоматическое обнаружение" },
-  "config_delayForDuplicatedTabDetection_test": { "message": "Тест обнаружения" },
-  "config_delayForDuplicatedTabDetection_test_resultMessage": { "message": "$PERCENTAGE$% успешно обнаружено.",
+      "NAME": {
+        "content": "$1",
+        "example": "foobar"
+      },
+      "PERMISSIONS": {
+        "content": "$2",
+        "example": "tabs"
+      }
+    }
+  },
+  "api_requestedPermissions_message_linux": {
+    "message": "⚠Аддон \"$NAME$\" запрашивает выполнение операции:\n\n$PERMISSIONS$\n\nЧерез API Tree Style Tab. Нажмите кнопку, если вы разрешаете.",
     "placeholders": {
-      "percentage": { "content": "$1", "example": "50" }
-    }},
-  "config_labelOverflowStyle_caption": { "message": "Слишком длинный заголовок вкладок:" },
-  "config_labelOverflowStyle_fade":    { "message": "Увядание (лучшая видимость)" },
-  "config_labelOverflowStyle_crop":    { "message": "Подставлять \"..\" (лучше производительность)" },
-
-  "config_requestPermissions_bookmarks": { "message": "Разрешить читать и писать закладки" },
-  "config_requestPermissions_bookmarks_context": { "message": "Включить контекстное меню закладок" },
-  "config_requestPermissions_tabHide":   { "message": "Разрешить показывать / скрывать отдельные вкладки ( * Вы должны снять/поставить этот флажок перед запуском тестов, чтобы убедиться, что разрешение получено)" },
-
-  "config_requestPermissions_fallbackToToolbarButton_title": { "message": "Нажмите \"Tree Style Tab\" кнопку панели инструментов" },
-  "config_requestPermissions_fallbackToToolbarButton_message": { "message": "Из-за бага Firefox, вы не сможете запросить разрешение на этой странице. Нажмите \"Tree Style Tab\" кнопку на панели инструментов, чтобы получить разрешение." },
-
-  "config_all_caption": { "message": "Все конфигурации" },
-
-  "config_terms_delimiter": { "message": " " },
-
-
-  "tabContextMenu_newTab_label":      { "message": "Нов&ая вкладка" },
-
-  "tabContextMenu_reload_label":      { "message": "&Обновить вкладку" },
-  "tabContextMenu_mute_label":        { "message": "Выключить зв&ук" },
-  "tabContextMenu_unmute_label":      { "message": "Включить зв&ук" },
-
-  "tabContextMenu_pin_label":         { "message": "Закрепи&ть вкладку" },
-  "tabContextMenu_unpin_label":       { "message": "Открепи&ть вкладку" },
-  "tabContextMenu_duplicate_label":   { "message": "&Дублировать вкладку" },
-  "tabContextMenu_selectAllTabs_label": { "message": "&Выбрать все вкладки" },
-  "tabContextMenu_bookmark_label":    { "message": "Добавить вкладку в зак&ладки" },
-  "tabContextMenu_reopenInContainer_label":             { "message": "Переоткрыть в &контейнере" },
-  "tabContextMenu_reopenInContainer_noContainer_label": { "message": "Переоткрыть &без контейнера" },
-  "tabContextMenu_moveTab_label":     { "message": "&Переместить вкладку" },
-  "tabContextMenu_moveTabToStart_label": { "message": "Переместить в &начало" },
-  "tabContextMenu_moveTabToEnd_label":   { "message": "Переместить в &конец" },
-  "tabContextMenu_tearOff_label":     { "message": "Пере&местить в новое окно" },
-  "tabContextMenu_sendTabsToDevice_label": { "message": "Отправить вкладку на устройство" },
-  "tabContextMenu_sendTabsToAllDevices_label": { "message": "Отправить на все устройства" },
-  "tabContextMenu_manageSyncDevices_label": { "message": "Управление устройствами…" },
-  "tabContextMenu_shareTabURL_label":   { "message": "Поделиться" },
-
-
-  "tabContextMenu_closeMultipleTabs_label":  { "message": "&Закрыть несколько вкладок" },
-  "tabContextMenu_closeTabsToTop_label":  { "message": "Закрыть вкладки с&верху" },
-  "tabContextMenu_closeTabsToBottom_label":  { "message": "Закрыть вкладки с&низу" },
-  "tabContextMenu_closeOther_label":  { "message": "Закрыть &другие вкладки" },
-
-  "tabContextMenu_undoClose_label":   { "message": "Восстанов&ить закрытую вкладку" },
-  "tabContextMenu_undoClose_label_multiple": { "message": "Восстанов&ить закрытые вкладки" },
-  "tabContextMenu_close_label":       { "message": "Закр&ыть вкладку" },
-
-  "tabContextMenu_reload_label_multiselected":      { "message": "&Обновить выбранные вкладки" },
-  "tabContextMenu_mute_label_multiselected":        { "message": "Выключить зв&ук на выбранных" },
-  "tabContextMenu_unmute_label_multiselected":      { "message": "Включить зв&ук на выбранных" },
-
-  "tabContextMenu_pin_label_multiselected":         { "message": "Закрепи&ть вкладки" },
-  "tabContextMenu_unpin_label_multiselected":       { "message": "Открепи&ть вкладки" },
-
-  "tabContextMenu_duplicate_label_multiselected":   { "message": "&Дублировать вкладки" },
-
-  "tabContextMenu_moveTab_label_multiselected": { "message": "П&ереместить вкладки" },
-  "tabContextMenu_sendTabsToDevice_label_multiselected": { "message": "Отправить %S вкладок на устройство" },
-
-  "tabContextMenu_bookmark_label_multiselected": { "message": "Добавить вкладки в зак&ладки…" },
-  "tabContextMenu_bookmarkSelected_label":       { "message": "Добавить выб&ранные в закладки…" },
-
-  "tabContextMenu_close_label_multiselected":       { "message": "Закрыть в&ыбранные вкладки" }
+      "NAME": {
+        "content": "$1",
+        "example": "foobar"
+      },
+      "PERMISSIONS": {
+        "content": "$2",
+        "example": "tabs"
+      }
+    }
+  },
+  "api_requestedPermissions_type_activeTab": {
+    "message": "Доступ к активной вкладке браузера"
+  },
+  "api_requestedPermissions_type_tabs": {
+    "message": "Доступ к вкладкам браузера"
+  },
+  "api_requestedPermissions_type_cookies": {
+    "message": "Обнаружение контейнера вкладок браузера"
+  },
+  "guessNewOrphanTabAsOpenedByNewTabCommandTitle": {
+    "message": "Новая вкладка|Новая приватная вкладка"
+  },
+  "context_menu_label": {
+    "message": "Дерево вкладок"
+  },
+  "context_reloadTree_label": {
+    "message": "Обновить это дерево"
+  },
+  "context_reloadTree_label_multiselected": {
+    "message": "Обновить эти деревья"
+  },
+  "context_reloadTree_command": {
+    "message": "Обновить это дерево"
+  },
+  "context_reloadDescendants_label": {
+    "message": "Обновить дочерние"
+  },
+  "context_reloadDescendants_label_multiselected": {
+    "message": "Обновить дочерние этих вкладок"
+  },
+  "context_reloadDescendants_command": {
+    "message": "Обновить дочерние"
+  },
+  "context_toggleMuteTree_label_mute": {
+    "message": "Убрать зв&ук этого дерева"
+  },
+  "context_toggleMuteTree_label_multiselected_mute": {
+    "message": "Убрать зв&ук выбранных деревьев"
+  },
+  "context_toggleMuteTree_label_unmute": {
+    "message": "Вкл. зв&ук этому дереву"
+  },
+  "context_toggleMuteTree_label_multiselected_unmute": {
+    "message": "Вкл. зв&ук выбранным деревьям"
+  },
+  "context_toggleMuteTree_command": {
+    "message": "Убрать/дать звук этому дереву"
+  },
+  "context_toggleMuteDescendants_label_mute": {
+    "message": "Убра&ть звук у дочерних"
+  },
+  "context_toggleMuteDescendants_label_multiselected_mute": {
+    "message": "Убра&ть звук у дочерних выбранных вкладок"
+  },
+  "context_toggleMuteDescendants_label_unmute": {
+    "message": "Да&ть звук дочерним"
+  },
+  "context_toggleMuteDescendants_label_multiselected_unmute": {
+    "message": "Да&ть звук дочерним выбранных вкладок"
+  },
+  "context_toggleMuteDescendants_command": {
+    "message": "Убрать/дать звук дочерним"
+  },
+  "context_unblockAutoplayTree_label": {
+    "message": "П&роигрывать это дерево"
+  },
+  "context_unblockAutoplayTree_label_multiselected": {
+    "message": "П&роигрывать выбранные деревья"
+  },
+  "context_unblockAutoplayTree_command": {
+    "message": "Проигрывать это дерево"
+  },
+  "context_unblockAutoplayDescendants_label": {
+    "message": "Пр&оигрывать дочерние"
+  },
+  "context_unblockAutoplayDescendants_label_multiselected": {
+    "message": "Пр&оигрывать дочерние у выбранных вкладок"
+  },
+  "context_unblockAutoplayDescendants_command": {
+    "message": "Проигрывать дочерние"
+  },
+  "context_closeTree_label": {
+    "message": "Закрыть это дерево"
+  },
+  "context_closeTree_label_multiselected": {
+    "message": "Закрыть эти деревья"
+  },
+  "context_closeTree_command": {
+    "message": "Закрыть это дерево"
+  },
+  "context_closeDescendants_label": {
+    "message": "Закрыть дочерние"
+  },
+  "context_closeDescendants_label_multiselected": {
+    "message": "Закрыть дочерние этих вкладок"
+  },
+  "context_closeDescendants_command": {
+    "message": "Закрыть дочерние"
+  },
+  "context_closeOthers_label": {
+    "message": "Закрыть все, кроме этого дерева"
+  },
+  "context_closeOthers_label_multiselected": {
+    "message": "Закрыть другие, кроме этих деревьев"
+  },
+  "context_closeOthers_command": {
+    "message": "Закрыть все, кроме этого дерева"
+  },
+  "context_toggleSticky_label_stick": {
+    "message": "Закрепит&ь вкладку сбоку"
+  },
+  "context_toggleSticky_label_multiselected_stick": {
+    "message": "Закрепит&ь выбранные вкладки сбоку"
+  },
+  "context_toggleSticky_label_unstick": {
+    "message": "Открепит&ь вкладку с бока"
+  },
+  "context_toggleSticky_label_multiselected_unstick": {
+    "message": "Открепит&ь выбранные вкладки с бока"
+  },
+  "context_toggleSticky_command": {
+    "message": "За-/Открепить вкладки по бокам"
+  },
+  "context_collapseTree_label": {
+    "message": "Свернуть это дерево"
+  },
+  "context_collapseTree_label_multiselected": {
+    "message": "Свернуть эти деревья"
+  },
+  "context_collapseTree_command": {
+    "message": "Свернуть это дерево"
+  },
+  "context_collapseTreeRecursively_label": {
+    "message": "Свернуть это дерево рекурсивно"
+  },
+  "context_collapseTreeRecursively_label_multiselected": {
+    "message": "Свернуть эти деревья рекурсивно"
+  },
+  "context_collapseTreeRecursively_command": {
+    "message": "Свернуть это дерево рекурсивн"
+  },
+  "context_collapseAll_label": {
+    "message": "Свернуть все"
+  },
+  "context_collapseAll_command": {
+    "message": "Свернуть все"
+  },
+  "context_expandTree_label": {
+    "message": "Развернуть это дерево"
+  },
+  "context_expandTree_label_multiselected": {
+    "message": "Развернуть эти деревья"
+  },
+  "context_expandTree_command": {
+    "message": "Развернуть это дерево"
+  },
+  "context_expandTreeRecursively_label": {
+    "message": "Развернуть это дерево рекурсивно"
+  },
+  "context_expandTreeRecursively_label_multiselected": {
+    "message": "Развернуть эти деревья рекурсивно"
+  },
+  "context_expandTreeRecursively_command": {
+    "message": "Развернуть это дерево рекурсивно"
+  },
+  "context_expandAll_label": {
+    "message": "Развернуть все"
+  },
+  "context_expandAll_command": {
+    "message": "Развернуть все"
+  },
+  "context_bookmarkTree_label": {
+    "message": "Всё дерево в закладки…"
+  },
+  "context_bookmarkTree_label_multiselected": {
+    "message": "Выбранные деревья в закладки…"
+  },
+  "context_bookmarkTree_command": {
+    "message": "Всё дерево в закладки…"
+  },
+  "context_sendTreeToDevice_label": {
+    "message": "Отправить это дерево на устройство"
+  },
+  "context_sendTreeToDevice_label_multiselected": {
+    "message": "Отправить выбранные деревья на устройство"
+  },
+  "context_sendTreeToDevice_command": {
+    "message": "Отправить это дерево на устройство"
+  },
+  "context_topLevel_prefix": {
+    "message": "Верхний элемент: "
+  },
+  "context_collapsed_label": {
+    "message": "Свернут (для проверки меню типа флажок)"
+  },
+  "context_pinnedTab_label": {
+    "message": "Прикреплен (для проверки меню типа переключатель)"
+  },
+  "context_unpinnedTab_label": {
+    "message": "Откреплен (для проверки меню типа переключатель)"
+  },
+  "context_openAllBookmarksWithStructure_label": {
+    "message": "Открыть все как дерево"
+  },
+  "context_openAllBookmarksWithStructureRecursively_label": {
+    "message": "Открыть все включая подпапки"
+  },
+  "config_showTreeCommandsInTabsContextMenuGlobally_label": {
+    "message": "Показывать управление над древовидными вкладками в глобальном контекстном меню, например в браузерной панели вкладок "
+  },
+  "config_title": {
+    "message": "Настройки Tree Style Tab"
+  },
+  "config_recommended_choice": {
+    "message": "(Рекомендуется)"
+  },
+  "config_firefoxCompatible_choice": {
+    "message": "(имитация поведения Firefox)"
+  },
+  "config_showExpertOptions_label": {
+    "message": "Режим эксперта"
+  },
+  "config_openOptionsInTab_label": {
+    "message": "Открыть эту страницу в широком представлении "
+  },
+  "config_appearance_caption": {
+    "message": "Внешний вид"
+  },
+  "config_sidebarPosition_caption": {
+    "message": "Позиция содержимого боковой панели:"
+  },
+  "config_sidebarPosition_left": {
+    "message": "Слева"
+  },
+  "config_sidebarPosition_right": {
+    "message": "Справа"
+  },
+  "config_sidebarPosition_auto": {
+    "message": "Автоопределять когда показывать боковую панель"
+  },
+  "config_sidebarPosition_description": {
+    "message": "* Эта настройка не меняет положение боковой панели. Если нужно переместить саму панель, то в меню заголовка боковой панели выберите \"Переместить боковую панель...\"."
+  },
+  "config_style_caption": {
+    "message": "Тема"
+  },
+  "config_style_proton": {
+    "message": "Proton"
+  },
+  "config_style_photon": {
+    "message": "Photon"
+  },
+  "config_style_sidebar": {
+    "message": "Боковая панель"
+  },
+  "config_style_highcontrast": {
+    "message": "Высококонтрастный"
+  },
+  "config_style_none": {
+    "message": "Без стиля"
+  },
+  "config_style_none_info": {
+    "message": " ( * Можете перекрасить всё самостоятельно через \"Расширенные настройки\" => \"Пользовательские стили\")"
+  },
+  "config_colorScheme_caption": {
+    "message": "Цветовая схема:"
+  },
+  "config_colorScheme_photon": {
+    "message": "Photon"
+  },
+  "config_colorScheme_systemColor": {
+    "message": "Системные цвета"
+  },
+  "config_maxTreeLevel_before": {
+    "message": "Отступ вкладок до"
+  },
+  "config_maxTreeLevel_after": {
+    "message": "уровней ( * Отрицательное значение = \"бесконечно\")"
+  },
+  "config_faviconizePinnedTabs_label": {
+    "message": "Показывать закрепленные вкладки как значок"
+  },
+  "config_maxFaviconizedPinnedTabsInOneRow_label_before": {
+    "message": "Показать "
+  },
+  "config_maxFaviconizedPinnedTabsInOneRow_label_after": {
+    "message": " или меньше вкладок на строку ( * 0 или \"-\" авторасчет)"
+  },
+  "config_maxPinnedTabsRowsAreaPercentage_label_before": {
+    "message": "Максимум высоты области закрепленных вкладок:"
+  },
+  "config_maxPinnedTabsRowsAreaPercentage_label_after": {
+    "message": "% от боковой панели"
+  },
+  "config_animation_label": {
+    "message": "Включить эффекты анимации"
+  },
+  "config_animationForce_label": {
+    "message": "Включить анимацию независимо от настроек браузера"
+  },
+  "config_showCollapsedDescendantsByTooltip_label": {
+    "message": "Показывать свернутые дочерние элементы в подсказке вкладки"
+  },
+  "config_shiftTabsForScrollbarDistance_label_before": {
+    "message": "Сдвигать вкладки в сторону на "
+  },
+  "config_shiftTabsForScrollbarDistance_label_after": {
+    "message": " чтобы кнопки на вкладках не перекрывались скролбаром"
+  },
+  "config_shiftTabsForScrollbarDistance_placeholder": {
+    "message": "(CSS length)"
+  },
+  "config_shiftTabsForScrollbarOnlyOnHover_label": {
+    "message": "Сдвигать вкладки только если курсор рядом с полосой прокрутки"
+  },
+  "config_suppressGapFromShownOrHiddenToolbar_caption": {
+    "message": "Исправлять глюки боковой панели при отображении/скрытии других панелей, для:"
+  },
+  "config_suppressGapFromShownOrHiddenToolbarOnFullScreen_label": {
+    "message": "Полноэкранных окон"
+  },
+  "config_suppressGapFromShownOrHiddenToolbarOnNewTab_label": {
+    "message": "Пустых новых вкладок (Firefox 85 и новее)"
+  },
+  "config_suppressGapFromShownOrHiddenToolbarOnlyOnMouseOperation_label": {
+    "message": "Только при щелчках на боковой панели."
+  },
+  "config_showDialogInSidebar_label": {
+    "message": "Показать диалоги на боковой панели, если возможно"
+  },
+  "config_outOfScreenTabsRenderingPages_label": {
+    "message": "Сколько страниц отрисовывать заранее:"
+  },
+  "config_outOfScreenTabsRenderingPages_description": {
+    "message": "* \"-1\" будет отрисовывать все вкладки для ускорения прокрутки, но из-за этого первоначальная загрузка может дольше длиться."
+  },
+  "config_renderHiddenTabs_label": {
+    "message": "Показывать скрытые вкладки, скрытые другими расширениями"
+  },
+  "config_context_caption": {
+    "message": "Контекстное меню"
+  },
+  "config_emulateDefaultContextMenu_label": {
+    "message": "Имитация контекстного меню вкладок на боковой панели"
+  },
+  "config_extraItems_tabs_caption": {
+    "message": "Дополнительные пункты контекстного меню"
+  },
+  "config_extraItems_tabs_topLevel": {
+    "message": "Основное меню"
+  },
+  "config_extraItems_tabs_subMenu": {
+    "message": "Вложенное меню"
+  },
+  "config_extraItems_tabs_middleClick": {
+    "message": "Действие щелчка колесика"
+  },
+  "config_extraItems_bookmarks_caption": {
+    "message": "Пункты контекстного меню закладок"
+  },
+  "config_openAllBookmarksWithStructureDiscarded_label": {
+    "message": "Открывать незагруженными"
+  },
+  "config_suppressGroupTabForStructuredTabsFromBookmarks_label": {
+    "message": "Отмена групповой вкладки верхнего уровня, если вкладки уже организованы в дерево"
+  },
+  "config_sendTabsToDevice_caption": {
+    "message": "Отправляйте вкладки на другие устройства из контекстного меню через Firefox Sync"
+  },
+  "config_syncRequirements_description": {
+    "message": "Эта функция зависит от Firefox Sync. Вкладки можно отправлять только на устройства с установленным TST. Сначала активируйте Firefox Sync в настройках Firefox и установите TST на другие устройства."
+  },
+  "config_syncDeviceInfo_name_label": {
+    "message": "Название и значок этого устройства:"
+  },
+  "config_syncDeviceInfo_name_description_before": {
+    "message": "TST не может определить имя устройства, из-за ограничений API WebExtensions. Установите имя(id) для этого устройства вручную. (Рекомендуется копировать "
+  },
+  "config_syncDeviceInfo_name_description_link": {
+    "message": "имя устройства из Firefox Sync"
+  },
+  "config_syncDeviceInfo_name_description_href": {
+    "message": "https://accounts.firefox.com/settings/clients"
+  },
+  "config_syncDeviceInfo_name_description_after": {
+    "message": ".)"
+  },
+  "config_syncDeviceExpirationDays_label_before": {
+    "message": "Автоисключение неиспользуемых устройств, если они не подключались более "
+  },
+  "config_syncDeviceExpirationDays_label_after": {
+    "message": " дней (\"0\" - \"не исключать\")"
+  },
+  "config_syncUnsendableUrlPattern_label": {
+    "message": "Правило соответствия для неотправляемых URL вкладок ( * Это должно быть синхронизировано с параметром \"services.sync.engine.tabs.filteredUrls\" Firefox:"
+  },
+  "config_otherDevices_caption": {
+    "message": "Активные другие устройства:"
+  },
+  "config_removeDeviceButton_label": {
+    "message": "Удалить"
+  },
+  "config_removeDeviceButton_tooltip": {
+    "message": "Удалить это устройство из списка"
+  },
+  "config_autoAttachOnContextNewTabCommand_before": {
+    "message": "Для кнопки \"Новая вкладка\" в контекстном меню, открывать пустую вкладку как"
+  },
+  "config_autoAttachOnContextNewTabCommand_noControl": {
+    "message": "(не контролируется)"
+  },
+  "config_autoAttachOnContextNewTabCommand_independent": {
+    "message": "Независимая вкладка"
+  },
+  "config_autoAttachOnContextNewTabCommand_childTop": {
+    "message": "Первая дочерняя от текущей вкладки"
+  },
+  "config_autoAttachOnContextNewTabCommand_childEnd": {
+    "message": "Последняя дочерняя от текущей вкладки"
+  },
+  "config_autoAttachOnContextNewTabCommand_sibling": {
+    "message": "Соседняя от текущей вкладки"
+  },
+  "config_autoAttachOnContextNewTabCommand_nextSibling": {
+    "message": "След. соседняя от текущей вкладки"
+  },
+  "config_autoAttachOnContextNewTabCommand_nextSiblingWithInheritedContainer": {
+    "message": "След. соседняя, тот же контейнер"
+  },
+  "config_autoAttachOnContextNewTabCommand_after": {
+    "message": "​"
+  },
+  "config_newTabWithOwner_caption": {
+    "message": "Вкладки, открытые из существующих вкладок"
+  },
+  "config_autoAttachOnOpenedWithOwner_before": {
+    "message": "Если вкладка открывается из существующей вкладки, открыть ее как - "
+  },
+  "config_autoAttachOnOpenedWithOwner_noControl": {
+    "message": "(не контролируется)"
+  },
+  "config_autoAttachOnOpenedWithOwner_independent": {
+    "message": "независимая вкладка"
+  },
+  "config_autoAttachOnOpenedWithOwner_childNextToLastRelatedTab": {
+    "message": "дочерняя вкладка, рядом с недавно открытой дочерней"
+  },
+  "config_autoAttachOnOpenedWithOwner_childTop": {
+    "message": "Первая дочерняя от родительской вкладки"
+  },
+  "config_autoAttachOnOpenedWithOwner_childEnd": {
+    "message": "Последняя дочерняя от родительской вкладки"
+  },
+  "config_autoAttachOnOpenedWithOwner_sibling": {
+    "message": "Соседняя от родительской вкладки"
+  },
+  "config_autoAttachOnOpenedWithOwner_nextSibling": {
+    "message": "След. соседняя от родительской вкладки"
+  },
+  "config_autoAttachOnOpenedWithOwner_after": {
+    "message": "​"
+  },
+  "config_insertNewTabFromFirefoxViewAt_caption": {
+    "message": "Куда вставлять новые вкладки от Firefox View (будут появляться как корневые вкладки)"
+  },
+  "config_insertNewTabFromFirefoxViewAt_noControl": {
+    "message": "Без изменений (оставлять решение за браузером или другими расширениями вкладок)"
+  },
+  "config_insertNewTabFromFirefoxViewAt_top": {
+    "message": "В верху дерева (рядом с открывающей)"
+  },
+  "config_insertNewTabFromFirefoxViewAt_end": {
+    "message": "В конце дерева"
+  },
+  "config_autoGroupNewTabsFromFirefoxView_label": {
+    "message": "Автогруппирование вкладок открытых из Firefox View (новая вкладка группы будет открыта с заголовком типа \"Вкладки из ...\")"
+  },
+  "config_groupTabTemporaryStateForChildrenOfFirefoxView_label": {
+    "message": "Стандартное состояние группы вкладок открытых из Firefox View: "
+  },
+  "config_insertNewTabFromPinnedTabAt_caption": {
+    "message": "Позиция новых дочерних вкладок открытых из закрепленных (будут отображаться как корневые)"
+  },
+  "config_insertNewTabFromPinnedTabAt_noControl": {
+    "message": "Не контролируется (решает Firefox или другие аддоны)"
+  },
+  "config_insertNewTabFromPinnedTabAt_nextToLastRelatedTab": {
+    "message": "После недавно открытой дочерней или рядом с родителем"
+  },
+  "config_insertNewTabFromPinnedTabAt_top": {
+    "message": "Добавить в начало дерева (рядом с родителем)"
+  },
+  "config_insertNewTabFromPinnedTabAt_end": {
+    "message": "Добавить в конец дерева"
+  },
+  "config_autoGroupNewTabsFromPinned_label": {
+    "message": "Автогруппировка вкладок, открытых с одной закрепленной вкладки (с вкладкой группы с заголовком типа \"Вкладки из ...\")"
+  },
+  "config_groupTabTemporaryStateForChildrenOfPinned_label": {
+    "message": "Состояние по умолчанию вкладки группы для вкладок, открытых с одной закрепленной вкладки:"
+  },
+  "config_newTab_caption": {
+    "message": "Вкладки, открытые НЕ из существующих вкладок"
+  },
+  "config_newTabButton_caption": {
+    "message": "Специальные действия для кнопки \"Новая вкладка\" "
+  },
+  "config_longPressOnNewTabButton_before": {
+    "message": "Длительное нажатие кнопки \"Новая вкладка\", чтобы "
+  },
+  "config_longPressOnNewTabButton_newTabAction": {
+    "message": "указать, где откроется новая вкладка"
+  },
+  "config_longPressOnNewTabButton_contextualIdentities": {
+    "message": "выбрать контейнер"
+  },
+  "config_longPressOnNewTabButton_none": {
+    "message": "(ничего)"
+  },
+  "config_longPressOnNewTabButton_after": {
+    "message": "​"
+  },
+  "config_showNewTabActionSelector_label": {
+    "message": "Показывать кнопку выбора позиции на кнопке \"Новая вкладка\" "
+  },
+  "config_showContextualIdentitiesSelector_label": {
+    "message": "Показывать кнопку выбора контейнера на кнопке \"Новая вкладка\" "
+  },
+  "config_newTabAction_caption": {
+    "message": "Управляющие элементы \"Новой вкладкой\" (кнопки панели, горячие клавиши и прочее)"
+  },
+  "config_autoAttachOnNewTabCommand_before": {
+    "message": "Открыть новую пустую вкладку как"
+  },
+  "config_autoAttachOnNewTabCommand_noControl": {
+    "message": "(не контролируется)"
+  },
+  "config_autoAttachOnNewTabCommand_independent": {
+    "message": "независимую вкладку"
+  },
+  "config_autoAttachOnNewTabCommand_childTop": {
+    "message": "Первая дочерняя текущей вкладки"
+  },
+  "config_autoAttachOnNewTabCommand_childEnd": {
+    "message": "Последняя дочерняя текущей вкладки"
+  },
+  "config_autoAttachOnNewTabCommand_sibling": {
+    "message": "одноуровневую вкладку"
+  },
+  "config_autoAttachOnNewTabCommand_nextSibling": {
+    "message": "следующую одноуровневую"
+  },
+  "config_autoAttachOnNewTabCommand_after": {
+    "message": "​"
+  },
+  "config_guessNewOrphanTabAsOpenedByNewTabCommandTitle_before": {
+    "message": "Считать свежеоткрытую вкладку как открытую действием \"Новая вкладка\", если она открывается с заголовком(-ами) "
+  },
+  "config_guessNewOrphanTabAsOpenedByNewTabCommandUrl_before": {
+    "message": " или адресом(-ами)"
+  },
+  "config_guessNewOrphanTabAsOpenedByNewTabCommandUrl_after": {
+    "message": "(* Можно задать несколько значений списком, разделяя их \"|\")"
+  },
+  "config_autoAttachOnNewTabButtonMiddleClick_before": {
+    "message": "По щелчку колесиком, открыть новую пустую вкладку как"
+  },
+  "config_autoAttachOnNewTabButtonMiddleClick_noControl": {
+    "message": "(не контролируется)"
+  },
+  "config_autoAttachOnNewTabButtonMiddleClick_independent": {
+    "message": "независимую вкладку"
+  },
+  "config_autoAttachOnNewTabButtonMiddleClick_childTop": {
+    "message": "Первая дочерняя текущей вкладки"
+  },
+  "config_autoAttachOnNewTabButtonMiddleClick_childEnd": {
+    "message": "Последняя дочерняя текущей вкладки"
+  },
+  "config_autoAttachOnNewTabButtonMiddleClick_sibling": {
+    "message": "одноуровневую вкладку"
+  },
+  "config_autoAttachOnNewTabButtonMiddleClick_nextSibling": {
+    "message": "следующую одноуровневую"
+  },
+  "config_autoAttachOnNewTabButtonMiddleClick_nextSiblingWithInheritedContainer": {
+    "message": "тоже что и с Ctrl (следующую одноуровневую, тот же контейнер)"
+  },
+  "config_autoAttachOnNewTabButtonMiddleClick_after": {
+    "message": "​"
+  },
+  "config_middleClickPasteURLOnNewTabButton_label": {
+    "message": "Открыть новую вкладку по адресу из буфера обмена (*симуляция браузерного поведения с \"browser.tabs.searchclipboardfor.middleclick\"=\"true\", еще может надо будет включить \"dom.events.asyncClipboard.clipboardItem\")"
+  },
+  "config_autoAttachOnNewTabButtonAccelClick_before": {
+    "message": "Щелчком ЛКМ+Ctrl/⌘, открыть новую пустую вкладку как"
+  },
+  "config_autoAttachOnNewTabButtonAccelClick_noControl": {
+    "message": "(не контролируется)"
+  },
+  "config_autoAttachOnNewTabButtonAccelClick_independent": {
+    "message": "независимую вкладку"
+  },
+  "config_autoAttachOnNewTabButtonAccelClick_childTop": {
+    "message": "Первая дочерняя текущей вкладки"
+  },
+  "config_autoAttachOnNewTabButtonAccelClick_childEnd": {
+    "message": "Последняя дочерняя текущей вкладки"
+  },
+  "config_autoAttachOnNewTabButtonAccelClick_sibling": {
+    "message": "одноуровневую вкладку"
+  },
+  "config_autoAttachOnNewTabButtonAccelClick_nextSibling": {
+    "message": "следующую одноуровневую"
+  },
+  "config_autoAttachOnNewTabButtonAccelClick_nextSiblingWithInheritedContainer": {
+    "message": "следующую одноуровневую, тот же контейнер"
+  },
+  "config_autoAttachOnNewTabButtonAccelClick_after": {
+    "message": "​"
+  },
+  "config_autoAttachWithURL_caption": {
+    "message": "Непустые новые вкладки"
+  },
+  "config_duplicateTabAction_caption": {
+    "message": "Дублировать вкладки (щелчком СКМ на кнопке \"Перезагрузить\" и т. п.)"
+  },
+  "config_autoAttachOnDuplicated_before": {
+    "message": "Дублировать вкладку как"
+  },
+  "config_autoAttachOnDuplicated_noControl": {
+    "message": "(не контролируется)"
+  },
+  "config_autoAttachOnDuplicated_independent": {
+    "message": "независимую вкладку"
+  },
+  "config_autoAttachOnDuplicated_childTop": {
+    "message": "Первая дочерняя текущей вкладки"
+  },
+  "config_autoAttachOnDuplicated_childEnd": {
+    "message": "Последняя дочерняя текущей вкладки"
+  },
+  "config_autoAttachOnDuplicated_sibling": {
+    "message": "одноуровневую вкладку"
+  },
+  "config_autoAttachOnDuplicated_nextSibling": {
+    "message": "следующую одноуровневую"
+  },
+  "config_autoAttachOnDuplicated_after": {
+    "message": "​"
+  },
+  "config_fromExternal_caption": {
+    "message": "Новая вкладка передается извне Firefox"
+  },
+  "config_autoAttachOnOpenedFromExternal_before": {
+    "message": "Открыть как"
+  },
+  "config_autoAttachOnOpenedFromExternal_noControl": {
+    "message": "(не контролируется)"
+  },
+  "config_autoAttachOnOpenedFromExternal_independent": {
+    "message": "независимую вкладку"
+  },
+  "config_autoAttachOnOpenedFromExternal_childTop": {
+    "message": "Первая дочерняя текущей вкладки"
+  },
+  "config_autoAttachOnOpenedFromExternal_childEnd": {
+    "message": "Последняя дочерняя текущей вкладки"
+  },
+  "config_autoAttachOnOpenedFromExternal_sibling": {
+    "message": "одноуровневую вкладку"
+  },
+  "config_autoAttachOnOpenedFromExternal_nextSibling": {
+    "message": "следующую одноуровневую"
+  },
+  "config_autoAttachOnOpenedFromExternal_after": {
+    "message": "​"
+  },
+  "config_inheritContextualIdentityToTabsFromExternalMode_label": {
+    "message": "Контейнер:"
+  },
+  "config_inheritContextualIdentityToTabsFromExternalMode_default": {
+    "message": "(не контролируется)"
+  },
+  "config_inheritContextualIdentityToTabsFromExternalMode_parent": {
+    "message": "Наследовать от родительской вкладки в дереве"
+  },
+  "config_inheritContextualIdentityToTabsFromExternalMode_lastActive": {
+    "message": "Наследовать от текущей вкладки"
+  },
+  "config_sameSiteOrphan_caption": {
+    "message": "Если новая вкладка открывается с сайтом, как в текущей вкладке -"
+  },
+  "config_autoAttachSameSiteOrphan_before": {
+    "message": "Открыть ее как "
+  },
+  "config_autoAttachSameSiteOrphan_noControl": {
+    "message": "(не контролируется)"
+  },
+  "config_autoAttachSameSiteOrphan_independent": {
+    "message": "независимую вкладку"
+  },
+  "config_autoAttachSameSiteOrphan_childTop": {
+    "message": "Первая дочерняя текущей вкладки"
+  },
+  "config_autoAttachSameSiteOrphan_childEnd": {
+    "message": "Последняя дочерняя текущей вкладки"
+  },
+  "config_autoAttachSameSiteOrphan_sibling": {
+    "message": "одноуровневую вкладку"
+  },
+  "config_autoAttachSameSiteOrphan_nextSibling": {
+    "message": "следующую одноуровневую"
+  },
+  "config_autoAttachSameSiteOrphan_after": {
+    "message": "​"
+  },
+  "config_inheritContextualIdentityToSameSiteOrphanMode_label": {
+    "message": "Контейнер:"
+  },
+  "config_inheritContextualIdentityToSameSiteOrphanMode_default": {
+    "message": "(не контролируется)"
+  },
+  "config_inheritContextualIdentityToSameSiteOrphanMode_parent": {
+    "message": "Наследовать от родительской вкладки в дереве"
+  },
+  "config_inheritContextualIdentityToSameSiteOrphanMode_lastActive": {
+    "message": "Наследовать от текущей вкладки"
+  },
+  "config_anyOtherTrigger_caption": {
+    "message": "Вкладки из любого другого триггера"
+  },
+  "config_autoAttachOnAnyOtherTrigger_before": {
+    "message": "Открыть как"
+  },
+  "config_autoAttachOnAnyOtherTrigger_noControl": {
+    "message": "(не контролируется)"
+  },
+  "config_autoAttachOnAnyOtherTrigger_independent": {
+    "message": "независимую вкладку"
+  },
+  "config_autoAttachOnAnyOtherTrigger_childTop": {
+    "message": "Первая дочерняя текущей вкладки"
+  },
+  "config_autoAttachOnAnyOtherTrigger_childEnd": {
+    "message": "Последняя дочерняя текущей вкладки"
+  },
+  "config_autoAttachOnAnyOtherTrigger_sibling": {
+    "message": "одноуровневую вкладку"
+  },
+  "config_autoAttachOnAnyOtherTrigger_nextSibling": {
+    "message": "следующую одноуровневую"
+  },
+  "config_autoAttachOnAnyOtherTrigger_after": {
+    "message": "​"
+  },
+  "config_autoAttachOnAnyOtherTrigger_caution": {
+    "message": " * ВНИМАНИЕ: этот параметр может нарушить работу других аддонов."
+  },
+  "config_inheritContextualIdentityToTabsFromAnyOtherTriggerMode_label": {
+    "message": "Контейнер:"
+  },
+  "config_inheritContextualIdentityToTabsFromAnyOtherTriggerMode_default": {
+    "message": "(не контролируется)"
+  },
+  "config_inheritContextualIdentityToTabsFromAnyOtherTriggerMode_parent": {
+    "message": "Наследовать от родительской вкладки в дереве"
+  },
+  "config_inheritContextualIdentityToTabsFromAnyOtherTriggerMode_lastActive": {
+    "message": "Наследовать от текущей вкладки"
+  },
+  "config_inheritContextualIdentityToUnopenableURLTabs_label": {
+    "message": "Переоткрыть вкладку в унаследованном контейнере, даже если там неоткрывающийся, из-за доступа расширения, адрес"
+  },
+  "config_groupTab_caption": {
+    "message": "Автогруппировка вкладок"
+  },
+  "config_tabBunchesDetectionTimeout_before": {
+    "message": "Обнаружение вкладок, открытых из закладок в течение"
+  },
+  "config_tabBunchesDetectionTimeout_after": {
+    "message": "мс, и:"
+  },
+  "config_autoGroupNewTabsFromBookmarks_label": {
+    "message": "Группировать вкладки с заголовком типа \"... и т. п.\""
+  },
+  "config_restoreTreeForTabsFromBookmarks_label": {
+    "message": "Восстановить структуру дерева"
+  },
+  "config_requireBookmarksPermission_tooltiptext": {
+    "message": "Эта функция требует права доступа к закладкам. Нажмите здесь, чтобы запросить необходимое разрешение."
+  },
+  "config_requestPermissions_bookmarks_autoGroupNewTabs_before": {
+    "message": "("
+  },
+  "config_requestPermissions_bookmarks_autoGroupNewTabs_after": {
+    "message": "Разрешить обнаруживать закладки, соответствующие вкладкам)"
+  },
+  "config_tabsFromSameFolderMinThresholdPercentage_before": {
+    "message": "Рассматривать все новые вкладки как открытые из одной папки закладок, если более "
+  },
+  "config_tabsFromSameFolderMinThresholdPercentage_after": {
+    "message": "% вкладок имеют соответствующую закладку в общей папке закладок"
+  },
+  "config_autoGroupNewTabsFromOthers_label": {
+    "message": "Автогруппировать вкладки, открытые одновременно не из закладок"
+  },
+  "config_tabBunchesDetectionDelayOnNewWindow_before": {
+    "message": "Автогруппировать вкладки открытые в течении"
+  },
+  "config_tabBunchesDetectionDelayOnNewWindow_after": {
+    "message": "мс, при открытии нового окна, в составе вкладок открытых как \"домашняя страница\"."
+  },
+  "config_warnOnAutoGroupNewTabs_label": {
+    "message": "Подтверждать группировку вкладок"
+  },
+  "config_warnOnAutoGroupNewTabsWithListing_label": {
+    "message": "Группировать список вкладок в диалоге подтверждения"
+  },
+  "config_renderTreeInGroupTabs_label": {
+    "message": "Отрисовывать дерево во вкладке группы"
+  },
+  "config_groupTabTemporaryState_caption": {
+    "message": "Состояние (по умолчанию) группы вкладок для разных контекстов"
+  },
+  "config_groupTabTemporaryState_option_default": {
+    "message": "Не проверять"
+  },
+  "config_groupTabTemporaryState_option_checked_before": {
+    "message": "Проверять \""
+  },
+  "config_groupTabTemporaryState_option_checked_after": {
+    "message": "\""
+  },
+  "config_groupTabTemporaryStateForNewTabsFromBookmarks_label": {
+    "message": "Для открытых из закладок:"
+  },
+  "config_groupTabTemporaryStateForNewTabsFromOthers_label": {
+    "message": "Для открытых одновременно не из закладок:"
+  },
+  "config_groupTabTemporaryStateForOrphanedTabs_label": {
+    "message": "Открытую для замены закрытой родительской вкладки::"
+  },
+  "config_inheritContextualIdentityToChildTabMode_label": {
+    "message": "Контейнер:"
+  },
+  "config_inheritContextualIdentityToChildTabMode_default": {
+    "message": "(не контролируется)"
+  },
+  "config_inheritContextualIdentityToChildTabMode_parent": {
+    "message": "Наследовать от родительской вкладки в дереве"
+  },
+  "config_inheritContextualIdentityToChildTabMode_lastActive": {
+    "message": "Наследовать от текущей вкладки"
+  },
+  "config_treeBehavior_caption": {
+    "message": "Поведение дерева"
+  },
+  "config_successorTabControlLevel_caption": {
+    "message": "Если текущая вкладка закрывается как последняя дочерняя"
+  },
+  "config_successorTabControlLevel_inTree": {
+    "message": "Перейти на предыдущую вкладку дерева"
+  },
+  "config_successorTabControlLevel_simulateDefault": {
+    "message": "Перейти на следующую вкладку (как в Firefox)"
+  },
+  "config_successorTabControlLevel_never": {
+    "message": "Не контролировать фокус (решает Firefox или другие аддоны)"
+  },
+  "config_successorTabControlLevel_legacyDescription": {
+    "message": "* Поведение Firefox с \"browser.tabs.selectOwnerOnClose\"=\"true\" сработает раньше этой настройки."
+  },
+  "config_simulateSelectOwnerOnClose_label": {
+    "message": "Переместить фокус на вкладку, из которой открыта закрываемая ( * имитация \"browser.tabs.selectOwnerOnClose\"=\"true\", приорететно для настроек выше)"
+  },
+  "config_fixupTreeOnTabVisibilityChanged_caption": {
+    "message": "Если видимость вкладок изменяется другими аддонами"
+  },
+  "config_fixupTreeOnTabVisibilityChanged_fix": {
+    "message": "Исправить древья с видимыми вкладками ( * Рекомендуется, если есть другие аддоны для переключения групп вкладок)"
+  },
+  "config_fixupTreeOnTabVisibilityChanged_keep": {
+    "message": "Сохранить деревья включая скрытые вкладки ( * Рекомендуется, если есть другие аддоны для скрытия групп вкладок)"
+  },
+  "config_autoCollapseExpandSubtreeOnAttach_label": {
+    "message": "Если появляется новое дерево, автосвернуть остальные"
+  },
+  "config_autoCollapseExpandSubtreeOnSelect_label": {
+    "message": "Если вкладка получает фокус, развернуть её дерево и автосвернуть другие"
+  },
+  "config_autoCollapseExpandSubtreeOnSelectExceptActiveTabRemove_label": {
+    "message": "За исключением фокуса, вызванного закрытием текущей вкладки"
+  },
+  "config_unfocusableCollapsedTab_label": {
+    "message": "Если свернутая вкладка получает фокус, авторазвернуть ее дерево"
+  },
+  "config_autoDiscardTabForUnexpectedFocus_label": {
+    "message": "Удерживать вкладки выгружеными при кратковременном фокусе"
+  },
+  "config_avoidDiscardedTabToBeActivatedIfPossible_label": {
+    "message": "Избегать активации выгруженных при закрытии текущей или сворачивании дерева"
+  },
+  "config_treeDoubleClickBehavior_caption": {
+    "message": "Двойной щелчок"
+  },
+  "config_treeDoubleClickBehavior_toggleCollapsed": {
+    "message": "Свернуть/развернуть дерево"
+  },
+  "config_treeDoubleClickBehavior_toggleSticky": {
+    "message": "Не/Прикрепляться к краям панели вкладок"
+  },
+  "config_treeDoubleClickBehavior_close": {
+    "message": "Закрыть вкладку"
+  },
+  "config_treeDoubleClickBehavior_close_note": {
+    "message": " (* имитация поведения браузера с \"browser.tabs.closeTabByDblclick\"=\"true\")"
+  },
+  "config_treeDoubleClickBehavior_none": {
+    "message": "Ничего не делать"
+  },
+  "config_parentTabOperationBehaviorMode_caption": {
+    "message": "Если родительская вкладка закрыта или перемещена"
+  },
+  "config_parentTabOperationBehaviorMode_noteForPermanentlyConsistentBehaviors": {
+    "message": "Независимо от того, как вы настроили этот раздел, в боковой панели есть несколько констант поведения:\n･ Закрытие родительской вкладки вместе со свернутым деревом: Закрыть все дерево\n･ Перемещение родительской вкладки вместе со свернутым деревом: Переместить все дерево\n･ Перемещение родительской вкладки вместе с развернутым деревом: Ведет себя в соответствии с настройками раздела \"Перетягивание\" "
+  },
+  "config_parentTabOperationBehaviorMode_parallel": {
+    "message": "Рекомендуется тем, кто все еще использует нативную панель вкладок Firefox"
+  },
+  "config_closeParentBehavior_insideSidebar": {
+    "message": "Если родительская вкладка с развернутым деревом закрывается через боковую панель,"
+  },
+  "config_closeParentBehavior_outsideSidebar": {
+    "message": "Если родительская вкладка (независимо от состояния ее дерева) закрывается в нативной панели вкладок Firefox, сочетанием клавиш или другим аддоном,"
+  },
+  "config_moveParentBehavior_outsideSidebar": {
+    "message": "Если родительская вкладка (независимо от состояния ее дерева) перемещается в нативной панели вкладок Firefox, сочетанием клавиш или другим аддоном,"
+  },
+  "config_parentTabOperationBehaviorMode_consistent": {
+    "message": "Рекомендуется для тех, кто не используют нативную панель вкладок Firefox"
+  },
+  "config_parentTabOperationBehaviorMode_consistent_caption": {
+    "message": "Независимо от видимости боковой панели, для любой операции:"
+  },
+  "config_parentTabOperationBehaviorMode_consistent_notes": {
+    "message": "Вкладки ведут себя так, как указано выше, даже при действиях в нативной панели вкладок Firefox, по сочетанию клавиш или из других аддонов."
+  },
+  "config_parentTabOperationBehaviorMode_custom": {
+    "message": "Свое"
+  },
+  "config_closeParentBehavior_insideSidebar_expanded_caption": {
+    "message": "Закрыть: Если родительская вкладка с развернутым деревом закрывается через боковую панель,"
+  },
+  "config_closeParentBehavior_outsideSidebar_collapsed_caption": {
+    "message": "Закрыть: Если родительская вкладка со свернутым деревом закрывается в нативной панели вкладок Firefox, сочетанием клавиш или из другого аддона,"
+  },
+  "config_closeParentBehavior_outsideSidebar_expanded_caption": {
+    "message": "Закрыть: Если родительская вкладка с развернутым деревом закрывается в нативной панели вкладок Firefox, сочетанием клавиш или из другого аддона,"
+  },
+  "config_closeParentBehavior_noSidebar_collapsed_caption": {
+    "message": "если боковая панель закрыта,"
+  },
+  "config_closeParentBehavior_noSidebar_expanded_caption": {
+    "message": "если боковая панель закрыта,"
+  },
+  "config_moveParentBehavior_outsideSidebar_collapsed_caption": {
+    "message": "Переместить: Если родительская вкладка со свернутым деревом перемещается в нативной панели вкладок Firefox, сочетанием клавиш или из другого аддона,"
+  },
+  "config_moveParentBehavior_outsideSidebar_expanded_caption": {
+    "message": "Переместить: Если родительская вкладка с развернутым деревом перемещается в нативной панели вкладок Firefox, сочетанием клавиш или из другого аддона,"
+  },
+  "config_moveParentBehavior_noSidebar_collapsed_caption": {
+    "message": "если боковая панель закрыта,"
+  },
+  "config_moveParentBehavior_noSidebar_expanded_caption": {
+    "message": "если боковая панель закрыта,"
+  },
+  "config_parentTabOperationBehavior_entireTree": {
+    "message": "Закрыть / переместить все дерево"
+  },
+  "config_closeParentBehavior_entireTree": {
+    "message": "Закрыть все дерево"
+  },
+  "config_moveParentBehavior_entireTree": {
+    "message": "Переместить все дерево"
+  },
+  "config_parentTabOperationBehavior_replaceWithGroupTab": {
+    "message": "Заменить закрытую/перемещенную родительскую вкладку вкладкой группы"
+  },
+  "config_closeParentBehavior_replaceWithGroupTab": {
+    "message": "Заменить закрытую родительскую вкладку вкладкой группы"
+  },
+  "config_moveParentBehavior_replaceWithGroupTab": {
+    "message": "Заменить перемещенную родительскую вкладку вкладкой группы"
+  },
+  "config_parentTabOperationBehavior_promoteFirst": {
+    "message": "Назначить первую дочернюю вкладку новой родительской"
+  },
+  "config_closeParentBehavior_promoteFirst": {
+    "message": "Назначить первую дочернюю вкладку новой родительской"
+  },
+  "config_moveParentBehavior_promoteFirst": {
+    "message": "Назначить первую дочернюю вкладку новой родительской"
+  },
+  "config_parentTabOperationBehavior_promoteAll": {
+    "message": "Назначить все дочерние вкладки на уровень закрытой родительской вкладки"
+  },
+  "config_closeParentBehavior_promoteAll": {
+    "message": "Назначить все дочерние вкладки на уровень закрытой родительской вкладки"
+  },
+  "config_moveParentBehavior_promoteAll": {
+    "message": "Назначить все дочерние вкладки на уровень закрытой родительской вкладки"
+  },
+  "config_parentTabOperationBehavior_promoteIntelligently": {
+    "message": "Повысить первую дочернюю, если закрыта корневая, иначе повысить все дочерние"
+  },
+  "config_closeParentBehavior_promoteIntelligently": {
+    "message": "Повысить первую дочернюю, если закрыта корневая, иначе повысить все дочерние"
+  },
+  "config_moveParentBehavior_promoteIntelligently": {
+    "message": "Повысить первую дочернюю, если закрыта корневая, иначе повысить все дочерние"
+  },
+  "config_parentTabOperationBehavior_detach": {
+    "message": "Освободить все дочерние вкладки из дерева"
+  },
+  "config_closeParentBehavior_detach": {
+    "message": "Освободить все дочерние вкладки из дерева"
+  },
+  "config_moveParentBehavior_detach": {
+    "message": "Освободить все дочерние вкладки из дерева"
+  },
+  "config_warnOnCloseTabs_label": {
+    "message": "Предупреждать при закрытии нескольких вкладок"
+  },
+  "config_warnOnCloseTabsByClosebox_label": {
+    "message": "Предупреждать при закрытии нескольких вкладок по крестику закрытия вкладки (свернутое дерево)"
+  },
+  "config_warnOnCloseTabsWithListing_label": {
+    "message": "Список закрывающихся вкладок в диалоге подтверждения"
+  },
+  "config_insertNewChildAt_caption": {
+    "message": "Место появления новых дочерних вкладок"
+  },
+  "config_insertNewChildAt_noControl": {
+    "message": "Не контролируется (решает Firefox или другие аддоны)"
+  },
+  "config_insertNewChildAt_nextToLastRelatedTab": {
+    "message": "После недавно открытой дочерней или после родителя"
+  },
+  "config_insertNewChildAt_top": {
+    "message": "Добавить в начало дерева, как первую дочернюю"
+  },
+  "config_insertNewChildAt_end": {
+    "message": "Добавить в конец дерева"
+  },
+  "config_drag_caption": {
+    "message": "Перетягивание"
+  },
+  "config_tabDragBehavior_caption": {
+    "message": "Если дерево перетягивается за границы панели вкладок"
+  },
+  "config_tabDragBehavior_description": {
+    "message": "Из-за ограничений Firefox, вам необходимо заранее определить, как обрабатывать вкладки, перетягиваемые за границы панели TST."
+  },
+  "config_tabDragBehavior_label": {
+    "message": "Перетягивание"
+  },
+  "config_tabDragBehaviorShift_label": {
+    "message": "Перетягивание с Shift"
+  },
+  "config_tabDragBehavior_label_behaviorInsideSidebar": {
+    "message": "Поведение внутри"
+  },
+  "config_tabDragBehavior_label_behaviorOutsideSidebar": {
+    "message": "вне боковой панели"
+  },
+  "config_tabDragBehavior_moveEntireTreeAlways": {
+    "message": "Перемещение дерева"
+  },
+  "config_tabDragBehavior_detachEntireTreeAlways": {
+    "message": "Отсоединить дерево от окна (невозможно создать закладку)"
+  },
+  "config_tabDragBehavior_bookmarkEntireTreeAlways": {
+    "message": "Создать закладки или сслыки (невозможно отсоединить от окна)"
+  },
+  "config_tabDragBehavior_moveSoloTabIfExpanded": {
+    "message": "Перемещение вкладки"
+  },
+  "config_tabDragBehavior_detachSoloTabIfExpanded": {
+    "message": "Отсоеденить вкладку от окна (невозможно создать закладку)"
+  },
+  "config_tabDragBehavior_bookmarkSoloTabIfExpanded": {
+    "message": "Создать закладку или ссылку (невозможно отсоединить от окна)"
+  },
+  "config_tabDragBehavior_doNothing": {
+    "message": "Ничего не делать"
+  },
+  "config_tabDragBehavior_noteForDragstartOutsideSidebar": {
+    "message": "Если родительские вкладки перетаскиваются из нативной панели вкладок Firefox, они будут вести себя как нстроено в разделе \"Поведение дерева\" => \"Если родительская вкладка закрыта или перемещена\"."
+  },
+  "config_showTabDragBehaviorNotification_label": {
+    "message": "Показывать напоминание о том, что произойдет после отпускания вкладки за пределами боковой панели"
+  },
+  "config_dropLinksOnTabBehavior_caption": {
+    "message": "При перетягивании ссылки или URL на вкладку"
+  },
+  "config_dropLinksOnTabBehavior_ask": {
+    "message": "Всегда спрашивать что делать"
+  },
+  "config_dropLinksOnTabBehavior_load": {
+    "message": "Загрузить во вкладке"
+  },
+  "config_dropLinksOnTabBehavior_newtab": {
+    "message": "Открыть новую дочернюю вкладку"
+  },
+  "config_simulateTabsLoadInBackgroundInverted_label": {
+    "message": "При открытии ссылки в новой вкладке, переключатся на эту вкладку (* имитация параметра Firefox \"Переключаться на открываемую ссылку, изображение или медиа\" (\"browser.tabs.loadInBackground\"))"
+  },
+  "config_insertDroppedTabsAt_caption": {
+    "message": "Позиция вставки дочерних элементов, перетянутых на родителя"
+  },
+  "config_insertDroppedTabsAt_inherit": {
+    "message": "Рассматривать как новые дочерние, открытые из родителя"
+  },
+  "config_insertDroppedTabsAt_first": {
+    "message": "Добавить в начало дерева (сразу за родителем)"
+  },
+  "config_insertDroppedTabsAt_end": {
+    "message": "Добавить в конец дерева"
+  },
+  "config_autoExpandOnLongHoverDelay_before": {
+    "message": "Развернуть свернутое дерево при наведении указателя мыши более "
+  },
+  "config_autoExpandOnLongHoverDelay_after": {
+    "message": "мс при перетягивании"
+  },
+  "config_autoExpandOnLongHoverRestoreIniitalState_label": {
+    "message": "Автосворачивать такие деревья после завершения перетягивания"
+  },
+  "config_autoExpandIntelligently_label": {
+    "message": "Свернуть другие деревья, когда свернутое дерево авторазворачивается"
+  },
+  "config_ignoreTabDropNearSidebarArea_label": {
+    "message": "Не отделять вкладку от окна, если она отпущена в области боковой панели (снимите, если \"privacy.resistFingerprinting\"=\"true\")"
+  },
+  "config_more_caption": {
+    "message": "Больше..."
+  },
+  "config_shortcuts_caption": {
+    "message": "Горячие клавиши"
+  },
+  "config_requestPermissions_allUrls_ctrlTabTracking": {
+    "message": "Не разворачивать свернутое дерево и пропускать свернутые потомки, переключая фокус вкладок сочетаниями клавиш. ( * Вы должны разрешить выполнение сценариев на веб-страницах.)"
+  },
+  "config_autoExpandOnTabSwitchingShortcutsDelay_before": {
+    "message": "Развернуть активное свернутое дерево при удержании клавиши Tab "
+  },
+  "config_autoExpandOnTabSwitchingShortcutsDelay_after": {
+    "message": "мс"
+  },
+  "config_accelKey_label": {
+    "message": "Модификатор сочетания клавиш ( * необходимо сопоставить с \"ui.key.accelKey\"):"
+  },
+  "config_accelKey_auto": {
+    "message": "По умолчанию (macOS=⌘, другие=Ctrl)"
+  },
+  "config_accelKey_alt": {
+    "message": "Alt"
+  },
+  "config_accelKey_control": {
+    "message": "Ctrl/Control"
+  },
+  "config_accelKey_meta": {
+    "message": "Meta/⌘"
+  },
+  "config_shortcuts_resetAll": {
+    "message": "Сбросить ВСЕ горячие клавиши"
+  },
+  "config_advanced_caption": {
+    "message": "Расширенные настройки"
+  },
+  "config_bookmarkTreeFolderName_before": {
+    "message": "Имя папки для \"Это дерево в закладки\":"
+  },
+  "config_bookmarkTreeFolderName_after": {
+    "message": "​"
+  },
+  "config_bookmarkTreeFolderName_description": {
+    "message": "Доступные шаблоны: %TITLE% (заголовок первой вкладки), %URL% (адрес первой вкладки), %YEAR% (год, 4 символа), %SHORT_YEAR% (год, 2 символа), %MONTH% (месяц, 2 символа), %DATE% (число, два символа), %HOURS% (часов, два символа), %MINUTES% (минут, два символа), %SECONDS% (секунд, два символа), %MILLISECONDS% (мс, три символа), %GROUP% (заголовок первой вкладки, если это вкладка группы - иначе пусто), %ANY(значение1, значение2, ...)% (первое эффективное значение из заданного списка)"
+  },
+  "config_defaultBookmarkParentId_label_before": {
+    "message": "Создать новую закладку в"
+  },
+  "config_defaultBookmarkParentId_label_after": {
+    "message": "​"
+  },
+  "config_supportTabsMultiselect_label": {
+    "message": "Использовать интерфейс API выбора нескольких вкладок  ( * зависит от \"browser.tabs.multiselect\"=\"true\")"
+  },
+  "config_undoMultipleTabsClose_label": {
+    "message": "Восстановить набор закрытых вкладок, когда одна из них восстанавливается командой \"Восстановить закрытую вкладку\""
+  },
+  "config_scrollLines_label_before": {
+    "message": "Прокручивать вверх или вниз на "
+  },
+  "config_scrollLines_label_after": {
+    "message": "строк командами \"Листать вкладки вверх/вниз построчно\" "
+  },
+  "config_userStyleRules_label": {
+    "message": "Пользовательские стили (дополнительные правила стилизации для элементов Tree Style Tab, например боковой панели)"
+  },
+  "config_userStyleRules_description_before": {
+    "message": "Смотрите "
+  },
+  "config_userStyleRules_description_link_label": {
+    "message": "примеры кода и описания на TST-вики"
+  },
+  "config_userStyleRules_description_after": {
+    "message": " ."
+  },
+  "config_userStyleRules_description_link_uri": {
+    "message": "https://github.com/piroor/treestyletab/wiki/Code-snippets-for-custom-style-rules#for-version-2x"
+  },
+  "config_userStyleRules_themeRules_description": {
+    "message": "Следующие свойства также доступны через \"var()\", в зависимости от текущей темы браузера"
+  },
+  "config_userStyleRules_themeRules_description_alphaVariations": {
+    "message": "Вы можете изменить непрозрачность цвета с помощью цифрового суффикса, например, \"--theme-colors-tab_background_text-30\" (каждые 10%), тут это непрозрачность в 30%."
+  },
+  "config_userStyleRules_import": {
+    "message": "Загрузить из файла"
+  },
+  "config_userStyleRules_export": {
+    "message": "Сохранить в файл"
+  },
+  "config_userStyleRules_overwrite_title": {
+    "message": "Заменить текущие правила стиля?"
+  },
+  "config_userStyleRules_overwrite_message": {
+    "message": "Заменить все текущие правила стиля загруженным файлом?"
+  },
+  "config_userStyleRules_overwrite_overwrite": {
+    "message": "Заменить все"
+  },
+  "config_userStyleRules_overwrite_append": {
+    "message": "Добавить в конец"
+  },
+  "config_tooLargeUserStyleRulesCaution": {
+    "message": "Слишком длинный код стиля! Нужно сократить."
+  },
+  "config_userStyleRulesTheme_label": {
+    "message": "Тема:"
+  },
+  "config_userStyleRulesTheme_auto": {
+    "message": "Авто"
+  },
+  "config_userStyleRulesTheme_separator": {
+    "message": "-----------------"
+  },
+  "config_userStyleRulesTheme_default": {
+    "message": "По умолчанию"
+  },
+  "config_addons_caption": {
+    "message": "Дополнительные функции через другие аддоны"
+  },
+  "config_addons_description_before": {
+    "message": "Есть "
+  },
+  "config_addons_description_link_label": {
+    "message": "расширения, дополняющие возможности TST"
+  },
+  "config_addons_description_after": {
+    "message": ". Взгляните на них, если понадобится большего от боковой панели TST."
+  },
+  "helper_addons_list_link_uri": {
+    "message": "https://github.com/piroor/treestyletab/wiki/Helper-addons-extending-functionality-of-TST"
+  },
+  "config_theme_description_before": {
+    "message": "Сейчас доступны только три встроенные темы: \"Простая\", \"Боковая панель\" и \"Высококонтрастная\". Если захотите использовать стороннюю тему, см. "
+  },
+  "config_theme_description_link_label": {
+    "message": "отрывки с кодом"
+  },
+  "config_theme_description_after": {
+    "message": " ради примеров."
+  },
+  "helper_theme_list_link_uri": {
+    "message": "https://github.com/piroor/treestyletab/wiki/Code-snippets-for-custom-style-rules#restore-old-built-in-themes"
+  },
+  "config_externaladdonpermissions_label": {
+    "message": "Разрешения для вызова API из других расширений"
+  },
+  "config_externaladdonpermissions_description": {
+    "message": "Расширения, разрешенные здесь, смогут получить доступ к данным вкладок или вкладкам в приватных окнах, <em>через разрешения TreeStyleTab<em>, даже если само расширение не имеет таких разрешений.. <em>Осторожней, не давайте разрешений недоверенным расширениям.</em>"
+  },
+  "config_externalAddonPermissions_header_name": {
+    "message": "Название расширения"
+  },
+  "config_externalAddonPermissions_header_permissions": {
+    "message": "Разрешенные специальные операции"
+  },
+  "config_externalAddonPermissions_header_incognito": {
+    "message": "Уведомлять из приватных окон"
+  },
+  "addon_containerBookmarks_label": {
+    "message": "Закладки с контейнером"
+  },
+  "addon_containerBookmarks_uri": {
+    "message": "https://addons.mozilla.org/firefox/addon/container-bookmarks/"
+  },
+  "config_containerRedirectKey_label": {
+    "message": "Ключ перенаправления ( * установите значение как в параметрах Container Bookmarks):"
+  },
+  "config_debug_caption": {
+    "message": "Разработка"
+  },
+  "config_link_startupPage_label": {
+    "message": "Стартовая страница Tree Style Tab"
+  },
+  "config_link_groupPage_label": {
+    "message": "Страница группы вкладок Tree Style Tab"
+  },
+  "config_link_tabbarPage_label": {
+    "message": "Панель Tree Style Tab во вкладке"
+  },
+  "config_runTests_label": {
+    "message": "Запустить автоматические тесты"
+  },
+  "config_runTestsParameters_label": {
+    "message": " / Какие тесты запускать (список наименований тестов или рег. выражений, как \"testInheritMutedState,/^testHidden/,...\")"
+  },
+  "config_runBenchmark_label": {
+    "message": "Запустить бенчмарк"
+  },
+  "config_enableLinuxBehaviors_label": {
+    "message": "Активация специфического поведения Linux"
+  },
+  "config_enableMacOSBehaviors_label": {
+    "message": "Активация специфического поведения macOS"
+  },
+  "config_enableWindowsBehaviors_label": {
+    "message": "Активация специфического поведения Windows"
+  },
+  "config_debug_label": {
+    "message": "Режим отладки"
+  },
+  "config_log_caption": {
+    "message": "Детальное логирование"
+  },
+  "config_logTimestamp_label": {
+    "message": "Логировать с отметками времени"
+  },
+  "config_logFor_common": {
+    "message": "Запись логов из общих модулей"
+  },
+  "config_logFor_background": {
+    "message": "Запись логов из фоновых модулей"
+  },
+  "config_logFor_sidebar": {
+    "message": "Запись логов из модулей боковой панели"
+  },
+  "config_loggingQueries_label": {
+    "message": "Лог запросов вкладок"
+  },
+  "config_loggingConnectionMessages_label": {
+    "message": "Лог внутренних сообщений"
+  },
+  "config_showLogsButton_label": {
+    "message": "Показать журналы"
+  },
+  "config_simulateSVGContextFill_label": {
+    "message": "Активировать обходной путь для бага 1388193 и бага 1421329 для симуляции SVG иконок (* Может увеличить нагрузку на процессор. Для деактивации переключите \"svg.context-properties.content.enabled\" в \"about:config\", пока эти баги не будут исправлены.)"
+  },
+  "config_staticARIALabel_label": {
+    "message": "Использовать статическую метку ARIA для вкладок"
+  },
+  "config_staticARIALabel_description": {
+    "message": "* Попробуйте включить это, если ваша система распознавания речи пропускает вкладки после некоторых операций с ними."
+  },
+  "config_useCachedTree_label": {
+    "message": "Оптимизовать восстановление дерева с помощью кэша"
+  },
+  "config_useCachedTree_description": {
+    "message": "* Попробуйте снять флажок и установить повторно, чтобы обновить кэш, если дерево ведет себя нестабильно."
+  },
+  "config_persistCachedTree_label": {
+    "message": "Запоминать кэш дерева"
+  },
+  "config_persistCachedTree_description": {
+    "message": "*Процесс загрузки на старте браузера может ускорится, но из-за этого раздуется размер файла браузерной сессии и повысится I/O нагрузка на диск."
+  },
+  "config_acceleratedTabCreation_label": {
+    "message": "Ускорение операций с повторно открытыми вкладками (*ПРИМЕЧАНИЕ: Возможна нестабильная работа вкладок.)"
+  },
+  "config_maximumAcceptableDelayForTabDuplication_before": {
+    "message": "Отменить дублирование вкладок, если оно длится"
+  },
+  "config_maximumAcceptableDelayForTabDuplication_after": {
+    "message": "миллисекунд или больше."
+  },
+  "config_delayForDuplicatedTabDetection_label_before": {
+    "message": "Задержка обнаружения дублей вкладок:"
+  },
+  "config_delayForDuplicatedTabDetection_label_after": {
+    "message": "мс (увеличьте значение, если дубли вкладок не обнаруживаются правильно)"
+  },
+  "config_delayForDuplicatedTabDetection_autoDetect": {
+    "message": "Автоматическое обнаружение"
+  },
+  "config_delayForDuplicatedTabDetection_test": {
+    "message": "Тест обнаружения"
+  },
+  "config_delayForDuplicatedTabDetection_test_resultMessage": {
+    "message": "$PERCENTAGE$% успешно обнаружено.",
+    "placeholders": {
+      "percentage": {
+        "content": "$1",
+        "example": "50"
+      }
+    }
+  },
+  "config_labelOverflowStyle_caption": {
+    "message": "Слишком длинный заголовок вкладок:"
+  },
+  "config_labelOverflowStyle_fade": {
+    "message": "Затухание (лучше видимость)"
+  },
+  "config_labelOverflowStyle_crop": {
+    "message": "Обрезать с \"..\" (лучше производительность)"
+  },
+  "config_requestPermissions_bookmarks": {
+    "message": "Разрешить читать и создавать закладки"
+  },
+  "config_requestPermissions_bookmarks_context": {
+    "message": "Разрешить открывать контекстное меню в закладках"
+  },
+  "config_requestPermissions_tabHide": {
+    "message": "Разрешить показывать / скрывать отдельные вкладки (* Надо снять/поставить этот флажок перед запуском тестов, чтобы убедиться, что разрешение получено)"
+  },
+  "config_requestPermissions_fallbackToToolbarButton_title": {
+    "message": "Нажмите \"Tree Style Tab\" кнопку панели инструментов"
+  },
+  "config_requestPermissions_fallbackToToolbarButton_message": {
+    "message": "Из-за бага Firefox, вы не сможете запросить разрешение на этой странице. Нажмите \"Tree Style Tab\" кнопку на панели инструментов, чтобы получить разрешение."
+  },
+  "config_all_caption": {
+    "message": "Все конфигурации"
+  },
+  "config_terms_delimiter": {
+    "message": " "
+  },
+  "tabContextMenu_newTab_label": {
+    "message": "Нов&ая вкладка"
+  },
+  "tabContextMenu_reload_label": {
+    "message": "&Обновить вкладку"
+  },
+  "tabContextMenu_unblockAutoplay_label": {
+    "message": "П&роигрывать вкладку"
+  },
+  "tabContextMenu_mute_label": {
+    "message": "Выключить зв&ук"
+  },
+  "tabContextMenu_unmute_label": {
+    "message": "Включить зв&ук"
+  },
+  "tabContextMenu_pin_label": {
+    "message": "Закрепи&ть вкладку"
+  },
+  "tabContextMenu_unpin_label": {
+    "message": "Открепи&ть вкладку"
+  },
+  "tabContextMenu_duplicate_label": {
+    "message": "&Дублировать вкладку"
+  },
+  "tabContextMenu_selectAllTabs_label": {
+    "message": "&Выбрать все вкладки"
+  },
+  "tabContextMenu_bookmark_label": {
+    "message": "Добавить вкладку в зак&ладки"
+  },
+  "tabContextMenu_reopenInContainer_label": {
+    "message": "Переоткрыть в &контейнере"
+  },
+  "tabContextMenu_reopenInContainer_noContainer_label": {
+    "message": "Переоткрыть &без контейнера"
+  },
+  "tabContextMenu_moveTab_label": {
+    "message": "&Переместить вкладку"
+  },
+  "tabContextMenu_moveTabToStart_label": {
+    "message": "Переместить в &начало"
+  },
+  "tabContextMenu_moveTabToEnd_label": {
+    "message": "Переместить в &конец"
+  },
+  "tabContextMenu_tearOff_label": {
+    "message": "Пере&местить в новое окно"
+  },
+  "tabContextMenu_sendTabsToDevice_label": {
+    "message": "Отправить вкладку на устройство"
+  },
+  "tabContextMenu_sendTabsToAllDevices_label": {
+    "message": "Отправить на все устройства"
+  },
+  "tabContextMenu_manageSyncDevices_label": {
+    "message": "Управление устройствами…"
+  },
+  "tabContextMenu_shareTabURL_label": {
+    "message": "Поделиться"
+  },
+  "tabContextMenu_shareTabURL_more_label": {
+    "message": "Далее…"
+  },
+  "tabContextMenu_closeMultipleTabs_label": {
+    "message": "&Закрыть несколько вкладок"
+  },
+  "tabContextMenu_closeTabsToTop_label": {
+    "message": "Закрыть вкладки с&верху"
+  },
+  "tabContextMenu_closeTabsToBottom_label": {
+    "message": "Закрыть вкладки с&низу"
+  },
+  "tabContextMenu_closeOther_label": {
+    "message": "Закрыть &другие вкладки"
+  },
+  "tabContextMenu_undoClose_label": {
+    "message": "Восстанов&ить закрытую вкладку"
+  },
+  "tabContextMenu_undoClose_label_multiple": {
+    "message": "Восстанов&ить закрытые вкладки"
+  },
+  "tabContextMenu_close_label": {
+    "message": "Закр&ыть вкладку"
+  },
+  "tabContextMenu_reload_label_multiselected": {
+    "message": "&Обновить выбранные вкладки"
+  },
+  "tabContextMenu_unblockAutoplay_label_multiselected": {
+    "message": "П&роигрывать вкладку"
+  },
+  "tabContextMenu_mute_label_multiselected": {
+    "message": "Выключить зв&ук на выбранных"
+  },
+  "tabContextMenu_unmute_label_multiselected": {
+    "message": "Включить зв&ук на выбранных"
+  },
+  "tabContextMenu_pin_label_multiselected": {
+    "message": "Закрепи&ть вкладки"
+  },
+  "tabContextMenu_unpin_label_multiselected": {
+    "message": "Открепи&ть вкладки"
+  },
+  "tabContextMenu_duplicate_label_multiselected": {
+    "message": "&Дублировать вкладки"
+  },
+  "tabContextMenu_moveTab_label_multiselected": {
+    "message": "П&ереместить вкладки"
+  },
+  "tabContextMenu_sendTabsToDevice_label_multiselected": {
+    "message": "Отправить %S вкладок на устройство"
+  },
+  "tabContextMenu_reloadSelected_label": {
+    "message": "Пере&загрузить выбранную вкладку"
+  },
+  "tabContextMenu_reloadSelected_label_multiselected": {
+    "message": "Пере&загрузить выбранные вкладки"
+  },
+  "tabContextMenu_bookmark_label_multiselected": {
+    "message": "Добавить вкладки в зак&ладки…"
+  },
+  "tabContextMenu_bookmarkSelected_label": {
+    "message": "Добавить выб&ранную в закладки…"
+  },
+  "tabContextMenu_bookmarkSelected_label_multiselected": {
+    "message": "Добавить выб&ранные в закладки…"
+  },
+  "tabContextMenu_close_label_multiselected": {
+    "message": "Закрыть в&ыбранные вкладки"
+  }
 }


### PR DESCRIPTION
- Completely update the Russian translation. Including fixes and new strings
- More strings translated in German. Few updates/fixes
- Only grammar fixes in English locale

Completely untested. Created with Web Extension Translator

----

**Preface:** someone in comments on a website that's presumably catering to open-source and FOSS enthusiasts "can someone report this grammar mistake?" ... Well yes, but *did you know that magic doesn't happen on its own accord?*

---

I used the WET as per instructions. I see the diff is absolutely massive, because it changed the JSON structure completely. I am not sure if you are

a. OK with this? Because you point out to use git's diffing to see if the source (EN) translation was updated and downstream locales need updates as well
b. If this breaks the structure the i18n library you use expects?

---

Yes, I didn't test this (how would I load a changed locale file along the extension in Firefox?). I hope this **runs** but as for translation quality, I actually wish and expect for other people pick this up and improve, in wiki style.

- I didn't finish German because I've had too much. 
- As far as Russian goes I am fairly certain of my translation skill and while there are some strings that need double-checking with Firefox' own terminology (glossary), it should be a very close match. I've also adapted some IT terminology like "Addon" -> "Extension" to be easier to comprehend for everyone, since addons are no longer called such anyways. I doubt there will be uproar from the previous translator(s). Even if: point them towards a "Create pull request" button ;)