### PR TITLE
perf(canBecomeSticky): iterate smaller Set instead of spreading both

### DIFF
--- a/webextensions/common/TreeItem.js
+++ b/webextensions/common/TreeItem.js
@@ -251,8 +251,13 @@ export class TreeItem {
     if (this.sticky)
       return true;
 
-    if ((new Set([...this.states, ...TreeItem.allAutoStickyStates])).size < this.states.size + TreeItem.allAutoStickyStates.size) {
-      return true;
+    // Returns true if the two arrays share at least one element
+    const [smaller, larger] = this.states.size <= TreeItem.allAutoStickyStates.size
+      ? [this.states, TreeItem.allAutoStickyStates]
+      : [TreeItem.allAutoStickyStates, this.states];
+    for (const state of smaller) {
+      if (larger.has(state))
+        return true;
     }
 
     return false;


### PR DESCRIPTION
In `TreeItem.canBecomeSticky`, current implementation determined whether `this.states` and `TreeItem.allAutoStickyStates` contained common elements by spreading both Sets into a new Set and comparing their sizes:

```
if ((new Set([...this.states, ...TreeItem.allAutoStickyStates])).size < this.states.size + TreeItem.allAutoStickyStates.size)
```

This method incurs the cost of allocating a temporary Set and copying all elements on every call. Since `canBecomeSticky` is a frequently called getter during scrolls and sticky tab updates, even a small reduction in computational cost is desirable.

The new implementation selects the smaller of the two Sets to iterate over and uses `Set.has()` to check for existence in the larger Set. This eliminates the need for a temporary Set allocation and improves the computational complexity from O(m + n) to O(min(m, n)).
