### PR TITLE
Fix tree structure loss on session restore for moved active tabs

### DIFF
--- a/webextensions/background/background.js
+++ b/webextensions/background/background.js
@@ -92,7 +92,15 @@ async function getAllWindows() {
 
 log('init: Start queuing of messages notified via WE APIs');
 ApiTabsListener.init();
-const promisedRestored = waitUntilCompletelyRestored(); // this must be called synchronosly
+const promisedRestored = UniqueId.ensurePersistentIdRestored(tab => { // this must be called synchronously
+  // Read caches from restored tabs while waiting, for better performance.
+  browser.sessions.getWindowValue(tab.windowId, Constants.kWINDOW_STATE_CACHED_TABS)
+    .catch(ApiTabs.createErrorSuppressor())
+    .then(cache => mPreloadedCaches.set(`window-${tab.windowId}`, cache));
+  browser.sessions.getTabValue(tab.id, Constants.kWINDOW_STATE_CACHED_TABS)
+    .catch(ApiTabs.createErrorSuppressor())
+    .then(cache => mPreloadedCaches.set(`tab-${tab.id}`, cache));
+});
 
 export async function init() {
   log('init: start');
@@ -118,11 +126,9 @@ export async function init() {
     });
 
   let promisedWindows;
-  let restoredPersistentIdMap;
   log('init: Getting existing windows and tabs');
-  await MetricsData.addAsync('init: waiting for waitUntilCompletelyRestored, ContextualIdentities.init and configs.$loaded', Promise.all([
-    promisedRestored.then(result => {
-      restoredPersistentIdMap = result;
+  await MetricsData.addAsync('init: waiting for ensurePersistentIdRestored, ContextualIdentities.init and configs.$loaded', Promise.all([
+    promisedRestored.then(() => {
       // don't wait at here for better performance
       promisedWindows = getAllWindows();
     }),
@@ -140,11 +146,8 @@ export async function init() {
   updatePanelUrl();
 
   const windows = await MetricsData.addAsync('init: getting all tabs across windows', promisedWindows); // wait at here for better performance
-  if (restoredPersistentIdMap && restoredPersistentIdMap.size > 0)
-    UniqueId.setRestoredPersistentIdMap(restoredPersistentIdMap);
-  const restoredFromCache = await MetricsData.addAsync('init: rebuildAll', rebuildAll(windows));
+  const restoredFromCache = await MetricsData.addAsync('init: rebuildAll', rebuildAll(windows));  // request() consumes internal Map
   mPreloadedCaches.clear();
-  UniqueId.clearRestoredPersistentIdMap();
   await MetricsData.addAsync('init: TreeStructure.loadTreeStructure', TreeStructure.loadTreeStructure(windows, restoredFromCache));
 
   log('init: Start to process messages including queued ones');
@@ -184,7 +187,7 @@ export async function init() {
   MetricsData.addAsync('init: initializing API for other addons', TSTAPI.initAsBackend());
 
   mInitialized = true;
-  UniqueId.readyToDetectDuplicatedTab();
+  UniqueId.completeRestoration();
   Tab.broadcastState.enabled = true;
   onReady.dispatch();
   BackgroundCache.activate();
@@ -232,63 +235,6 @@ async function updatePanelUrl(theme) {
   if (browser.sidebarAction)
     browser.sidebarAction.setPanel({ panel: url.href });
 */
-}
-
-async function waitUntilCompletelyRestored() {
-  log('waitUntilCompletelyRestored');
-  const initialTabs = await browser.tabs.query({});
-  const restoredPersistentIdMap = new Map();
-  await Promise.all([
-    MetricsData.addAsync('waitUntilCompletelyRestored: existing tabs ', Promise.all(
-      initialTabs.map(tab => waitUntilPersistentIdBecomeAvailable(tab.id)
-        .then(uniqueId => { if (uniqueId) restoredPersistentIdMap.set(tab.id, uniqueId); })
-        .catch(_error => {}))
-    )),
-    MetricsData.addAsync('waitUntilCompletelyRestored: opening tabs ', new Promise((resolve, _reject) => {
-      let promises = [];
-      let timeout;
-      let resolver;
-      let onNewTabRestored = async (tab, _info = {}) => {
-        clearTimeout(timeout);
-        log('new restored tab is detected.');
-        promises.push(
-          waitUntilPersistentIdBecomeAvailable(tab.id)
-            .then(uniqueId => { if (uniqueId) restoredPersistentIdMap.set(tab.id, uniqueId); })
-            .catch(_error => {})
-        );
-        // Read caches from restored tabs while waiting, for better performance.
-        browser.sessions.getWindowValue(tab.windowId, Constants.kWINDOW_STATE_CACHED_TABS)
-          .catch(ApiTabs.createErrorSuppressor())
-          .then(cache => mPreloadedCaches.set(`window-${tab.windowId}`, cache));
-        browser.sessions.getTabValue(tab.id, Constants.kWINDOW_STATE_CACHED_TABS)
-          .catch(ApiTabs.createErrorSuppressor())
-          .then(cache => mPreloadedCaches.set(`tab-${tab.id}`, cache));
-        //uniqueId = uniqueId?.id || '?'; // not used
-        timeout = setTimeout(resolver, 100);
-      };
-      browser.tabs.onCreated.addListener(onNewTabRestored);
-      resolver = (async () => {
-        log(`timeout: all ${promises.length} tabs are restored. `, promises);
-        browser.tabs.onCreated.removeListener(onNewTabRestored);
-        timeout = resolver = onNewTabRestored = undefined;
-        await Promise.all(promises);
-        promises = undefined;
-        resolve();
-      });
-      timeout = setTimeout(resolver, 500);
-    })),
-  ]);
-  return restoredPersistentIdMap;
-}
-async function waitUntilPersistentIdBecomeAvailable(tabId, retryCount = 0) {
-  if (retryCount > 10) {
-    console.log(`could not get persistent ID for ${tabId}`);
-    return null;
-  }
-  const uniqueId = await browser.sessions.getTabValue(tabId, Constants.kPERSISTENT_ID);
-  if (!uniqueId)
-    return wait(100).then(() => waitUntilPersistentIdBecomeAvailable(tabId, retryCount + 1));
-  return uniqueId;
 }
 
 function destroy() {

--- a/webextensions/background/background.js
+++ b/webextensions/background/background.js
@@ -118,9 +118,11 @@ export async function init() {
     });
 
   let promisedWindows;
+  let restoredPersistentIdMap;
   log('init: Getting existing windows and tabs');
   await MetricsData.addAsync('init: waiting for waitUntilCompletelyRestored, ContextualIdentities.init and configs.$loaded', Promise.all([
-    promisedRestored.then(() => {
+    promisedRestored.then(result => {
+      restoredPersistentIdMap = result;
       // don't wait at here for better performance
       promisedWindows = getAllWindows();
     }),
@@ -138,8 +140,11 @@ export async function init() {
   updatePanelUrl();
 
   const windows = await MetricsData.addAsync('init: getting all tabs across windows', promisedWindows); // wait at here for better performance
+  if (restoredPersistentIdMap && restoredPersistentIdMap.size > 0)
+    UniqueId.setRestoredPersistentIdMap(restoredPersistentIdMap);
   const restoredFromCache = await MetricsData.addAsync('init: rebuildAll', rebuildAll(windows));
   mPreloadedCaches.clear();
+  UniqueId.clearRestoredPersistentIdMap();
   await MetricsData.addAsync('init: TreeStructure.loadTreeStructure', TreeStructure.loadTreeStructure(windows, restoredFromCache));
 
   log('init: Start to process messages including queued ones');
@@ -232,9 +237,12 @@ async function updatePanelUrl(theme) {
 async function waitUntilCompletelyRestored() {
   log('waitUntilCompletelyRestored');
   const initialTabs = await browser.tabs.query({});
+  const restoredPersistentIdMap = new Map();
   await Promise.all([
     MetricsData.addAsync('waitUntilCompletelyRestored: existing tabs ', Promise.all(
-      initialTabs.map(tab => waitUntilPersistentIdBecomeAvailable(tab.id).catch(_error => {}))
+      initialTabs.map(tab => waitUntilPersistentIdBecomeAvailable(tab.id)
+        .then(uniqueId => { if (uniqueId) restoredPersistentIdMap.set(tab.id, uniqueId); })
+        .catch(_error => {}))
     )),
     MetricsData.addAsync('waitUntilCompletelyRestored: opening tabs ', new Promise((resolve, _reject) => {
       let promises = [];
@@ -243,7 +251,11 @@ async function waitUntilCompletelyRestored() {
       let onNewTabRestored = async (tab, _info = {}) => {
         clearTimeout(timeout);
         log('new restored tab is detected.');
-        promises.push(waitUntilPersistentIdBecomeAvailable(tab.id).catch(_error => {}));
+        promises.push(
+          waitUntilPersistentIdBecomeAvailable(tab.id)
+            .then(uniqueId => { if (uniqueId) restoredPersistentIdMap.set(tab.id, uniqueId); })
+            .catch(_error => {})
+        );
         // Read caches from restored tabs while waiting, for better performance.
         browser.sessions.getWindowValue(tab.windowId, Constants.kWINDOW_STATE_CACHED_TABS)
           .catch(ApiTabs.createErrorSuppressor())
@@ -266,16 +278,17 @@ async function waitUntilCompletelyRestored() {
       timeout = setTimeout(resolver, 500);
     })),
   ]);
+  return restoredPersistentIdMap;
 }
 async function waitUntilPersistentIdBecomeAvailable(tabId, retryCount = 0) {
   if (retryCount > 10) {
     console.log(`could not get persistent ID for ${tabId}`);
-    return false;
+    return null;
   }
   const uniqueId = await browser.sessions.getTabValue(tabId, Constants.kPERSISTENT_ID);
   if (!uniqueId)
     return wait(100).then(() => waitUntilPersistentIdBecomeAvailable(tabId, retryCount + 1));
-  return true;
+  return uniqueId;
 }
 
 function destroy() {

--- a/webextensions/background/tree-structure.js
+++ b/webextensions/background/tree-structure.js
@@ -231,7 +231,7 @@ async function attachTabFromRestoredInfo(tab, options = {}) {
   ]);
   ancestors = ancestors || [];
   children  = children  || [];
-  const hasSessionTreeInfo = ancestors.length > 0 || children.length > 0;
+  const maybeRecycledTab = tab.active && ancestors.length == 0 && children.length == 0;
   log(`persistent references for ${dumpTab(tab)} (${uniqueId.id}): `, {
     insertBefore, insertAfter,
     insertAfterLegacy,
@@ -381,7 +381,7 @@ async function attachTabFromRestoredInfo(tab, options = {}) {
   // recycled active tab which doesn't have session data yet at this
   // point. Setting the flag with empty data would block the later
   // restoration when the actual session data becomes available.
-  if (hasSessionTreeInfo)
+  if (!maybeRecycledTab)
     tab.$TST.temporaryMetadata.set('treeStructureAlreadyRestoredFromSessionData', true);
 
   if (options.bulk)

--- a/webextensions/background/tree-structure.js
+++ b/webextensions/background/tree-structure.js
@@ -231,6 +231,7 @@ async function attachTabFromRestoredInfo(tab, options = {}) {
   ]);
   ancestors = ancestors || [];
   children  = children  || [];
+  const hasSessionTreeInfo = ancestors.length > 0 || children.length > 0;
   log(`persistent references for ${dumpTab(tab)} (${uniqueId.id}): `, {
     insertBefore, insertAfter,
     insertAfterLegacy,
@@ -375,7 +376,13 @@ async function attachTabFromRestoredInfo(tab, options = {}) {
     }
   };
 
-  tab.$TST.temporaryMetadata.set('treeStructureAlreadyRestoredFromSessionData', true);
+  // We should not mark the tab as "already restored" when there is
+  // no tree info in the session data, because the tab may be a
+  // recycled active tab which doesn't have session data yet at this
+  // point. Setting the flag with empty data would block the later
+  // restoration when the actual session data becomes available.
+  if (hasSessionTreeInfo)
+    tab.$TST.temporaryMetadata.set('treeStructureAlreadyRestoredFromSessionData', true);
 
   if (options.bulk)
     await Promise.all(promises).then(updateCollapsedState);

--- a/webextensions/common/unique-id.js
+++ b/webextensions/common/unique-id.js
@@ -13,6 +13,7 @@ import {
 import * as ApiTabs from './api-tabs.js';
 import * as Constants from './constants.js';
 import * as TabsStore from './tabs-store.js';
+import MetricsData from './MetricsData.js';
 
 function log(...args) {
   internalLogger('common/unique-id', ...args);
@@ -85,17 +86,81 @@ let mReadyToDetectDuplicatedTab = false;
 
 const mRestoredPersistentIdMap = new Map();
 
-export function setRestoredPersistentIdMap(map) {
-  for (const [tabId, value] of map) {
-    mRestoredPersistentIdMap.set(tabId, value);
+/**
+ * Monitor session restoration and pre-fetch persistent IDs for all tabs.
+ * Must be called synchronously at startup (to register tabs.onCreated
+ * listener before any await).
+ * Background page only.
+ *
+ * @param {function(tab: browser.tabs.Tab): void} [onTabRestored]
+ *   Called for each tab detected via tabs.onCreated during restoration.
+ *   Called immediately (without waiting for persistent ID polling) so
+ *   callers can start parallel work like cache preloading.
+ * @returns {Promise<void>}
+ */
+export function ensurePersistentIdRestored(onTabRestored) {
+  log('ensurePersistentIdRestored');
+
+  const promisedInitialTabs = browser.tabs.query({});
+
+  return promisedInitialTabs.then(initialTabs => Promise.all([
+    MetricsData.addAsync('ensurePersistentIdRestored: existing tabs ', Promise.all(
+      initialTabs.map(tab => waitUntilPersistentIdBecomeAvailable(tab.id)
+        .then(uniqueId => { if (uniqueId) mRestoredPersistentIdMap.set(tab.id, uniqueId); })
+        .catch(_error => {}))
+    )),
+    MetricsData.addAsync('ensurePersistentIdRestored: opening tabs ', new Promise((resolve, _reject) => {
+      let promises = [];
+      let timeout;
+      let resolver;
+      let onNewTabRestored = async (tab, _info = {}) => {
+        clearTimeout(timeout);
+        log('new restored tab is detected.');
+        promises.push(
+          waitUntilPersistentIdBecomeAvailable(tab.id)
+            .then(uniqueId => { if (uniqueId) mRestoredPersistentIdMap.set(tab.id, uniqueId); })
+            .catch(_error => {})
+        );
+        if (onTabRestored) {
+          try { onTabRestored(tab); }
+          catch(e) { console.error('Error in onTabRestored callback:', e); }
+        }
+        timeout = setTimeout(resolver, 100);
+      };
+      browser.tabs.onCreated.addListener(onNewTabRestored);
+      resolver = (async () => {
+        log(`timeout: all ${promises.length} tabs are restored. `, promises);
+        browser.tabs.onCreated.removeListener(onNewTabRestored);
+        timeout = resolver = onNewTabRestored = undefined;
+        await Promise.all(promises);
+        promises = undefined;
+        resolve();
+      });
+      timeout = setTimeout(resolver, 500);
+    })),
+  ]));
+}
+
+async function waitUntilPersistentIdBecomeAvailable(tabId, retryCount = 0) {
+  if (retryCount > 10) {
+    console.log(`could not get persistent ID for ${tabId}`);
+    return null;
   }
+  const uniqueId = await browser.sessions.getTabValue(tabId, Constants.kPERSISTENT_ID);
+  if (!uniqueId)
+    return wait(100).then(() => waitUntilPersistentIdBecomeAvailable(tabId, retryCount + 1));
+  return uniqueId;
 }
 
-export function clearRestoredPersistentIdMap() {
+/**
+ * Complete the restoration phase.
+ * - Clears remaining entries in the internal persistent ID map (safety net)
+ * - Enables delayed duplicate tab detection
+ *
+ * Call after rebuildAll() and loadTreeStructure() have finished.
+ */
+export function completeRestoration() {
   mRestoredPersistentIdMap.clear();
-}
-
-export function readyToDetectDuplicatedTab() {
   mReadyToDetectDuplicatedTab = true;
 }
 
@@ -186,12 +251,6 @@ function generate() {
   const noun        = kID_NOUNS[Math.floor(Math.random() * kID_NOUNS.length)];
   const randomValue = Math.floor(Math.random() * 1000);
   return `${adjective}-${noun}-${Date.now()}-${randomValue}`;
-}
-
-export async function getFromTabs(tabs) {
-  return Promise.all(tabs.map(tab =>
-    browser.sessions.getTabValue(tab.id, Constants.kPERSISTENT_ID).catch(ApiTabs.createErrorHandler())
-  ));
 }
 
 export async function ensureWindowId(windowId) {

--- a/webextensions/common/unique-id.js
+++ b/webextensions/common/unique-id.js
@@ -83,6 +83,18 @@ Zapus
 
 let mReadyToDetectDuplicatedTab = false;
 
+const mRestoredPersistentIdMap = new Map();
+
+export function setRestoredPersistentIdMap(map) {
+  for (const [tabId, value] of map) {
+    mRestoredPersistentIdMap.set(tabId, value);
+  }
+}
+
+export function clearRestoredPersistentIdMap() {
+  mRestoredPersistentIdMap.clear();
+}
+
 export function readyToDetectDuplicatedTab() {
   mReadyToDetectDuplicatedTab = true;
 }
@@ -115,7 +127,14 @@ export async function request(tabOrId, options = {}) {
         configs.delayForDuplicatedTabDetection > 0)
       await wait(configs.delayForDuplicatedTabDetection);
 
-    let oldId = await browser.sessions.getTabValue(tab.id, Constants.kPERSISTENT_ID).catch(ApiTabs.createErrorHandler());
+    let oldId;
+    if (mRestoredPersistentIdMap.has(tab.id)) {
+      oldId = mRestoredPersistentIdMap.get(tab.id);
+      mRestoredPersistentIdMap.delete(tab.id);
+    }
+    else {
+      oldId = await browser.sessions.getTabValue(tab.id, Constants.kPERSISTENT_ID).catch(ApiTabs.createErrorHandler());
+    }
     if (oldId && !oldId.tabId) // ignore broken information!
       oldId = null;
 


### PR DESCRIPTION
## 概要

タブを移動した直後にFirefoxをkillして再起動すると、セッション復元時にツリー構造が壊れることがある問題を修正します。問題の発生率は100%ではないもののかなり高く、おそらく、Firefoxのセッション永続化が15秒置きであるのに対し、TSTのキャッシュ永続化が500msの待ち時間で行われるため、2つの永続化情報の矛盾が生じた際にツリー構造が壊れていたものと思われます。

本PRでは2つの根本原因に対処しています:
  1. `waitUntilCompletelyRestored()` が取得済みの persistent ID を破棄していたため、`UniqueId.request()` が再度非同期で取得し直す必要がありました。しかし `loadTreeStructure()` はその完了を待たないため、`Tab.getByUniqueId()` が親タブを見つけられずツリーが壊れていました
  2. `attachTabFromRestoredInfo()` がセッションデータ（ancestors/children）が空でも無条件に `treeStructureAlreadyRestoredFromSessionData` フラグを設定していたため、recycled active tab の `Tab.onRestored` 経由での再復元がブロックされていました

## 変更内容

### 起動時に取得した persistent ID を保持する (`background.js`, `unique-id.js`)

- `waitUntilCompletelyRestored()` が取得済みの ID を `Map<tabId, persistentId>` として返すように変更しました（これまでは一旦取得した情報を捨てて、後でもう一度rebuildAll内で非同期的に取得のコードが動いていた）
- `UniqueId.request()` はこの Map を先に確認し、エントリがあれば同期的に解決します（冗長な `browser.sessions.getTabValue()` 呼び出しを省略します）
- これにより `loadTreeStructure()` 実行前にすべての uniqueId が解決済みになります

### `treeStructureAlreadyRestoredFromSessionData` フラグにガードを追加する (`tree-structure.js`)

- `ancestors.length > 0 || children.length > 0` の場合のみフラグを設定するように変更しました
- recycled active tab は `attachTabFromRestoredInfo()` の初回実行時点ではまだセッションデータを持っていない場合があり、空データでフラグを設定すると、後から実際のセッションデータが到着した際の復元がブロックされていました
