### PR TITLE
Fix broken broadcastTooltipText: store messages in Map and iterate values

### DIFF
--- a/webextensions/common/TreeItem.js
+++ b/webextensions/common/TreeItem.js
@@ -3721,8 +3721,9 @@ export class Tab extends TreeItem {
         };
         message.tabIds.push(change.tabId);
         message.changes.push(change);
+        messageForWindows.set(change.windowId, message);
       }
-      for (const message of messageForWindows) {
+      for (const message of messageForWindows.values()) {
         SidebarConnection.sendMessage(message);
       }
       Tab.bufferedTooltipTextChanges.clear();


### PR DESCRIPTION
## 概要

TreeItem.jsの`broadcastTooltipText` メソッドにおいて、`messageForWindows` (Map) の扱いについて、開発者の意図が反映されていなさそうな部分がありました。

## 修正内容

1. **Mapへの格納漏れの修正**: ウィンドウごとにメッセージオブジェクトを組み立てた後、`messageForWindows.set(change.windowId, message)` でMapに格納する処理が欠落していました。この結果、正しくブロードキャストされない状態になっていました。
2. **Mapのイテレーション方法の修正**: `for (const message of messageForWindows)` では、Mapのエントリが `[key, value]` のペアとして返されるため、`message` にはメッセージオブジェクトではなく配列が入ってしまっていました。`messageForWindows.values()`を使用するように修正し、正しくメッセージオブジェクトを取得できるようにしました。
