### PR TITLE
fix: replace try/catch with .catch() for unawaited promise

### DIFF
--- a/webextensions/common/sidebar-connection.js
+++ b/webextensions/common/sidebar-connection.js
@@ -241,13 +241,9 @@ if (Constants.IS_BACKGROUND) {
             await wait(10);
             count = 0;
           }
-          try {
-            browser.tabs.sendMessage(tab.id, {
-              type: Constants.kCOMMAND_NOTIFY_SIDEBAR_CLOSED,
-            });
-          }
-          catch(_error) {
-          }
+          browser.tabs.sendMessage(tab.id, {
+            type: Constants.kCOMMAND_NOTIFY_SIDEBAR_CLOSED,
+          }).catch(_error => {});
         }
       });
     };

--- a/webextensions/common/sidebar-connection.js
+++ b/webextensions/common/sidebar-connection.js
@@ -241,9 +241,13 @@ if (Constants.IS_BACKGROUND) {
             await wait(10);
             count = 0;
           }
-          browser.tabs.sendMessage(tab.id, {
-            type: Constants.kCOMMAND_NOTIFY_SIDEBAR_CLOSED,
-          }).catch(_error => {});
+          try {
+            browser.tabs.sendMessage(tab.id, {
+              type: Constants.kCOMMAND_NOTIFY_SIDEBAR_CLOSED,
+            }).catch(_error => {});
+          }
+          catch(_error) {
+          }
         }
       });
     };


### PR DESCRIPTION
`sidebar-connection.js` において、`browser.tabs.sendMessage()` の呼び出しに対するエラーハンドリングを修正します。

## 変更内容

`browser.tabs.sendMessage()` は 非同期関数であり、同期的な `try/catch` ではエラーを補足できないため、`.catch()`を使ったエラー処理に置き換えました。
