### PR TITLE
Fix bugs in tree-structure restoration and progress tracking

### DIFF
--- a/webextensions/background/tree-structure.js
+++ b/webextensions/background/tree-structure.js
@@ -452,7 +452,7 @@ Tab.onRestored.addListener(tab => {
             UserOperationBlocker.unblockIn(tab.windowId, { throbber: true });
           }, 0);
 
-          const countToBeRestored = mRecentlyClosedTabs.filter(tab => !mRestoredTabIds.has(tab.uniqueId));
+          const countToBeRestored = mRecentlyClosedTabs.filter(tab => !mRestoredTabIds.has(tab.uniqueId)).length;
           log('countToBeRestored: ', countToBeRestored);
           if (countToBeRestored > 0)
             tryRestoreClosedSetFor(tab, countToBeRestored);
@@ -461,7 +461,7 @@ Tab.onRestored.addListener(tab => {
         else {
           mRestoringTabs.set(tab.windowId, count);
           const maxCount = mMaxRestoringTabs.get(tab.windowId);
-          UserOperationBlocker.setProgress(Math.round(maxCount - count / maxCount * 100), tab.windowId);
+          UserOperationBlocker.setProgress(Math.round((maxCount - count) / maxCount * 100), tab.windowId);
         }
       });
     }
@@ -495,9 +495,8 @@ Tab.onRemoved.addListener((_tab, _info) => {
   mRecentlyClosedTabs = [];
   mRecentlyClosedTabsTreeStructure = [];
 
-  const newlyRestorable = mRecentlyClosedTabs.length > 1;
-  if (currentlyRestorable != newlyRestorable)
-    Tab.onChangeMultipleTabsRestorability.dispatch(newlyRestorable);
+  if (currentlyRestorable)
+    Tab.onChangeMultipleTabsRestorability.dispatch(false);
 });
 
 Tab.onMultipleTabsRemoving.addListener((tabs, { triggerTab, originalStructure } = {}) => {


### PR DESCRIPTION
Fix three bugs in `webextensions/background/tree-structure.js` related to tab restoration and progress tracking.

## Changes

### 1. "Undo Close Tabs" never triggered for multiple tabs

`Array.prototype.filter()` returns an array, but the result was compared directly as `countToBeRestored > 0`. Since comparing an array to a number always evaluates to `false`, `tryRestoreClosedSetFor()` was never called. Added the missing `.length` property access.

### 2. Wrong progress calculation during tab restoration

`Math.round(maxCount - count / maxCount * 100)` was evaluated as `maxCount - ((count / maxCount) * 100)` due to operator precedence, producing incorrect progress values. Fixed to `(maxCount - count) / maxCount * 100`.

### 3. Dead condition in Tab.onRemoved listener

`mRecentlyClosedTabs` was cleared to `[]` and then immediately checked with `.length > 1`, so `newlyRestorable` was always `false`. The condition `currentlyRestorable != newlyRestorable` only passed when `currentlyRestorable` was `true`, dispatching `false` — which was the correct value but via unnecessarily convoluted logic. Simplified to directly check the pre-clear state.
