### PR TITLE
Fix missing sharingScreenChildrenIds cleanup on parent change

### DIFF
--- a/webextensions/common/TreeItem.js
+++ b/webextensions/common/TreeItem.js
@@ -1903,8 +1903,8 @@ export class Tab extends TreeItem {
       oldParent.$TST.sharingCameraChildrenIds.delete(this.id);
       oldParent.$TST.maybeSharingCameraChildrenIds.delete(this.id);
       oldParent.$TST.sharingMicrophoneChildrenIds.delete(this.id);
-      oldParent.$TST.maybeSharingScreenChildrenIds.delete(this.id);
       oldParent.$TST.maybeSharingMicrophoneChildrenIds.delete(this.id);
+      oldParent.$TST.sharingScreenChildrenIds.delete(this.id);
       oldParent.$TST.maybeSharingScreenChildrenIds.delete(this.id);
       oldParent.$TST.inheritSharingStateFromChildren();
 


### PR DESCRIPTION
`set parent` (行 1903-1908) で、古い親から子タブを削除する際の共有状態のクリーンアップにバグがあると思われる。

元のコード:
```js
oldParent.$TST.sharingCameraChildrenIds.delete(this.id);
oldParent.$TST.maybeSharingCameraChildrenIds.delete(this.id);
oldParent.$TST.sharingMicrophoneChildrenIds.delete(this.id);
oldParent.$TST.maybeSharingScreenChildrenIds.delete(this.id);    // ← バグ: sharingScreenChildrenIds であるべき
oldParent.$TST.maybeSharingMicrophoneChildrenIds.delete(this.id); // ← 順序が不自然
oldParent.$TST.maybeSharingScreenChildrenIds.delete(this.id);     // ← 重複
```

- `sharingScreenChildrenIds.delete()` が呼ばれていない
- `maybeSharingScreenChildrenIds.delete()` が2回呼ばれている
- `maybeSharingMicrophoneChildrenIds` と `maybeSharingScreenChildrenIds` の順序が Camera/Microphone/Screen の並びと一致していない

## 修正

`sharingScreenChildrenIds.delete()` が呼ばれるように修正:
```js
oldParent.$TST.sharingCameraChildrenIds.delete(this.id);
oldParent.$TST.maybeSharingCameraChildrenIds.delete(this.id);
oldParent.$TST.sharingMicrophoneChildrenIds.delete(this.id);
oldParent.$TST.maybeSharingMicrophoneChildrenIds.delete(this.id);
oldParent.$TST.sharingScreenChildrenIds.delete(this.id);
oldParent.$TST.maybeSharingScreenChildrenIds.delete(this.id);
```
