### PR TITLE
Use Map.get() for restoredFromCache instead of bracket notation

### DIFF
--- a/webextensions/background/background.js
+++ b/webextensions/background/background.js
@@ -158,7 +158,7 @@ export async function init() {
   Permissions.clearRequest();
 
   for (const windowId of restoredFromCache.keys()) {
-    if (!restoredFromCache[windowId])
+    if (!restoredFromCache.get(windowId))
       BackgroundCache.reserveToCacheTree(windowId, 'initialize');
     TabsUpdate.completeLoadingTabs(windowId);
   }


### PR DESCRIPTION
Mapオブジェクト(initialized as new Map() at line 301)に対して[]でアクセスしていて、明らかに意図と違うコードになっていたと思われるので修正します。しかし、良くも悪くも、長期間動作していたコードの挙動をちょっと大きめに変更することになるので、却って別のバグが見つかる原因になるかもしれません。

一応、セッションのリストアの動作確認はしましたが、コードに詳しくないので、ここで挙動が変わるパスを踏んでいるのかどうか、動作確認が適切に行えた自信がありません。
