### PR TITLE
Fix typos in log messages of TreeItem.js

### DIFF
--- a/webextensions/common/TreeItem.js
+++ b/webextensions/common/TreeItem.js
@@ -548,7 +548,7 @@ export class TreeItem {
     const previousTab = this.unsafePreviousTab;
     if (this.lastPreviousTabId &&
         this.lastPreviousTabId != previousTab?.id) {
-      log(`not bulkMoved lastPreviousTabId=${this.lastNextTabId}, previousTab=${previousTab?.id}`);
+      log(`not bulkMoved lastPreviousTabId=${this.lastPreviousTabId}, previousTab=${previousTab?.id}`);
       return false;
     }
 
@@ -1526,7 +1526,7 @@ export class Tab extends TreeItem {
         resolve(this.possibleOpenerBookmarks = possibleBookmarks.flat());
       }
       catch(error) {
-        log(`promisedPossibleOpenerBookmarks for the tab {this.id} (${url}): `, error);
+        log(`promisedPossibleOpenerBookmarks for the tab ${this.id} (${url}): `, error);
         // If it is detected as "not a valid URL", then
         // it cannot be a tab opened from a bookmark.
         resolve(this.possibleOpenerBookmarks = []);


### PR DESCRIPTION
- Fix wrong variable reference in movedInBulk log: this.lastNextTabId → this.lastPreviousTabId to match the label lastPreviousTabId=
- Fix missing $ in template literal in promisedPossibleOpenerBookmarks error log: {this.id} → ${this.id}

Both changes are in debug log messages only, no behavioral impact
