### PR TITLE
Fix property name mismatches in lastSoundStateCounts and lastSharingStateCounts

### DIFF
--- a/webextensions/common/TreeItem.js
+++ b/webextensions/common/TreeItem.js
@@ -1160,7 +1160,7 @@ export class Tab extends TreeItem {
     this.lastSoundStateCounts = {
       soundPlaying:    0,
       muted:           0,
-      autoPlayBlocked: 0,
+      autoplayBlocked: 0,
     };
     this.soundPlayingChildrenIds = new Set();
     this.maybeSoundPlayingChildrenIds = new Set();
@@ -1170,9 +1170,9 @@ export class Tab extends TreeItem {
     this.maybeAutoplayBlockedChildrenIds = new Set();
 
     this.lastSharingStateCounts = {
-      camera:     0,
-      microphone: 0,
-      screen:     0,
+      sharingCamera:     0,
+      sharingMicrophone: 0,
+      sharingScreen:     0,
     };
     this.sharingCameraChildrenIds = new Set();
     this.maybeSharingCameraChildrenIds = new Set();


### PR DESCRIPTION
# fix/state-counts-property-name-mismatch

## 問題

`lastSoundStateCounts` と `lastSharingStateCounts` の初期化プロパティ名が、実際の使用箇所（`inheritSoundStateFromChildren` / `inheritSharingStateFromChildren`）のプロパティ名と不一致だった。

| 初期化 (コンストラクタ) | 使用箇所 (inheritXxxStateFromChildren) |
|-------------------------|----------------------------------------|
| `autoPlayBlocked`       | `autoplayBlocked`                      |
| `camera`                | `sharingCamera`                        |
| `microphone`            | `sharingMicrophone`                    |
| `screen`                | `sharingScreen`                        |

この不一致により、`inheritXxxStateFromChildren` で参照するプロパティが初期化時に存在せず、`undefined` として扱われる。

## 修正

コンストラクタの初期化プロパティ名を使用箇所に合わせた:
- `autoPlayBlocked` → `autoplayBlocked`
- `camera` → `sharingCamera`
- `microphone` → `sharingMicrophone`
- `screen` → `sharingScreen`
