### PR TITLE
fix(sidebar): fix mBufferedMessages leak in collapsed state handler

### DIFF
--- a/webextensions/sidebar/background-connection.js
+++ b/webextensions/sidebar/background-connection.js
@@ -151,6 +151,13 @@ export function fetchBufferedMessage(type, key) {
   return message;
 }
 
+export function clearBufferedMessagesForKey(key) {
+  for (const bufferKey of mBufferedMessages.keys()) {
+    if (bufferKey.endsWith(`:${key}`))
+      mBufferedMessages.delete(bufferKey);
+  }
+}
+
 
 //===================================================================
 // Logging

--- a/webextensions/sidebar/sidebar-items.js
+++ b/webextensions/sidebar/sidebar-items.js
@@ -1125,6 +1125,7 @@ BackgroundConnection.onMessage.addListener(async message => {
         clearTimeout(burstEnd);
       mDelayedBurstEnd.delete(message.tabId);
       CollapseExpand.clearState(message.tabId);
+      BackgroundConnection.clearBufferedMessagesForKey(`${BUFFER_KEY_PREFIX}${message.tabId}`);
       // remove from "highlighted tabs" cache immediately, to prevent misdetection for "multiple highlighted".
       TabsStore.removeHighlightedTab(tab);
       TabsStore.removeGroupTab(tab);
@@ -1325,9 +1326,12 @@ BackgroundConnection.onMessage.addListener(async message => {
     }; break;
 
     case Constants.kCOMMAND_NOTIFY_TAB_COLLAPSED_STATE_CHANGED: {
-      if (BackgroundConnection.handleBufferedMessage(message, `${BUFFER_KEY_PREFIX}${message.tabId}`) ||
-          message.collapsed)
+      if (BackgroundConnection.handleBufferedMessage(message, `${BUFFER_KEY_PREFIX}${message.tabId}`))
         return;
+      if (message.collapsed) {
+        BackgroundConnection.fetchBufferedMessage(message.type, `${BUFFER_KEY_PREFIX}${message.tabId}`);
+        return;
+      }
       await Tab.waitUntilTracked(message.tabId);
       const tab = Tab.get(message.tabId);
       const lastMessage = BackgroundConnection.fetchBufferedMessage(message.type, `${BUFFER_KEY_PREFIX}${message.tabId}`);


### PR DESCRIPTION
サイドバーの `mBufferedMessages` (Map) にエントリが蓄積し続けるリソースリークを修正します。

## 問題

`sidebar-items.js` の `kCOMMAND_NOTIFY_TAB_COLLAPSED_STATE_CHANGED` ハンドラに設計上の問題がありました。

```javascript
  // 修正前
  if (BackgroundConnection.handleBufferedMessage(message, ...) ||
      message.collapsed)
    return;
```

  handleBufferedMessage() はエントリを mBufferedMessages に追加した上で、既存エントリの有無を返します。この条件式では以下の流れでエントリが永久に残存します：

  1. collapsed=true のメッセージが初めて到着 → handleBufferedMessage() が false を返す（初回）が、message.collapsed が true のため早期リターン → エントリは追加されたまま fetchBufferedMessage() が呼ばれない
  2. 以降のメッセージ → handleBufferedMessage() が true を返す（既存エントリあり）→ 常に早期リターン
  3. エントリを消費するパスに到達しなくなる

  この結果、一度でも collapse されたタブごとに1エントリが蓄積し、タブが閉じられた後も残り続けます。

## 修正内容

  1. collapsed state ハンドラのバグ修正 (sidebar-items.js)

  複合 if 条件を分離し、collapsed=true で早期リターンする前に fetchBufferedMessage() でエントリを消費するようにしました。

  2. 防御的クリーンアップの追加 (background-connection.js, sidebar-items.js)

 clearBufferedMessagesForKey() を追加し、`kCOMMAND_NOTIFY_TAB_REMOVING` ハンドラからタブ削除時に関連するバッファエントリを一括削除するようにしました。通常のフローでは fetchBufferedMessage() によりエントリは回収されますが、想定外のエッジケースに対する安全策として機能します。（今後リソースリークがまた混入した際にタブを閉じると一旦問題が軽減されるので、問題追跡を却って難しくしているかもしれないので、これがあったほうがいいのかは、正直、悩ましいです。）
