### PR TITLE
stabilize object shape (hidden class) for inline cache optimization

### DIFF
--- a/webextensions/common/TreeItem.js
+++ b/webextensions/common/TreeItem.js
@@ -116,6 +116,10 @@ function getChildrenIdsSize(map, tabId) {
   return map.get(tabId)?.size ?? 0;
 }
 
+// Dynamic properties that should not change the shape of TreeItem instances.
+// Using a module-level Map preserves SpiderMonkey's Shape (hidden class) optimization.
+const mPossibleOpenerBookmarks = new Map();
+
 
 browser.windows.onRemoved.addListener(windowId => {
   mIncompletelyTrackedTabs.delete(windowId);
@@ -171,8 +175,14 @@ export class TreeItem {
       this._promisedElementResolver = resolve;
     });
 
+    this.lastPreviousTabId = null;
+    this.lastNextTabId     = null;
+    this.label             = null;
+
     this.states = new Set();
     this.clear();
+
+    this.destroyed = false;
 
     this.uniqueId = {
       id:            null,
@@ -192,12 +202,16 @@ export class TreeItem {
     this.promisedUniqueId = null;
     this.uniqueId = null;
     this.destroyed = true;
+    mPossibleOpenerBookmarks.delete(this.id);
   }
 
   clear() {
     this.states.clear();
     this.attributes = {};
   }
+
+  get possibleOpenerBookmarks() { return mPossibleOpenerBookmarks.get(this.id); }
+  set possibleOpenerBookmarks(value) { mPossibleOpenerBookmarks.set(this.id, value); }
 
   bindElement(element) {
     element.$TST   = this;
@@ -924,6 +938,8 @@ export class TabGroup extends TreeItem {
   constructor(raw) {
     super(raw);
 
+    this._collapsedMembersCounterItem = null;
+
     TabsStore.tabGroups.set(raw.id, raw);
     TabsStore.windows.get(raw.windowId)?.tabGroups.set(raw.id, raw);
 
@@ -1560,11 +1576,13 @@ export class Tab extends TreeItem {
   }
 
   get promisedPossibleOpenerBookmarks() {
-    if ('possibleOpenerBookmarks' in this)
-      return Promise.resolve(this.possibleOpenerBookmarks);
+    if (mPossibleOpenerBookmarks.has(this.id))
+      return Promise.resolve(mPossibleOpenerBookmarks.get(this.id));
     return new Promise(async (resolve, _reject) => {
-      if (!browser.bookmarks || !this.raw)
-        return resolve(this.possibleOpenerBookmarks = []);
+      if (!browser.bookmarks || !this.raw) {
+        mPossibleOpenerBookmarks.set(this.id, []);
+        return resolve([]);
+      }
       // A new tab from bookmark is opened with a title: its URL without the scheme part.
       const url = this.raw.$possibleInitialUrl;
       try {
@@ -1578,13 +1596,16 @@ export class Tab extends TreeItem {
           this._safeSearchBookmstksWithUrl(url), // about:* and so on
         ]);
         log(`promisedPossibleOpenerBookmarks for tab ${this.id} (${url}): `, possibleBookmarks);
-        resolve(this.possibleOpenerBookmarks = possibleBookmarks.flat());
+        const result = possibleBookmarks.flat();
+        mPossibleOpenerBookmarks.set(this.id, result);
+        resolve(result);
       }
       catch(error) {
         log(`promisedPossibleOpenerBookmarks for the tab ${this.id} (${url}): `, error);
         // If it is detected as "not a valid URL", then
         // it cannot be a tab opened from a bookmark.
-        resolve(this.possibleOpenerBookmarks = []);
+        mPossibleOpenerBookmarks.set(this.id, []);
+        resolve([]);
       }
     });
   }

--- a/webextensions/sidebar/collapse-expand.js
+++ b/webextensions/sidebar/collapse-expand.js
@@ -63,7 +63,7 @@ export function setCollapsedOnCreated(tabId, value) {
     mCollapsedOnCreated.delete(tabId);
 }
 
-export function clearCollapseExpandStateForTab(tabId) {
+export function clearState(tabId) {
   mCollapsedOnCreated.delete(tabId);
   mUpdatingCollapsedStateCanceller.delete(tabId);
   const timeout = mCollapseExpandAnimationTimeout.get(tabId);

--- a/webextensions/sidebar/collapse-expand.js
+++ b/webextensions/sidebar/collapse-expand.js
@@ -46,6 +46,44 @@ function log(...args) {
   internalLogger('sidebar/collapse-expand', ...args);
 }
 
+// Module-level maps for per-tab sidebar collapse/expand state.
+// These should not be stored on TreeItem instances to preserve object shape stability.
+const mShouldExpandLater = new Map();
+const mCollapsedOnCreated = new Map();
+const mUpdatingCollapsedStateCanceller = new Map();
+const mCollapseExpandAnimationCallback = new Map();
+const mCollapseExpandAnimationTimeout = new Map();
+
+export function getShouldExpandLater(tabId) {
+  return mShouldExpandLater.get(tabId) || false;
+}
+export function setShouldExpandLater(tabId, value) {
+  if (value)
+    mShouldExpandLater.set(tabId, true);
+  else
+    mShouldExpandLater.delete(tabId);
+}
+export function getCollapsedOnCreated(tabId) {
+  return mCollapsedOnCreated.get(tabId) || false;
+}
+export function setCollapsedOnCreated(tabId, value) {
+  if (value)
+    mCollapsedOnCreated.set(tabId, true);
+  else
+    mCollapsedOnCreated.delete(tabId);
+}
+
+export function clearCollapseExpandStateForTab(tabId) {
+  mShouldExpandLater.delete(tabId);
+  mCollapsedOnCreated.delete(tabId);
+  mUpdatingCollapsedStateCanceller.delete(tabId);
+  const timeout = mCollapseExpandAnimationTimeout.get(tabId);
+  if (timeout)
+    clearTimeout(timeout);
+  mCollapseExpandAnimationCallback.delete(tabId);
+  mCollapseExpandAnimationTimeout.delete(tabId);
+}
+
 export const onUpdating = new EventListenerManager();
 export const onUpdated = new EventListenerManager();
 export const onReadyToExpand = new EventListenerManager();
@@ -60,7 +98,7 @@ export async function setCollapsed(tab, info = {}) {
     info.collapsed != tab.$TST.collapsedCompletely
   );
 
-  tab.$TST.shouldExpandLater = false; // clear flag
+  mShouldExpandLater.delete(tab.id); // clear flag
 
   if (info.collapsed) {
     tab.$TST.addState(Constants.kTAB_STATE_COLLAPSED);
@@ -78,9 +116,10 @@ export async function setCollapsed(tab, info = {}) {
     TabsStore.addExpandedTab(tab);
   }
 
-  if (tab.$TST.onEndCollapseExpandAnimation) {
-    clearTimeout(tab.$TST.onEndCollapseExpandAnimation.timeout);
-    delete tab.$TST.onEndCollapseExpandAnimation;
+  if (mCollapseExpandAnimationCallback.has(tab.id)) {
+    clearTimeout(mCollapseExpandAnimationTimeout.get(tab.id));
+    mCollapseExpandAnimationCallback.delete(tab.id);
+    mCollapseExpandAnimationTimeout.delete(tab.id);
   }
 
   if (tab.status == 'loading')
@@ -88,9 +127,10 @@ export async function setCollapsed(tab, info = {}) {
 
   const manager = tab.$TST.collapsedStateChangedManager || new EventListenerManager();
 
-  if (tab.$TST.updatingCollapsedStateCanceller) {
-    tab.$TST.updatingCollapsedStateCanceller(tab.$TST.collapsed);
-    delete tab.$TST.updatingCollapsedStateCanceller;
+  const prevCanceller = mUpdatingCollapsedStateCanceller.get(tab.id);
+  if (prevCanceller) {
+    prevCanceller(tab.$TST.collapsed);
+    mUpdatingCollapsedStateCanceller.delete(tab.id);
   }
 
   let cancelled = false;
@@ -140,7 +180,7 @@ export async function setCollapsed(tab, info = {}) {
     return;
   }
 
-  tab.$TST.updatingCollapsedStateCanceller = canceller;
+  mUpdatingCollapsedStateCanceller.set(tab.id, canceller);
 
   if (tab.$TST.collapsed) {
     tab.$TST.addState(Constants.kTAB_STATE_COLLAPSING);
@@ -171,7 +211,7 @@ export async function setCollapsed(tab, info = {}) {
       last:      info.last
     });
 
-    tab.$TST.onEndCollapseExpandAnimation = (() => {
+    const collapseExpandCallback = () => {
       if (cancelled) {
         onCanceled();
         return;
@@ -191,18 +231,21 @@ export async function setCollapsed(tab, info = {}) {
       onUpdated.dispatch(tab, {
         collapsed: tab.$TST.collapsed
       });
-    });
-    tab.$TST.onEndCollapseExpandAnimation.timeout = setTimeout(() => {
+    };
+    mCollapseExpandAnimationCallback.set(tab.id, collapseExpandCallback);
+    mCollapseExpandAnimationTimeout.set(tab.id, setTimeout(() => {
       if (cancelled ||
           !TabsStore.ensureLivingItem(tab) ||
-          !tab.$TST.onEndCollapseExpandAnimation) {
+          !mCollapseExpandAnimationCallback.has(tab.id)) {
         onCanceled();
         return;
       }
-      delete tab.$TST.onEndCollapseExpandAnimation.timeout;
-      tab.$TST.onEndCollapseExpandAnimation();
-      delete tab.$TST.onEndCollapseExpandAnimation;
-    }, configs.collapseDuration);
+      mCollapseExpandAnimationTimeout.delete(tab.id);
+      const callback = mCollapseExpandAnimationCallback.get(tab.id);
+      if (callback)
+        callback();
+      mCollapseExpandAnimationCallback.delete(tab.id);
+    }, configs.collapseDuration));
   });
 }
 
@@ -232,9 +275,9 @@ BackgroundConnection.onMessage.addListener(async message => {
       if (!tab ||
           !lastMessage)
         return;
-      if (tab.$TST.collapsedOnCreated) { // it may be already expanded by others!
+      if (mCollapsedOnCreated.get(tab.id)) { // it may be already expanded by others!
         if (!tab.$TST.collapsed) // expanded by someone, so clear the flag.
-          tab.$TST.collapsedOnCreated = false;
+          mCollapsedOnCreated.delete(tab.id);
 
         // Unexpectedly kept as collapsed case may happen when only "collapsed"
         // state was applied by broadcasting, so we clear it for now

--- a/webextensions/sidebar/collapse-expand.js
+++ b/webextensions/sidebar/collapse-expand.js
@@ -48,21 +48,11 @@ function log(...args) {
 
 // Module-level maps for per-tab sidebar collapse/expand state.
 // These should not be stored on TreeItem instances to preserve object shape stability.
-const mShouldExpandLater = new Map();
 const mCollapsedOnCreated = new Map();
 const mUpdatingCollapsedStateCanceller = new Map();
 const mCollapseExpandAnimationCallback = new Map();
 const mCollapseExpandAnimationTimeout = new Map();
 
-export function getShouldExpandLater(tabId) {
-  return mShouldExpandLater.get(tabId) || false;
-}
-export function setShouldExpandLater(tabId, value) {
-  if (value)
-    mShouldExpandLater.set(tabId, true);
-  else
-    mShouldExpandLater.delete(tabId);
-}
 export function getCollapsedOnCreated(tabId) {
   return mCollapsedOnCreated.get(tabId) || false;
 }
@@ -74,7 +64,6 @@ export function setCollapsedOnCreated(tabId, value) {
 }
 
 export function clearCollapseExpandStateForTab(tabId) {
-  mShouldExpandLater.delete(tabId);
   mCollapsedOnCreated.delete(tabId);
   mUpdatingCollapsedStateCanceller.delete(tabId);
   const timeout = mCollapseExpandAnimationTimeout.get(tabId);
@@ -97,8 +86,6 @@ export async function setCollapsed(tab, info = {}) {
     info.collapsed != tab.$TST.collapsed ||
     info.collapsed != tab.$TST.collapsedCompletely
   );
-
-  mShouldExpandLater.delete(tab.id); // clear flag
 
   if (info.collapsed) {
     tab.$TST.addState(Constants.kTAB_STATE_COLLAPSED);

--- a/webextensions/sidebar/scroll.js
+++ b/webextensions/sidebar/scroll.js
@@ -58,6 +58,7 @@ import { Tab, TabGroup, TreeItem } from '/common/TreeItem.js';
 
 import * as BackgroundConnection from './background-connection.js';
 import * as CollapseExpand from './collapse-expand.js';
+import { getCollapsedOnCreated, setCollapsedOnCreated } from './collapse-expand.js';
 import * as EventUtils from './event-utils.js';
 import * as RestoringTabCount from './restoring-tab-count.js';
 import * as SidebarItems from './sidebar-items.js';
@@ -1336,7 +1337,7 @@ async function onBackgroundMessage(message) {
       if (!item) // it can be closed while waiting
         break;
       const needToWaitForTreeExpansion = (
-        item.$TST.collapsedOnCreated &&
+        getCollapsedOnCreated(item.id) &&
         !item.active &&
         !Tab.getActiveTab(item.windowId).pinned
       );
@@ -1347,7 +1348,7 @@ async function onBackgroundMessage(message) {
           if (parent?.$TST.subtreeCollapsed) // possibly collapsed by other trigger intentionally
             return;
           const active = item.active;
-          item.$TST.collapsedOnCreated = false;
+          setCollapsedOnCreated(item.id, false);
           const activeTab = Tab.getActiveTab(item.windowId);
           CollapseExpand.setCollapsed(item, { // this is required to scroll to the tab with the "last" parameter
             collapsed: false,

--- a/webextensions/sidebar/sidebar-items.js
+++ b/webextensions/sidebar/sidebar-items.js
@@ -1114,7 +1114,7 @@ BackgroundConnection.onMessage.addListener(async message => {
       if (burstEnd)
         clearTimeout(burstEnd);
       mDelayedBurstEnd.delete(message.tabId);
-      CollapseExpand.clearCollapseExpandStateForTab(message.tabId);
+      CollapseExpand.clearState(message.tabId);
       // remove from "highlighted tabs" cache immediately, to prevent misdetection for "multiple highlighted".
       TabsStore.removeHighlightedTab(tab);
       TabsStore.removeGroupTab(tab);

--- a/webextensions/sidebar/sidebar-items.js
+++ b/webextensions/sidebar/sidebar-items.js
@@ -532,6 +532,8 @@ function maybeNewTabIsMoved(tabId) {
 }
 
 
+const mDelayedBurstEnd = new Map();
+
 const mPendingUpdates = new Map();
 
 function setupPendingUpdate(update) {
@@ -834,7 +836,7 @@ BackgroundConnection.onMessage.addListener(async message => {
           collapsed: true,
           justNow:   true
         });
-        tab.$TST.collapsedOnCreated = true;
+        CollapseExpand.setCollapsedOnCreated(tab.id, true);
       }
       else {
         reserveToUpdateLoadingState();
@@ -868,7 +870,7 @@ BackgroundConnection.onMessage.addListener(async message => {
       }
       reserveToUpdateLoadingState();
       const needToWaitForTreeExpansion = (
-        tab.$TST.shouldExpandLater &&
+        CollapseExpand.getShouldExpandLater(tab.id) &&
         !tab.active &&
         !Tab.getActiveTab(tab.windowId).pinned
       );
@@ -885,7 +887,7 @@ BackgroundConnection.onMessage.addListener(async message => {
         if (shouldApplyAnimation()) {
           await wait(0); // nextFrame() is too fast!
           if (!message.collapsed /* the new tab may be really collapsed not just for animation, and we should not expand */ &&
-              tab.$TST.collapsedOnCreated) {
+              CollapseExpand.getCollapsedOnCreated(tab.id)) {
             CollapseExpand.setCollapsed(tab, {
               collapsed: false,
             });
@@ -984,7 +986,7 @@ BackgroundConnection.onMessage.addListener(async message => {
           collapsed: true,
           justNow:   true
         });
-        tab.$TST.shouldExpandLater = true;
+        CollapseExpand.setShouldExpandLater(tab.id, true);
       }
 
       tab.index = message.toIndex;
@@ -1013,7 +1015,7 @@ BackgroundConnection.onMessage.addListener(async message => {
       }
       tab.$TST.applyAttributesToElement();
 
-      if (shouldAnimate && tab.$TST.shouldExpandLater) {
+      if (shouldAnimate && CollapseExpand.getShouldExpandLater(tab.id)) {
         CollapseExpand.setCollapsed(tab, {
           collapsed: false
         });
@@ -1079,14 +1081,15 @@ BackgroundConnection.onMessage.addListener(async message => {
         else {
           if (lastMessage.reallyChanged) {
             tab.$TST.addState(Constants.kTAB_STATE_BURSTING);
-            if (tab.$TST.delayedBurstEnd)
-              clearTimeout(tab.$TST.delayedBurstEnd);
-            tab.$TST.delayedBurstEnd = setTimeout(() => {
-              delete tab.$TST.delayedBurstEnd;
+            const prevBurstEnd = mDelayedBurstEnd.get(tab.id);
+            if (prevBurstEnd)
+              clearTimeout(prevBurstEnd);
+            mDelayedBurstEnd.set(tab.id, setTimeout(() => {
+              mDelayedBurstEnd.delete(tab.id);
               tab.$TST.removeState(Constants.kTAB_STATE_BURSTING);
               if (!tab.active)
                 tab.$TST.addState(Constants.kTAB_STATE_NOT_ACTIVATED_SINCE_LOAD);
-            }, configs.burstDuration);
+            }, configs.burstDuration));
           }
           tab.$TST.removeState(Constants.kTAB_STATE_THROBBER_UNSYNCHRONIZED);
           TabsStore.removeUnsynchronizedTab(tab);
@@ -1107,6 +1110,12 @@ BackgroundConnection.onMessage.addListener(async message => {
         return;
       }
       tab.$TST.parent = null;
+      // Clean up sidebar-local state maps for the removed tab.
+      const burstEnd = mDelayedBurstEnd.get(message.tabId);
+      if (burstEnd)
+        clearTimeout(burstEnd);
+      mDelayedBurstEnd.delete(message.tabId);
+      CollapseExpand.clearCollapseExpandStateForTab(message.tabId);
       // remove from "highlighted tabs" cache immediately, to prevent misdetection for "multiple highlighted".
       TabsStore.removeHighlightedTab(tab);
       TabsStore.removeGroupTab(tab);

--- a/webextensions/sidebar/sidebar-items.js
+++ b/webextensions/sidebar/sidebar-items.js
@@ -870,7 +870,7 @@ BackgroundConnection.onMessage.addListener(async message => {
       }
       reserveToUpdateLoadingState();
       const needToWaitForTreeExpansion = (
-        CollapseExpand.getShouldExpandLater(tab.id) &&
+        CollapseExpand.getCollapsedOnCreated(tab.id) &&
         !tab.active &&
         !Tab.getActiveTab(tab.windowId).pinned
       );
@@ -986,7 +986,6 @@ BackgroundConnection.onMessage.addListener(async message => {
           collapsed: true,
           justNow:   true
         });
-        CollapseExpand.setShouldExpandLater(tab.id, true);
       }
 
       tab.index = message.toIndex;
@@ -1015,7 +1014,7 @@ BackgroundConnection.onMessage.addListener(async message => {
       }
       tab.$TST.applyAttributesToElement();
 
-      if (shouldAnimate && CollapseExpand.getShouldExpandLater(tab.id)) {
+      if (shouldAnimate) {
         CollapseExpand.setCollapsed(tab, {
           collapsed: false
         });


### PR DESCRIPTION
TreeItem/Tab インスタンスに対してコンストラクタ外で動的にプロパティが追加・delete されていたため、SpiderMonkey の Shape（Hidden Class）が不安定になり、インラインキャッシュ最適化が阻害される可能性がある。

変更内容：

1. コンストラクタでのプロパティ初期化（TreeItem.js）

- TreeItem コンストラクタに lastPreviousTabId, lastNextTabId, label, destroyed を初期化
- TabGroup コンストラクタに _collapsedMembersCounterItem を初期化
- possibleOpenerBookmarks をインスタンスプロパティからモジュールレベル Map + getter/setter に移行

2. サイドバー動的プロパティの Map 化（collapse-expand.js, sidebar-items.js, scroll.js）

以下の6つのサイドバー専用プロパティを tab.$TST への動的追加・削除からモジュールレベル Map に移行:

- shouldExpandLater
- collapsedOnCreated
- updatingCollapsedStateCanceller
- onEndCollapseExpandAnimation（+ .timeout）
- delayedBurstEnd

実際のところ、hidden class optimizationがかかっているかどうか、かかっていない場合にどれくらいのデメリットが発生しているかを直接的に調べるのは難しいようです。
100タブくらいで動作確認してみていますが、当然ですが、体感では動作速度は変わっていません。コンパイラに優しくなって多少安心感が増す、くらいにお考えください。
