### PR TITLE
migrate media state sets to global maps

### DIFF
--- a/webextensions/common/TreeItem.js
+++ b/webextensions/common/TreeItem.js
@@ -1910,13 +1910,13 @@ export class Tab extends TreeItem {
 
       for (const [state, map] of mSoundChildrenIdsMaps) {
         if (this.states.has(state))
-          addToChildrenIds(map, parent.$TST.id, this.id);
+          addToChildrenIds(map, parent.id, this.id);
       }
       parent.$TST.inheritSoundStateFromChildren();
 
       for (const [state, map] of mSharingChildrenIdsMaps) {
         if (this.states.has(state))
-          addToChildrenIds(map, parent.$TST.id, this.id);
+          addToChildrenIds(map, parent.id, this.id);
       }
       parent.$TST.inheritSharingStateFromChildren();
 
@@ -1928,11 +1928,11 @@ export class Tab extends TreeItem {
     }
     if (oldParent && oldParent.id != this.parentId) {
       for (const [, map] of mSoundChildrenIdsMaps)
-        deleteFromChildrenIds(map, oldParent.$TST.id, this.id);
+        deleteFromChildrenIds(map, oldParent.id, this.id);
       oldParent.$TST.inheritSoundStateFromChildren();
 
       for (const [, map] of mSharingChildrenIdsMaps)
-        deleteFromChildrenIds(map, oldParent.$TST.id, this.id);
+        deleteFromChildrenIds(map, oldParent.id, this.id);
       oldParent.$TST.inheritSharingStateFromChildren();
 
       oldParent.$TST.children = oldParent.$TST.childIds.filter(id => id != this.id);
@@ -2369,12 +2369,12 @@ export class Tab extends TreeItem {
       case Constants.kTAB_STATE_SOUND_PLAYING: {
         const parent = this.parent;
         if (parent)
-          addToChildrenIds(mSoundPlayingChildrenIds, parent.$TST.id, this.id);
+          addToChildrenIds(mSoundPlayingChildrenIds, parent.id, this.id);
       } break;
       case Constants.kTAB_STATE_HAS_SOUND_PLAYING_MEMBER: {
         const parent = this.parent;
         if (parent)
-          addToChildrenIds(mMaybeSoundPlayingChildrenIds, parent.$TST.id, this.id);
+          addToChildrenIds(mMaybeSoundPlayingChildrenIds, parent.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_AUDIBLE:
@@ -2385,27 +2385,27 @@ export class Tab extends TreeItem {
       case Constants.kTAB_STATE_MUTED: {
         const parent = this.parent;
         if (parent)
-          addToChildrenIds(mMutedChildrenIds, parent.$TST.id, this.id);
+          addToChildrenIds(mMutedChildrenIds, parent.id, this.id);
         if (toTab)
           this.raw.mutedInfo.muted = true;
       } break;
       case Constants.kTAB_STATE_HAS_MUTED_MEMBER: {
         const parent = this.parent;
         if (parent)
-          addToChildrenIds(mMaybeMutedChildrenIds, parent.$TST.id, this.id);
+          addToChildrenIds(mMaybeMutedChildrenIds, parent.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_AUTOPLAY_BLOCKED: {
         const parent = this.parent;
         if (parent) {
-          addToChildrenIds(mAutoplayBlockedChildrenIds, parent.$TST.id, this.id);
+          addToChildrenIds(mAutoplayBlockedChildrenIds, parent.id, this.id);
           parent.$TST.inheritSoundStateFromChildren();
         }
       } break;
       case Constants.kTAB_STATE_HAS_AUTOPLAY_BLOCKED_MEMBER: {
         const parent = this.parent;
         if (parent) {
-          addToChildrenIds(mMaybeAutoplayBlockedChildrenIds, parent.$TST.id, this.id);
+          addToChildrenIds(mMaybeAutoplayBlockedChildrenIds, parent.id, this.id);
           parent.$TST.inheritSoundStateFromChildren();
         }
       } break;
@@ -2413,40 +2413,40 @@ export class Tab extends TreeItem {
       case Constants.kTAB_STATE_SHARING_CAMERA: {
         const parent = this.parent;
         if (parent)
-          addToChildrenIds(mSharingCameraChildrenIds, parent.$TST.id, this.id);
+          addToChildrenIds(mSharingCameraChildrenIds, parent.id, this.id);
         if (toTab && this.raw.sharingState)
           this.raw.sharingState.camera = true;
       } break;
       case Constants.kTAB_STATE_HAS_SHARING_CAMERA_MEMBER: {
         const parent = this.parent;
         if (parent)
-          addToChildrenIds(mMaybeSharingCameraChildrenIds, parent.$TST.id, this.id);
+          addToChildrenIds(mMaybeSharingCameraChildrenIds, parent.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_SHARING_MICROPHONE: {
         const parent = this.parent;
         if (parent)
-          addToChildrenIds(mSharingMicrophoneChildrenIds, parent.$TST.id, this.id);
+          addToChildrenIds(mSharingMicrophoneChildrenIds, parent.id, this.id);
         if (toTab && this.raw.sharingState)
           this.raw.sharingState.microphone = true;
       } break;
       case Constants.kTAB_STATE_HAS_SHARING_MICROPHONE_MEMBER: {
         const parent = this.parent;
         if (parent)
-          addToChildrenIds(mMaybeSharingMicrophoneChildrenIds, parent.$TST.id, this.id);
+          addToChildrenIds(mMaybeSharingMicrophoneChildrenIds, parent.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_SHARING_SCREEN: {
         const parent = this.parent;
         if (parent)
-          addToChildrenIds(mSharingScreenChildrenIds, parent.$TST.id, this.id);
+          addToChildrenIds(mSharingScreenChildrenIds, parent.id, this.id);
         if (toTab && this.raw.sharingState)
           this.raw.sharingState.screen = 'Something';
       } break;
       case Constants.kTAB_STATE_HAS_SHARING_SCREEN_MEMBER: {
         const parent = this.parent;
         if (parent)
-          addToChildrenIds(mMaybeSharingScreenChildrenIds, parent.$TST.id, this.id);
+          addToChildrenIds(mMaybeSharingScreenChildrenIds, parent.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_GROUP_TAB:
@@ -2562,12 +2562,12 @@ export class Tab extends TreeItem {
       case Constants.kTAB_STATE_SOUND_PLAYING: {
         const parent = this.parent;
         if (parent)
-          deleteFromChildrenIds(mSoundPlayingChildrenIds, parent.$TST.id, this.id);
+          deleteFromChildrenIds(mSoundPlayingChildrenIds, parent.id, this.id);
       } break;
       case Constants.kTAB_STATE_HAS_SOUND_PLAYING_MEMBER: {
         const parent = this.parent;
         if (parent)
-          deleteFromChildrenIds(mMaybeSoundPlayingChildrenIds, parent.$TST.id, this.id);
+          deleteFromChildrenIds(mMaybeSoundPlayingChildrenIds, parent.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_AUDIBLE:
@@ -2578,27 +2578,27 @@ export class Tab extends TreeItem {
       case Constants.kTAB_STATE_MUTED: {
         const parent = this.parent;
         if (parent)
-          deleteFromChildrenIds(mMutedChildrenIds, parent.$TST.id, this.id);
+          deleteFromChildrenIds(mMutedChildrenIds, parent.id, this.id);
         if (toTab)
           this.raw.mutedInfo.muted = false;
       } break;
       case Constants.kTAB_STATE_HAS_MUTED_MEMBER: {
         const parent = this.parent;
         if (parent)
-          deleteFromChildrenIds(mMaybeMutedChildrenIds, parent.$TST.id, this.id);
+          deleteFromChildrenIds(mMaybeMutedChildrenIds, parent.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_AUTOPLAY_BLOCKED: {
         const parent = this.parent;
         if (parent) {
-          deleteFromChildrenIds(mAutoplayBlockedChildrenIds, parent.$TST.id, this.id);
+          deleteFromChildrenIds(mAutoplayBlockedChildrenIds, parent.id, this.id);
           parent.$TST.inheritSoundStateFromChildren();
         }
       } break;
       case Constants.kTAB_STATE_HAS_AUTOPLAY_BLOCKED_MEMBER: {
         const parent = this.parent;
         if (parent) {
-          deleteFromChildrenIds(mMaybeAutoplayBlockedChildrenIds, parent.$TST.id, this.id);
+          deleteFromChildrenIds(mMaybeAutoplayBlockedChildrenIds, parent.id, this.id);
           parent.$TST.inheritSoundStateFromChildren();
         }
       } break;
@@ -2606,40 +2606,40 @@ export class Tab extends TreeItem {
       case Constants.kTAB_STATE_SHARING_CAMERA: {
         const parent = this.parent;
         if (parent)
-          deleteFromChildrenIds(mSharingCameraChildrenIds, parent.$TST.id, this.id);
+          deleteFromChildrenIds(mSharingCameraChildrenIds, parent.id, this.id);
         if (toTab && this.raw.sharingState)
           this.raw.sharingState.camera = false;
       } break;
       case Constants.kTAB_STATE_HAS_SHARING_CAMERA_MEMBER: {
         const parent = this.parent;
         if (parent)
-          deleteFromChildrenIds(mMaybeSharingCameraChildrenIds, parent.$TST.id, this.id);
+          deleteFromChildrenIds(mMaybeSharingCameraChildrenIds, parent.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_SHARING_MICROPHONE: {
         const parent = this.parent;
         if (parent)
-          deleteFromChildrenIds(mSharingMicrophoneChildrenIds, parent.$TST.id, this.id);
+          deleteFromChildrenIds(mSharingMicrophoneChildrenIds, parent.id, this.id);
         if (toTab && this.raw.sharingState)
           this.raw.sharingState.microphone = false;
       } break;
       case Constants.kTAB_STATE_HAS_SHARING_MICROPHONE_MEMBER: {
         const parent = this.parent;
         if (parent)
-          deleteFromChildrenIds(mMaybeSharingMicrophoneChildrenIds, parent.$TST.id, this.id);
+          deleteFromChildrenIds(mMaybeSharingMicrophoneChildrenIds, parent.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_SHARING_SCREEN: {
         const parent = this.parent;
         if (parent)
-          deleteFromChildrenIds(mSharingScreenChildrenIds, parent.$TST.id, this.id);
+          deleteFromChildrenIds(mSharingScreenChildrenIds, parent.id, this.id);
         if (toTab && this.raw.sharingState)
           this.raw.sharingState.screen = undefined;
       } break;
       case Constants.kTAB_STATE_HAS_SHARING_SCREEN_MEMBER: {
         const parent = this.parent;
         if (parent)
-          deleteFromChildrenIds(mMaybeSharingScreenChildrenIds, parent.$TST.id, this.id);
+          deleteFromChildrenIds(mMaybeSharingScreenChildrenIds, parent.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_GROUP_TAB:
@@ -2719,9 +2719,9 @@ export class Tab extends TreeItem {
         this.toggleState(Constants.kTAB_STATE_HAS_SOUND_PLAYING_MEMBER, soundPlayingCount > 0);
         if (parent) {
           if (soundPlayingCount > 0)
-            addToChildrenIds(mMaybeSoundPlayingChildrenIds, parent.$TST.id, this.id);
+            addToChildrenIds(mMaybeSoundPlayingChildrenIds, parent.id, this.id);
           else
-            deleteFromChildrenIds(mMaybeSoundPlayingChildrenIds, parent.$TST.id, this.id);
+            deleteFromChildrenIds(mMaybeSoundPlayingChildrenIds, parent.id, this.id);
         }
         modifiedCount++;
       }
@@ -2732,9 +2732,9 @@ export class Tab extends TreeItem {
         this.toggleState(Constants.kTAB_STATE_HAS_MUTED_MEMBER, mutedCount > 0);
         if (parent) {
           if (mutedCount > 0)
-            addToChildrenIds(mMaybeMutedChildrenIds, parent.$TST.id, this.id);
+            addToChildrenIds(mMaybeMutedChildrenIds, parent.id, this.id);
           else
-            deleteFromChildrenIds(mMaybeMutedChildrenIds, parent.$TST.id, this.id);
+            deleteFromChildrenIds(mMaybeMutedChildrenIds, parent.id, this.id);
         }
         modifiedCount++;
       }
@@ -2745,9 +2745,9 @@ export class Tab extends TreeItem {
         this.toggleState(Constants.kTAB_STATE_HAS_AUTOPLAY_BLOCKED_MEMBER, autoplayBlockedCount > 0);
         if (parent) {
           if (autoplayBlockedCount > 0)
-            addToChildrenIds(mMaybeAutoplayBlockedChildrenIds, parent.$TST.id, this.id);
+            addToChildrenIds(mMaybeAutoplayBlockedChildrenIds, parent.id, this.id);
           else
-            deleteFromChildrenIds(mMaybeAutoplayBlockedChildrenIds, parent.$TST.id, this.id);
+            deleteFromChildrenIds(mMaybeAutoplayBlockedChildrenIds, parent.id, this.id);
         }
         modifiedCount++;
       }
@@ -2791,9 +2791,9 @@ export class Tab extends TreeItem {
         this.toggleState(Constants.kTAB_STATE_HAS_SHARING_CAMERA_MEMBER, sharingCameraCount > 0);
         if (parent) {
           if (sharingCameraCount > 0)
-            addToChildrenIds(mMaybeSharingCameraChildrenIds, parent.$TST.id, this.id);
+            addToChildrenIds(mMaybeSharingCameraChildrenIds, parent.id, this.id);
           else
-            deleteFromChildrenIds(mMaybeSharingCameraChildrenIds, parent.$TST.id, this.id);
+            deleteFromChildrenIds(mMaybeSharingCameraChildrenIds, parent.id, this.id);
         }
         modifiedCount++;
       }
@@ -2804,9 +2804,9 @@ export class Tab extends TreeItem {
         this.toggleState(Constants.kTAB_STATE_HAS_SHARING_MICROPHONE_MEMBER, sharingMicrophoneCount > 0);
         if (parent) {
           if (sharingMicrophoneCount > 0)
-            addToChildrenIds(mMaybeSharingMicrophoneChildrenIds, parent.$TST.id, this.id);
+            addToChildrenIds(mMaybeSharingMicrophoneChildrenIds, parent.id, this.id);
           else
-            deleteFromChildrenIds(mMaybeSharingMicrophoneChildrenIds, parent.$TST.id, this.id);
+            deleteFromChildrenIds(mMaybeSharingMicrophoneChildrenIds, parent.id, this.id);
         }
         modifiedCount++;
       }
@@ -2817,9 +2817,9 @@ export class Tab extends TreeItem {
         this.toggleState(Constants.kTAB_STATE_HAS_SHARING_SCREEN_MEMBER, sharingScreenCount > 0);
         if (parent) {
           if (sharingScreenCount > 0)
-            addToChildrenIds(mMaybeSharingScreenChildrenIds, parent.$TST.id, this.id);
+            addToChildrenIds(mMaybeSharingScreenChildrenIds, parent.id, this.id);
           else
-            deleteFromChildrenIds(mMaybeSharingScreenChildrenIds, parent.$TST.id, this.id);
+            deleteFromChildrenIds(mMaybeSharingScreenChildrenIds, parent.id, this.id);
         }
         modifiedCount++;
       }

--- a/webextensions/common/TreeItem.js
+++ b/webextensions/common/TreeItem.js
@@ -59,6 +59,44 @@ const mIncompletelyTrackedTabs = new Map();
 const mMovingTabs              = new Map();
 const mPromisedTrackedTabs     = new Map();
 
+// Global maps for per-tab media state children IDs.
+// These are lazily populated only when a tab actually has children with media state,
+// saving memory compared to allocating 12 Sets per tab.
+const mSoundPlayingChildrenIds         = new Map();
+const mMaybeSoundPlayingChildrenIds    = new Map();
+const mMutedChildrenIds                = new Map();
+const mMaybeMutedChildrenIds           = new Map();
+const mAutoplayBlockedChildrenIds      = new Map();
+const mMaybeAutoplayBlockedChildrenIds = new Map();
+const mSharingCameraChildrenIds        = new Map();
+const mMaybeSharingCameraChildrenIds   = new Map();
+const mSharingMicrophoneChildrenIds    = new Map();
+const mMaybeSharingMicrophoneChildrenIds = new Map();
+const mSharingScreenChildrenIds        = new Map();
+const mMaybeSharingScreenChildrenIds   = new Map();
+
+function addToChildrenIds(map, tabId, childId) {
+  let set = map.get(tabId);
+  if (!set) {
+    set = new Set();
+    map.set(tabId, set);
+  }
+  set.add(childId);
+}
+
+function deleteFromChildrenIds(map, tabId, childId) {
+  const set = map.get(tabId);
+  if (set) {
+    set.delete(childId);
+    if (set.size === 0)
+      map.delete(tabId);
+  }
+}
+
+function getChildrenIdsSize(map, tabId) {
+  return map.get(tabId)?.size ?? 0;
+}
+
 
 browser.windows.onRemoved.addListener(windowId => {
   mIncompletelyTrackedTabs.delete(windowId);
@@ -1161,24 +1199,12 @@ export class Tab extends TreeItem {
       muted:           0,
       autoplayBlocked: 0,
     };
-    this.soundPlayingChildrenIds = new Set();
-    this.maybeSoundPlayingChildrenIds = new Set();
-    this.mutedChildrenIds = new Set();
-    this.maybeMutedChildrenIds = new Set();
-    this.autoplayBlockedChildrenIds = new Set();
-    this.maybeAutoplayBlockedChildrenIds = new Set();
 
     this.lastSharingStateCounts = {
       sharingCamera:     0,
       sharingMicrophone: 0,
       sharingScreen:     0,
     };
-    this.sharingCameraChildrenIds = new Set();
-    this.maybeSharingCameraChildrenIds = new Set();
-    this.sharingMicrophoneChildrenIds = new Set();
-    this.maybeSharingMicrophoneChildrenIds = new Set();
-    this.sharingScreenChildrenIds = new Set();
-    this.maybeSharingScreenChildrenIds = new Set();
 
     this.opened = new Promise((resolve, reject) => {
       const resolvers = mOpenedResolvers.get(raw.id) || new Set();
@@ -1249,6 +1275,35 @@ export class Tab extends TreeItem {
 
   clear() {
     super.clear();
+
+    // Clean up this tab as a child from parent's media state Sets
+    if (this.parentId) {
+      deleteFromChildrenIds(mSoundPlayingChildrenIds, this.parentId, this.id);
+      deleteFromChildrenIds(mMaybeSoundPlayingChildrenIds, this.parentId, this.id);
+      deleteFromChildrenIds(mMutedChildrenIds, this.parentId, this.id);
+      deleteFromChildrenIds(mMaybeMutedChildrenIds, this.parentId, this.id);
+      deleteFromChildrenIds(mAutoplayBlockedChildrenIds, this.parentId, this.id);
+      deleteFromChildrenIds(mMaybeAutoplayBlockedChildrenIds, this.parentId, this.id);
+      deleteFromChildrenIds(mSharingCameraChildrenIds, this.parentId, this.id);
+      deleteFromChildrenIds(mMaybeSharingCameraChildrenIds, this.parentId, this.id);
+      deleteFromChildrenIds(mSharingMicrophoneChildrenIds, this.parentId, this.id);
+      deleteFromChildrenIds(mMaybeSharingMicrophoneChildrenIds, this.parentId, this.id);
+      deleteFromChildrenIds(mSharingScreenChildrenIds, this.parentId, this.id);
+      deleteFromChildrenIds(mMaybeSharingScreenChildrenIds, this.parentId, this.id);
+    }
+    // Clean up this tab as a parent from global maps
+    mSoundPlayingChildrenIds.delete(this.id);
+    mMaybeSoundPlayingChildrenIds.delete(this.id);
+    mMutedChildrenIds.delete(this.id);
+    mMaybeMutedChildrenIds.delete(this.id);
+    mAutoplayBlockedChildrenIds.delete(this.id);
+    mMaybeAutoplayBlockedChildrenIds.delete(this.id);
+    mSharingCameraChildrenIds.delete(this.id);
+    mMaybeSharingCameraChildrenIds.delete(this.id);
+    mSharingMicrophoneChildrenIds.delete(this.id);
+    mMaybeSharingMicrophoneChildrenIds.delete(this.id);
+    mSharingScreenChildrenIds.delete(this.id);
+    mMaybeSharingScreenChildrenIds.delete(this.id);
 
     this.parentId = null;
     this.childIds = [];
@@ -1857,31 +1912,31 @@ export class Tab extends TreeItem {
       parent.$TST.invalidateCachedDescendants();
 
       if (this.states.has(Constants.kTAB_STATE_SOUND_PLAYING))
-        parent.$TST.soundPlayingChildrenIds.add(this.id);
+        addToChildrenIds(mSoundPlayingChildrenIds, parent.$TST.id, this.id);
       if (this.states.has(Constants.kTAB_STATE_HAS_SOUND_PLAYING_MEMBER))
-        parent.$TST.maybeSoundPlayingChildrenIds.add(this.id);
+        addToChildrenIds(mMaybeSoundPlayingChildrenIds, parent.$TST.id, this.id);
       if (this.states.has(Constants.kTAB_STATE_MUTED))
-        parent.$TST.mutedChildrenIds.add(this.id);
+        addToChildrenIds(mMutedChildrenIds, parent.$TST.id, this.id);
       if (this.states.has(Constants.kTAB_STATE_HAS_MUTED_MEMBER))
-        parent.$TST.maybeMutedChildrenIds.add(this.id);
+        addToChildrenIds(mMaybeMutedChildrenIds, parent.$TST.id, this.id);
       if (this.states.has(Constants.kTAB_STATE_AUTOPLAY_BLOCKED))
-        parent.$TST.autoplayBlockedChildrenIds.add(this.id);
+        addToChildrenIds(mAutoplayBlockedChildrenIds, parent.$TST.id, this.id);
       if (this.states.has(Constants.kTAB_STATE_HAS_AUTOPLAY_BLOCKED_MEMBER))
-        parent.$TST.maybeAutoplayBlockedChildrenIds.add(this.id);
+        addToChildrenIds(mMaybeAutoplayBlockedChildrenIds, parent.$TST.id, this.id);
       parent.$TST.inheritSoundStateFromChildren();
 
       if (this.states.has(Constants.kTAB_STATE_SHARING_CAMERA))
-        parent.$TST.sharingCameraChildrenIds.add(this.id);
+        addToChildrenIds(mSharingCameraChildrenIds, parent.$TST.id, this.id);
       if (this.states.has(Constants.kTAB_STATE_HAS_SHARING_CAMERA_MEMBER))
-        parent.$TST.maybeSharingCameraChildrenIds.add(this.id);
+        addToChildrenIds(mMaybeSharingCameraChildrenIds, parent.$TST.id, this.id);
       if (this.states.has(Constants.kTAB_STATE_SHARING_MICROPHONE))
-        parent.$TST.sharingMicrophoneChildrenIds.add(this.id);
+        addToChildrenIds(mSharingMicrophoneChildrenIds, parent.$TST.id, this.id);
       if (this.states.has(Constants.kTAB_STATE_HAS_SHARING_MICROPHONE_MEMBER))
-        parent.$TST.maybeSharingMicrophoneChildrenIds.add(this.id);
+        addToChildrenIds(mMaybeSharingMicrophoneChildrenIds, parent.$TST.id, this.id);
       if (this.states.has(Constants.kTAB_STATE_SHARING_SCREEN))
-        parent.$TST.sharingScreenChildrenIds.add(this.id);
+        addToChildrenIds(mSharingScreenChildrenIds, parent.$TST.id, this.id);
       if (this.states.has(Constants.kTAB_STATE_HAS_SHARING_SCREEN_MEMBER))
-        parent.$TST.maybeSharingScreenChildrenIds.add(this.id);
+        addToChildrenIds(mMaybeSharingScreenChildrenIds, parent.$TST.id, this.id);
       parent.$TST.inheritSharingStateFromChildren();
 
       TabsStore.removeRootTab(this.raw);
@@ -1891,20 +1946,20 @@ export class Tab extends TreeItem {
       TabsStore.addRootTab(this.raw);
     }
     if (oldParent && oldParent.id != this.parentId) {
-      oldParent.$TST.soundPlayingChildrenIds.delete(this.id);
-      oldParent.$TST.maybeSoundPlayingChildrenIds.delete(this.id);
-      oldParent.$TST.mutedChildrenIds.delete(this.id);
-      oldParent.$TST.maybeMutedChildrenIds.delete(this.id);
-      oldParent.$TST.autoplayBlockedChildrenIds.delete(this.id);
-      oldParent.$TST.maybeAutoplayBlockedChildrenIds.delete(this.id);
+      deleteFromChildrenIds(mSoundPlayingChildrenIds, oldParent.$TST.id, this.id);
+      deleteFromChildrenIds(mMaybeSoundPlayingChildrenIds, oldParent.$TST.id, this.id);
+      deleteFromChildrenIds(mMutedChildrenIds, oldParent.$TST.id, this.id);
+      deleteFromChildrenIds(mMaybeMutedChildrenIds, oldParent.$TST.id, this.id);
+      deleteFromChildrenIds(mAutoplayBlockedChildrenIds, oldParent.$TST.id, this.id);
+      deleteFromChildrenIds(mMaybeAutoplayBlockedChildrenIds, oldParent.$TST.id, this.id);
       oldParent.$TST.inheritSoundStateFromChildren();
 
-      oldParent.$TST.sharingCameraChildrenIds.delete(this.id);
-      oldParent.$TST.maybeSharingCameraChildrenIds.delete(this.id);
-      oldParent.$TST.sharingMicrophoneChildrenIds.delete(this.id);
-      oldParent.$TST.maybeSharingMicrophoneChildrenIds.delete(this.id);
-      oldParent.$TST.sharingScreenChildrenIds.delete(this.id);
-      oldParent.$TST.maybeSharingScreenChildrenIds.delete(this.id);
+      deleteFromChildrenIds(mSharingCameraChildrenIds, oldParent.$TST.id, this.id);
+      deleteFromChildrenIds(mMaybeSharingCameraChildrenIds, oldParent.$TST.id, this.id);
+      deleteFromChildrenIds(mSharingMicrophoneChildrenIds, oldParent.$TST.id, this.id);
+      deleteFromChildrenIds(mMaybeSharingMicrophoneChildrenIds, oldParent.$TST.id, this.id);
+      deleteFromChildrenIds(mSharingScreenChildrenIds, oldParent.$TST.id, this.id);
+      deleteFromChildrenIds(mMaybeSharingScreenChildrenIds, oldParent.$TST.id, this.id);
       oldParent.$TST.inheritSharingStateFromChildren();
 
       oldParent.$TST.children = oldParent.$TST.childIds.filter(id => id != this.id);
@@ -2341,12 +2396,12 @@ export class Tab extends TreeItem {
       case Constants.kTAB_STATE_SOUND_PLAYING: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.soundPlayingChildrenIds.add(this.id);
+          addToChildrenIds(mSoundPlayingChildrenIds, parent.$TST.id, this.id);
       } break;
       case Constants.kTAB_STATE_HAS_SOUND_PLAYING_MEMBER: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.maybeSoundPlayingChildrenIds.add(this.id);
+          addToChildrenIds(mMaybeSoundPlayingChildrenIds, parent.$TST.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_AUDIBLE:
@@ -2357,27 +2412,27 @@ export class Tab extends TreeItem {
       case Constants.kTAB_STATE_MUTED: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.mutedChildrenIds.add(this.id);
+          addToChildrenIds(mMutedChildrenIds, parent.$TST.id, this.id);
         if (toTab)
           this.raw.mutedInfo.muted = true;
       } break;
       case Constants.kTAB_STATE_HAS_MUTED_MEMBER: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.maybeMutedChildrenIds.add(this.id);
+          addToChildrenIds(mMaybeMutedChildrenIds, parent.$TST.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_AUTOPLAY_BLOCKED: {
         const parent = this.parent;
         if (parent) {
-          parent.$TST.autoplayBlockedChildrenIds.add(this.id);
+          addToChildrenIds(mAutoplayBlockedChildrenIds, parent.$TST.id, this.id);
           parent.$TST.inheritSoundStateFromChildren();
         }
       } break;
       case Constants.kTAB_STATE_HAS_AUTOPLAY_BLOCKED_MEMBER: {
         const parent = this.parent;
         if (parent) {
-          parent.$TST.maybeAutoplayBlockedChildrenIds.add(this.id);
+          addToChildrenIds(mMaybeAutoplayBlockedChildrenIds, parent.$TST.id, this.id);
           parent.$TST.inheritSoundStateFromChildren();
         }
       } break;
@@ -2385,40 +2440,40 @@ export class Tab extends TreeItem {
       case Constants.kTAB_STATE_SHARING_CAMERA: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.sharingCameraChildrenIds.add(this.id);
+          addToChildrenIds(mSharingCameraChildrenIds, parent.$TST.id, this.id);
         if (toTab && this.raw.sharingState)
           this.raw.sharingState.camera = true;
       } break;
       case Constants.kTAB_STATE_HAS_SHARING_CAMERA_MEMBER: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.maybeSharingCameraChildrenIds.add(this.id);
+          addToChildrenIds(mMaybeSharingCameraChildrenIds, parent.$TST.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_SHARING_MICROPHONE: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.sharingMicrophoneChildrenIds.add(this.id);
+          addToChildrenIds(mSharingMicrophoneChildrenIds, parent.$TST.id, this.id);
         if (toTab && this.raw.sharingState)
           this.raw.sharingState.microphone = true;
       } break;
       case Constants.kTAB_STATE_HAS_SHARING_MICROPHONE_MEMBER: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.maybeSharingMicrophoneChildrenIds.add(this.id);
+          addToChildrenIds(mMaybeSharingMicrophoneChildrenIds, parent.$TST.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_SHARING_SCREEN: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.sharingScreenChildrenIds.add(this.id);
+          addToChildrenIds(mSharingScreenChildrenIds, parent.$TST.id, this.id);
         if (toTab && this.raw.sharingState)
           this.raw.sharingState.screen = 'Something';
       } break;
       case Constants.kTAB_STATE_HAS_SHARING_SCREEN_MEMBER: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.maybeSharingScreenChildrenIds.add(this.id);
+          addToChildrenIds(mMaybeSharingScreenChildrenIds, parent.$TST.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_GROUP_TAB:
@@ -2534,12 +2589,12 @@ export class Tab extends TreeItem {
       case Constants.kTAB_STATE_SOUND_PLAYING: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.soundPlayingChildrenIds.delete(this.id);
+          deleteFromChildrenIds(mSoundPlayingChildrenIds, parent.$TST.id, this.id);
       } break;
       case Constants.kTAB_STATE_HAS_SOUND_PLAYING_MEMBER: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.maybeSoundPlayingChildrenIds.delete(this.id);
+          deleteFromChildrenIds(mMaybeSoundPlayingChildrenIds, parent.$TST.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_AUDIBLE:
@@ -2550,27 +2605,27 @@ export class Tab extends TreeItem {
       case Constants.kTAB_STATE_MUTED: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.mutedChildrenIds.delete(this.id);
+          deleteFromChildrenIds(mMutedChildrenIds, parent.$TST.id, this.id);
         if (toTab)
           this.raw.mutedInfo.muted = false;
       } break;
       case Constants.kTAB_STATE_HAS_MUTED_MEMBER: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.maybeMutedChildrenIds.delete(this.id);
+          deleteFromChildrenIds(mMaybeMutedChildrenIds, parent.$TST.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_AUTOPLAY_BLOCKED: {
         const parent = this.parent;
         if (parent) {
-          parent.$TST.autoplayBlockedChildrenIds.delete(this.id);
+          deleteFromChildrenIds(mAutoplayBlockedChildrenIds, parent.$TST.id, this.id);
           parent.$TST.inheritSoundStateFromChildren();
         }
       } break;
       case Constants.kTAB_STATE_HAS_AUTOPLAY_BLOCKED_MEMBER: {
         const parent = this.parent;
         if (parent) {
-          parent.$TST.maybeAutoplayBlockedChildrenIds.delete(this.id);
+          deleteFromChildrenIds(mMaybeAutoplayBlockedChildrenIds, parent.$TST.id, this.id);
           parent.$TST.inheritSoundStateFromChildren();
         }
       } break;
@@ -2578,40 +2633,40 @@ export class Tab extends TreeItem {
       case Constants.kTAB_STATE_SHARING_CAMERA: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.sharingCameraChildrenIds.delete(this.id);
+          deleteFromChildrenIds(mSharingCameraChildrenIds, parent.$TST.id, this.id);
         if (toTab && this.raw.sharingState)
           this.raw.sharingState.camera = false;
       } break;
       case Constants.kTAB_STATE_HAS_SHARING_CAMERA_MEMBER: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.maybeSharingCameraChildrenIds.delete(this.id);
+          deleteFromChildrenIds(mMaybeSharingCameraChildrenIds, parent.$TST.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_SHARING_MICROPHONE: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.sharingMicrophoneChildrenIds.delete(this.id);
+          deleteFromChildrenIds(mSharingMicrophoneChildrenIds, parent.$TST.id, this.id);
         if (toTab && this.raw.sharingState)
           this.raw.sharingState.microphone = false;
       } break;
       case Constants.kTAB_STATE_HAS_SHARING_MICROPHONE_MEMBER: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.maybeSharingMicrophoneChildrenIds.delete(this.id);
+          deleteFromChildrenIds(mMaybeSharingMicrophoneChildrenIds, parent.$TST.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_SHARING_SCREEN: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.sharingScreenChildrenIds.delete(this.id);
+          deleteFromChildrenIds(mSharingScreenChildrenIds, parent.$TST.id, this.id);
         if (toTab && this.raw.sharingState)
           this.raw.sharingState.screen = undefined;
       } break;
       case Constants.kTAB_STATE_HAS_SHARING_SCREEN_MEMBER: {
         const parent = this.parent;
         if (parent)
-          parent.$TST.maybeSharingScreenChildrenIds.delete(this.id);
+          deleteFromChildrenIds(mMaybeSharingScreenChildrenIds, parent.$TST.id, this.id);
       } break;
 
       case Constants.kTAB_STATE_GROUP_TAB:
@@ -2685,41 +2740,41 @@ export class Tab extends TreeItem {
       const parent = this.parent;
       let modifiedCount = 0;
 
-      const soundPlayingCount = this.soundPlayingChildrenIds.size + this.maybeSoundPlayingChildrenIds.size;
+      const soundPlayingCount = getChildrenIdsSize(mSoundPlayingChildrenIds, this.id) + getChildrenIdsSize(mMaybeSoundPlayingChildrenIds, this.id);
       if (soundPlayingCount != this.lastSoundStateCounts.soundPlaying) {
         this.lastSoundStateCounts.soundPlaying = soundPlayingCount;
         this.toggleState(Constants.kTAB_STATE_HAS_SOUND_PLAYING_MEMBER, soundPlayingCount > 0);
         if (parent) {
           if (soundPlayingCount > 0)
-            parent.$TST.maybeSoundPlayingChildrenIds.add(this.id);
+            addToChildrenIds(mMaybeSoundPlayingChildrenIds, parent.$TST.id, this.id);
           else
-            parent.$TST.maybeSoundPlayingChildrenIds.delete(this.id);
+            deleteFromChildrenIds(mMaybeSoundPlayingChildrenIds, parent.$TST.id, this.id);
         }
         modifiedCount++;
       }
 
-      const mutedCount = this.mutedChildrenIds.size + this.maybeMutedChildrenIds.size;
+      const mutedCount = getChildrenIdsSize(mMutedChildrenIds, this.id) + getChildrenIdsSize(mMaybeMutedChildrenIds, this.id);
       if (mutedCount != this.lastSoundStateCounts.muted) {
         this.lastSoundStateCounts.muted = mutedCount;
         this.toggleState(Constants.kTAB_STATE_HAS_MUTED_MEMBER, mutedCount > 0);
         if (parent) {
           if (mutedCount > 0)
-            parent.$TST.maybeMutedChildrenIds.add(this.id);
+            addToChildrenIds(mMaybeMutedChildrenIds, parent.$TST.id, this.id);
           else
-            parent.$TST.maybeMutedChildrenIds.delete(this.id);
+            deleteFromChildrenIds(mMaybeMutedChildrenIds, parent.$TST.id, this.id);
         }
         modifiedCount++;
       }
 
-      const autoplayBlockedCount = this.autoplayBlockedChildrenIds.size + this.maybeAutoplayBlockedChildrenIds.size;
+      const autoplayBlockedCount = getChildrenIdsSize(mAutoplayBlockedChildrenIds, this.id) + getChildrenIdsSize(mMaybeAutoplayBlockedChildrenIds, this.id);
       if (autoplayBlockedCount != this.lastSoundStateCounts.autoplayBlocked) {
         this.lastSoundStateCounts.autoplayBlocked = autoplayBlockedCount;
         this.toggleState(Constants.kTAB_STATE_HAS_AUTOPLAY_BLOCKED_MEMBER, autoplayBlockedCount > 0);
         if (parent) {
           if (autoplayBlockedCount > 0)
-            parent.$TST.maybeAutoplayBlockedChildrenIds.add(this.id);
+            addToChildrenIds(mMaybeAutoplayBlockedChildrenIds, parent.$TST.id, this.id);
           else
-            parent.$TST.maybeAutoplayBlockedChildrenIds.delete(this.id);
+            deleteFromChildrenIds(mMaybeAutoplayBlockedChildrenIds, parent.$TST.id, this.id);
         }
         modifiedCount++;
       }
@@ -2757,41 +2812,41 @@ export class Tab extends TreeItem {
       const parent = this.parent;
       let modifiedCount = 0;
 
-      const sharingCameraCount = this.sharingCameraChildrenIds.size + this.maybeSharingCameraChildrenIds.size;
+      const sharingCameraCount = getChildrenIdsSize(mSharingCameraChildrenIds, this.id) + getChildrenIdsSize(mMaybeSharingCameraChildrenIds, this.id);
       if (sharingCameraCount != this.lastSharingStateCounts.sharingCamera) {
         this.lastSharingStateCounts.sharingCamera = sharingCameraCount;
         this.toggleState(Constants.kTAB_STATE_HAS_SHARING_CAMERA_MEMBER, sharingCameraCount > 0);
         if (parent) {
           if (sharingCameraCount > 0)
-            parent.$TST.maybeSharingCameraChildrenIds.add(this.id);
+            addToChildrenIds(mMaybeSharingCameraChildrenIds, parent.$TST.id, this.id);
           else
-            parent.$TST.maybeSharingCameraChildrenIds.delete(this.id);
+            deleteFromChildrenIds(mMaybeSharingCameraChildrenIds, parent.$TST.id, this.id);
         }
         modifiedCount++;
       }
 
-      const sharingMicrophoneCount = this.sharingMicrophoneChildrenIds.size + this.maybeSharingMicrophoneChildrenIds.size;
+      const sharingMicrophoneCount = getChildrenIdsSize(mSharingMicrophoneChildrenIds, this.id) + getChildrenIdsSize(mMaybeSharingMicrophoneChildrenIds, this.id);
       if (sharingMicrophoneCount != this.lastSharingStateCounts.sharingMicrophone) {
         this.lastSharingStateCounts.sharingMicrophone = sharingMicrophoneCount;
         this.toggleState(Constants.kTAB_STATE_HAS_SHARING_MICROPHONE_MEMBER, sharingMicrophoneCount > 0);
         if (parent) {
           if (sharingMicrophoneCount > 0)
-            parent.$TST.maybeSharingMicrophoneChildrenIds.add(this.id);
+            addToChildrenIds(mMaybeSharingMicrophoneChildrenIds, parent.$TST.id, this.id);
           else
-            parent.$TST.maybeSharingMicrophoneChildrenIds.delete(this.id);
+            deleteFromChildrenIds(mMaybeSharingMicrophoneChildrenIds, parent.$TST.id, this.id);
         }
         modifiedCount++;
       }
 
-      const sharingScreenCount = this.sharingScreenChildrenIds.size + this.maybeSharingScreenChildrenIds.size;
+      const sharingScreenCount = getChildrenIdsSize(mSharingScreenChildrenIds, this.id) + getChildrenIdsSize(mMaybeSharingScreenChildrenIds, this.id);
       if (sharingScreenCount != this.lastSharingStateCounts.sharingScreen) {
         this.lastSharingStateCounts.sharingScreen = sharingScreenCount;
         this.toggleState(Constants.kTAB_STATE_HAS_SHARING_SCREEN_MEMBER, sharingScreenCount > 0);
         if (parent) {
           if (sharingScreenCount > 0)
-            parent.$TST.maybeSharingScreenChildrenIds.add(this.id);
+            addToChildrenIds(mMaybeSharingScreenChildrenIds, parent.$TST.id, this.id);
           else
-            parent.$TST.maybeSharingScreenChildrenIds.delete(this.id);
+            deleteFromChildrenIds(mMaybeSharingScreenChildrenIds, parent.$TST.id, this.id);
         }
         modifiedCount++;
       }

--- a/webextensions/common/TreeItem.js
+++ b/webextensions/common/TreeItem.js
@@ -75,6 +75,25 @@ const mMaybeSharingMicrophoneChildrenIds = new Map();
 const mSharingScreenChildrenIds        = new Map();
 const mMaybeSharingScreenChildrenIds   = new Map();
 
+// [stateConstant, map] pairs grouped by sound/sharing for inherit callbacks
+const mSoundChildrenIdsMaps = [
+  [Constants.kTAB_STATE_SOUND_PLAYING,                 mSoundPlayingChildrenIds],
+  [Constants.kTAB_STATE_HAS_SOUND_PLAYING_MEMBER,      mMaybeSoundPlayingChildrenIds],
+  [Constants.kTAB_STATE_MUTED,                         mMutedChildrenIds],
+  [Constants.kTAB_STATE_HAS_MUTED_MEMBER,              mMaybeMutedChildrenIds],
+  [Constants.kTAB_STATE_AUTOPLAY_BLOCKED,              mAutoplayBlockedChildrenIds],
+  [Constants.kTAB_STATE_HAS_AUTOPLAY_BLOCKED_MEMBER,   mMaybeAutoplayBlockedChildrenIds],
+];
+const mSharingChildrenIdsMaps = [
+  [Constants.kTAB_STATE_SHARING_CAMERA,                mSharingCameraChildrenIds],
+  [Constants.kTAB_STATE_HAS_SHARING_CAMERA_MEMBER,     mMaybeSharingCameraChildrenIds],
+  [Constants.kTAB_STATE_SHARING_MICROPHONE,            mSharingMicrophoneChildrenIds],
+  [Constants.kTAB_STATE_HAS_SHARING_MICROPHONE_MEMBER, mMaybeSharingMicrophoneChildrenIds],
+  [Constants.kTAB_STATE_SHARING_SCREEN,                mSharingScreenChildrenIds],
+  [Constants.kTAB_STATE_HAS_SHARING_SCREEN_MEMBER,     mMaybeSharingScreenChildrenIds],
+];
+const mAllChildrenIdsMaps = [...mSoundChildrenIdsMaps, ...mSharingChildrenIdsMaps];
+
 function addToChildrenIds(map, tabId, childId) {
   let set = map.get(tabId);
   if (!set) {
@@ -1276,34 +1295,12 @@ export class Tab extends TreeItem {
   clear() {
     super.clear();
 
-    // Clean up this tab as a child from parent's media state Sets
-    if (this.parentId) {
-      deleteFromChildrenIds(mSoundPlayingChildrenIds, this.parentId, this.id);
-      deleteFromChildrenIds(mMaybeSoundPlayingChildrenIds, this.parentId, this.id);
-      deleteFromChildrenIds(mMutedChildrenIds, this.parentId, this.id);
-      deleteFromChildrenIds(mMaybeMutedChildrenIds, this.parentId, this.id);
-      deleteFromChildrenIds(mAutoplayBlockedChildrenIds, this.parentId, this.id);
-      deleteFromChildrenIds(mMaybeAutoplayBlockedChildrenIds, this.parentId, this.id);
-      deleteFromChildrenIds(mSharingCameraChildrenIds, this.parentId, this.id);
-      deleteFromChildrenIds(mMaybeSharingCameraChildrenIds, this.parentId, this.id);
-      deleteFromChildrenIds(mSharingMicrophoneChildrenIds, this.parentId, this.id);
-      deleteFromChildrenIds(mMaybeSharingMicrophoneChildrenIds, this.parentId, this.id);
-      deleteFromChildrenIds(mSharingScreenChildrenIds, this.parentId, this.id);
-      deleteFromChildrenIds(mMaybeSharingScreenChildrenIds, this.parentId, this.id);
+    // Clean up media state children IDs from global maps
+    for (const [, map] of mAllChildrenIdsMaps) {
+      if (this.parentId)
+        deleteFromChildrenIds(map, this.parentId, this.id);
+      map.delete(this.id);
     }
-    // Clean up this tab as a parent from global maps
-    mSoundPlayingChildrenIds.delete(this.id);
-    mMaybeSoundPlayingChildrenIds.delete(this.id);
-    mMutedChildrenIds.delete(this.id);
-    mMaybeMutedChildrenIds.delete(this.id);
-    mAutoplayBlockedChildrenIds.delete(this.id);
-    mMaybeAutoplayBlockedChildrenIds.delete(this.id);
-    mSharingCameraChildrenIds.delete(this.id);
-    mMaybeSharingCameraChildrenIds.delete(this.id);
-    mSharingMicrophoneChildrenIds.delete(this.id);
-    mMaybeSharingMicrophoneChildrenIds.delete(this.id);
-    mSharingScreenChildrenIds.delete(this.id);
-    mMaybeSharingScreenChildrenIds.delete(this.id);
 
     this.parentId = null;
     this.childIds = [];
@@ -1911,32 +1908,16 @@ export class Tab extends TreeItem {
       this.setAttribute(Constants.kPARENT, parent.id);
       parent.$TST.invalidateCachedDescendants();
 
-      if (this.states.has(Constants.kTAB_STATE_SOUND_PLAYING))
-        addToChildrenIds(mSoundPlayingChildrenIds, parent.$TST.id, this.id);
-      if (this.states.has(Constants.kTAB_STATE_HAS_SOUND_PLAYING_MEMBER))
-        addToChildrenIds(mMaybeSoundPlayingChildrenIds, parent.$TST.id, this.id);
-      if (this.states.has(Constants.kTAB_STATE_MUTED))
-        addToChildrenIds(mMutedChildrenIds, parent.$TST.id, this.id);
-      if (this.states.has(Constants.kTAB_STATE_HAS_MUTED_MEMBER))
-        addToChildrenIds(mMaybeMutedChildrenIds, parent.$TST.id, this.id);
-      if (this.states.has(Constants.kTAB_STATE_AUTOPLAY_BLOCKED))
-        addToChildrenIds(mAutoplayBlockedChildrenIds, parent.$TST.id, this.id);
-      if (this.states.has(Constants.kTAB_STATE_HAS_AUTOPLAY_BLOCKED_MEMBER))
-        addToChildrenIds(mMaybeAutoplayBlockedChildrenIds, parent.$TST.id, this.id);
+      for (const [state, map] of mSoundChildrenIdsMaps) {
+        if (this.states.has(state))
+          addToChildrenIds(map, parent.$TST.id, this.id);
+      }
       parent.$TST.inheritSoundStateFromChildren();
 
-      if (this.states.has(Constants.kTAB_STATE_SHARING_CAMERA))
-        addToChildrenIds(mSharingCameraChildrenIds, parent.$TST.id, this.id);
-      if (this.states.has(Constants.kTAB_STATE_HAS_SHARING_CAMERA_MEMBER))
-        addToChildrenIds(mMaybeSharingCameraChildrenIds, parent.$TST.id, this.id);
-      if (this.states.has(Constants.kTAB_STATE_SHARING_MICROPHONE))
-        addToChildrenIds(mSharingMicrophoneChildrenIds, parent.$TST.id, this.id);
-      if (this.states.has(Constants.kTAB_STATE_HAS_SHARING_MICROPHONE_MEMBER))
-        addToChildrenIds(mMaybeSharingMicrophoneChildrenIds, parent.$TST.id, this.id);
-      if (this.states.has(Constants.kTAB_STATE_SHARING_SCREEN))
-        addToChildrenIds(mSharingScreenChildrenIds, parent.$TST.id, this.id);
-      if (this.states.has(Constants.kTAB_STATE_HAS_SHARING_SCREEN_MEMBER))
-        addToChildrenIds(mMaybeSharingScreenChildrenIds, parent.$TST.id, this.id);
+      for (const [state, map] of mSharingChildrenIdsMaps) {
+        if (this.states.has(state))
+          addToChildrenIds(map, parent.$TST.id, this.id);
+      }
       parent.$TST.inheritSharingStateFromChildren();
 
       TabsStore.removeRootTab(this.raw);
@@ -1946,20 +1927,12 @@ export class Tab extends TreeItem {
       TabsStore.addRootTab(this.raw);
     }
     if (oldParent && oldParent.id != this.parentId) {
-      deleteFromChildrenIds(mSoundPlayingChildrenIds, oldParent.$TST.id, this.id);
-      deleteFromChildrenIds(mMaybeSoundPlayingChildrenIds, oldParent.$TST.id, this.id);
-      deleteFromChildrenIds(mMutedChildrenIds, oldParent.$TST.id, this.id);
-      deleteFromChildrenIds(mMaybeMutedChildrenIds, oldParent.$TST.id, this.id);
-      deleteFromChildrenIds(mAutoplayBlockedChildrenIds, oldParent.$TST.id, this.id);
-      deleteFromChildrenIds(mMaybeAutoplayBlockedChildrenIds, oldParent.$TST.id, this.id);
+      for (const [, map] of mSoundChildrenIdsMaps)
+        deleteFromChildrenIds(map, oldParent.$TST.id, this.id);
       oldParent.$TST.inheritSoundStateFromChildren();
 
-      deleteFromChildrenIds(mSharingCameraChildrenIds, oldParent.$TST.id, this.id);
-      deleteFromChildrenIds(mMaybeSharingCameraChildrenIds, oldParent.$TST.id, this.id);
-      deleteFromChildrenIds(mSharingMicrophoneChildrenIds, oldParent.$TST.id, this.id);
-      deleteFromChildrenIds(mMaybeSharingMicrophoneChildrenIds, oldParent.$TST.id, this.id);
-      deleteFromChildrenIds(mSharingScreenChildrenIds, oldParent.$TST.id, this.id);
-      deleteFromChildrenIds(mMaybeSharingScreenChildrenIds, oldParent.$TST.id, this.id);
+      for (const [, map] of mSharingChildrenIdsMaps)
+        deleteFromChildrenIds(map, oldParent.$TST.id, this.id);
       oldParent.$TST.inheritSharingStateFromChildren();
 
       oldParent.$TST.children = oldParent.$TST.childIds.filter(id => id != this.id);


### PR DESCRIPTION
TreeItem.js の Tab コンストラクタでは、各タブに12個の `Set()` を生成しています（`soundPlayingChildrenIds`, `maybeSoundPlayingChildrenIds`, `mutedChildrenIds` 等）。これらは子タブのメディア状態（音声再生・ミュート・画面共有等）を追跡するためのものですが、実際にメディア状態を持つ子タブがいる親タブはごくわずかで、大半のタブでは全12個が空のままです。

空のSet一つのサイズはChatGPTによると80〜200バイトくらいでは、とのことで、実装を想像しても、そんなものだろうと思います。80バイトだと仮定して、100個タブがあったとして、96KBの程度のメモリ消費量の削減になります。大した削減量ではありませんが、大きなデメリットもない（厳密には、Mapのget処理が一回入る分、ごく僅かに計算は重たくなります）ので、メリットのほうが大きいと考えます。

## 変更内容

- 12個のインスタンスプロパティ (`this.xxxChildrenIds = new Set()`) を削除
- モジュールレベルの `Map<tabId, Set>` に置き換え、メディア状態を持つ子がいるタブにのみ Set を遅延生成
- 3つのヘルパー関数 (`addToChildrenIds`, `deleteFromChildrenIds`, `getChildrenIdsSize`) を追加し、Set の生成・削除・空 Map エントリのクリーンアップを一元化
- `Tab.clear()` に、親としてのエントリ削除と子としてのエントリ削除の両方のクリーンアップを追加
