### PR TITLE
fix: initialize delayedInheritSharingStateFromChildren for consistent object shape

### DIFF
--- a/webextensions/common/TreeItem.js
+++ b/webextensions/common/TreeItem.js
@@ -1225,6 +1225,7 @@ export class Tab extends TreeItem {
 
     // We should initialize private properties with blank value for better performance with a fixed shape.
     this.delayedInheritSoundStateFromChildren = null;
+    this.delayedInheritSharingStateFromChildren = null;
   }
 
   destroy() {


### PR DESCRIPTION
TreeItem.js の Tab コンストラクタでは、V8/SpiderMonkey の最適化のために delayedInheritSoundStateFromChildren が null に初期化されていますが、delayedInheritSharingStateFromChildren プロパティは初期化されていません。このため、後でプロパティが割り当てられる際にオブジェクトの形状が異なり、隠しクラスの最適化が損なわれます。

## 修正内容

コンストラクタ内の既存の this.delayedInheritSoundStateFromChildren = null; の初期化直後に、this.delayedInheritSharingStateFromChildren = null; を追加しました。
