### PR TITLE
Fix container assignment for extra tab contents below tabs

### DIFF
--- a/webextensions/sidebar/tst-api-frontend.js
+++ b/webextensions/sidebar/tst-api-frontend.js
@@ -534,7 +534,7 @@ function setExtraTabContentsToElement(tabElement, id, params = {}) {
       container = tabElement.extraItemsContainerAboveRoot;
       break;
 
-    case 'tab-above':
+    case 'tab-below':
       container = tabElement.extraItemsContainerBelowRoot;
       break;
   }


### PR DESCRIPTION
## PR Summary
This small PR fixes a bug routing 'tab-above' content to below-container instead of above-container. 
