### PR TITLE
Fix quadratic array copy cost in updateDescendants

### DIFF
--- a/webextensions/common/TreeItem.js
+++ b/webextensions/common/TreeItem.js
@@ -2112,13 +2112,17 @@ export class Tab extends TreeItem {
   }
 
   updateDescendants() {
-    let descendants = [];
+    const descendants = [];
     this.cachedDescendantIds = [];
     for (const child of this.children) {
       descendants.push(child);
-      descendants = descendants.concat(child.$TST.descendants);
+      for (const descendant of child.$TST.descendants) {
+        descendants.push(descendant);
+      }
       this.cachedDescendantIds.push(child.id);
-      this.cachedDescendantIds = this.cachedDescendantIds.concat(child.$TST.cachedDescendantIds);
+      for (const id of child.$TST.cachedDescendantIds) {
+        this.cachedDescendantIds.push(id);
+      }
     }
     return descendants;
   }


### PR DESCRIPTION
## 概要

`TreeItem.js` の `updateDescendants()` メソッドにおいて、ループ内で `concat()` を繰り返し呼び出していたため、子孫数 D に対して O(D²) の配列コピーコストが発生しています。本 PR では `concat()` を `for-of` ループ + `push()` に置き換えることで、時間計算量を O(D) に改善します。

正直、用途を考えると微々たる改善ですが、思いついてしまったので、送っておきます。

## 変更内容

- `descendants.concat(child.$TST.descendants)` → `for-of` ループで1要素ずつ `push`
- `cachedDescendantIds.concat(child.$TST.cachedDescendantIds)` → 同様に置き換え
- 再代入が不要になったため変数の定義を `let` → `const` に変更
