### PR TITLE
Fix contextTab error on sidebar right-click on free space

### DIFF
--- a/webextensions/sidebar/tab-context-menu.js
+++ b/webextensions/sidebar/tab-context-menu.js
@@ -374,7 +374,7 @@ async function onCommand(item, event) {
       srcUrl:           null,
       wasChecked
     },
-    tab: contextTab.$TST.sanitized,
+    tab: contextTab?.$TST.sanitized || contextTab,
   };
   if (owner == browser.runtime.id) {
     await browser.runtime.sendMessage(message).catch(ApiTabs.createErrorSuppressor());


### PR DESCRIPTION
Due to the recent changes by commit 973555f0b147 ("Invoke commands in fake context menu correctly"), right-clicking on free sidebar space then selecting an option of the context menu (e.g. "Reopen Closed Tab") causes a 'contextTab is null' error, since the context menu wasn't opened over any tab, but the changes assume `contextTab` isn't null.

![tstbug25](https://github.com/user-attachments/assets/068c0ed7-e35f-4f7e-a54a-e2fd9a4b6a96)

Fix it by tolerating a null `contextTab`.