### PR TITLE
Remove duplicate onStateChanged declaration in Tab class

### DIFF
--- a/webextensions/common/TreeItem.js
+++ b/webextensions/common/TreeItem.js
@@ -1134,7 +1134,6 @@ export class Tab extends TreeItem {
   static onMultipleTabsRemoving = new EventListenerManager();
   static onMultipleTabsRemoved  = new EventListenerManager();
   static onChangeMultipleTabsRestorability = new EventListenerManager();
-  static onStateChanged  = new EventListenerManager();
   static onNativeGroupModified = new EventListenerManager();
 
 


### PR DESCRIPTION
`Tab` クラスで `static onStateChanged` が2回宣言されていた。

- 行 1107: `static onStateChanged = new EventListenerManager();` (1回目)
- 行 1137: `static onStateChanged = new EventListenerManager();` (2回目、重複)

JavaScriptのクラスフィールドでは、後から宣言されたものが前のものを上書きする。そのため、1回目の宣言時にリスナーが登録されていた場合、2回目の宣言で新しい `EventListenerManager` インスタンスに置き換えられ、登録済みのリスナーが失われる可能性があった。

## 修正

行 1137 の重複宣言を削除。行 1107 の宣言のみを残す。
