### PR TITLE
fix: rebuild allAutoStickyStates with nested iteration instead of flat()

### DIFF
--- a/webextensions/common/TreeItem.js
+++ b/webextensions/common/TreeItem.js
@@ -740,9 +740,12 @@ export class TreeItem {
     else
       TreeItem.autoStickyStates.delete(providerId);
 
-    TreeItem.allAutoStickyStates = new Set([
-      ...TreeItem.autoStickyStates.values(),
-    ].flat());
+    TreeItem.allAutoStickyStates = new Set();
+    for (const states of TreeItem.autoStickyStates.values()) {
+      for (const state of states) {
+        TreeItem.allAutoStickyStates.add(state);
+      }
+    }
 
     TreeItem.updateCanBecomeStickyTabsIndex(TabsStore.getCurrentWindowId());
 


### PR DESCRIPTION
`unregisterAutoStickyState()` で `allAutoStickyStates` を再構築する際に `Array.prototype.flat()` を使用していましたが、`flat()` は配列のみを展開し `Set` は展開しません。`autoStickyStates` は `Map<string, Set<string>>` であるため、`.values()` を展開して `flat()` を呼ぶと、`Set` オブジェクトそのものが `allAutoStickyStates` に格納されてしまいます。

修正内容：ネストした `for...of` ループに置き換え、個々の状態文字列が正しく追加されるように修正しました
