### PR TITLE
Fix swapped Manifest v2/v3 comments for setIcon calls

### DIFF
--- a/webextensions/background/background.js
+++ b/webextensions/background/background.js
@@ -892,8 +892,8 @@ async function updateIconForBrowserTheme(theme) {
   await Promise.all([
     ...ContextMenu.getItemIdsWithIcon().map(id => browser.menus.update(id, { icons: menuIcons })),
     browser.menus.refresh().catch(ApiTabs.createErrorSuppressor()),
-    browser.action?.setIcon({ path: toolbarIcons }), // Manifest v2
-    browser.browserAction?.setIcon({ path: toolbarIcons }), // Manifest v3
+    browser.action?.setIcon({ path: toolbarIcons }), // Manifest v3
+    browser.browserAction?.setIcon({ path: toolbarIcons }), // Manifest v2
     browser.sidebarAction?.setIcon({ path: sidebarIcons }),
   ]);
 }


### PR DESCRIPTION
調査してみた限りでは、browser.actionはManifest V3のAPIで、browser.browserActionはManifest V2のAPIのようです。コメントが逆になっているようです。
