### PR TITLE
add missing property initializations to stabilize object shape

### DIFF
--- a/webextensions/background/background-cache.js
+++ b/webextensions/background/background-cache.js
@@ -435,7 +435,7 @@ function cancelReservedCacheTree(windowId) {
   const win = TabsStore.windows.get(windowId);
   if (win?.waitingToCacheTree) {
     clearTimeout(win.waitingToCacheTree);
-    delete win.waitingToCacheTree;
+    win.waitingToCacheTree = null;
   }
 }
 

--- a/webextensions/common/Window.js
+++ b/webextensions/common/Window.js
@@ -79,6 +79,12 @@ export default class Window {
 
     // We should initialize private properties with blank value for better performance with a fixed shape.
     this.delayedDestroy = null;
+    this.lastActiveTab  = null;
+    this.restoredCount  = 0;
+    this.promisedAllTabsRestored              = null;
+    this.markWindowCacheDirtyFromTabTimeout   = null;
+    this.waitingToCacheTree                   = null;
+    this.waitingToSaveTreeStructure           = null;
   }
   initTabGroups(tabGroups) {
     log(`initializing tabGroups of window ${this.id}: `, tabGroups);


### PR DESCRIPTION
Window クラスのインスタンスに対して、実行時に動的に追加されていた6つのプロパティをコンストラクタで初期化するようにしました。

## 変更内容

- `Window` コンストラクタに以下のプロパティの初期化を追加:
    - `lastActiveTab` — 直前にアクティブだったタブのID
    - `restoredCount` — セッション復元中のタブカウンタ
    - `promisedAllTabsRestored` — 全タブ復元完了を表す Promise
    - `markWindowCacheDirtyFromTabTimeout` — キャッシュ無効化デバウンス用タイマーID
    - `waitingToCacheTree` — ツリーキャッシュ書き込みデバウンス用タイマーID
    - `waitingToSaveTreeStructure` — ツリー構造保存デバウンス用タイマーID
- `background-cache.js` の `cancelReservedCacheTree` 内で `delete win.waitingToCacheTree` を `win.waitingToCacheTree = null` に変更
    - `delete` 演算子はhidden class最適化をキャンセルするらしいので

waitingToCacheTreeなどはテンポラリな存在ですが、Windowインスタンスの数を考えると、いちいちMapを作る程のことでもないと考え、プロパティを定義するだけにとどめています。
