### PR TITLE
fix(collapse-expand): clean up canceller entry on animation complete

### DIFF
--- a/webextensions/sidebar/collapse-expand.js
+++ b/webextensions/sidebar/collapse-expand.js
@@ -223,6 +223,7 @@ export async function setCollapsed(tab, info = {}) {
       if (callback)
         callback();
       mCollapseExpandAnimationCallback.delete(tab.id);
+      mUpdatingCollapsedStateCanceller.delete(tab.id);
     }, configs.collapseDuration));
   });
 }


### PR DESCRIPTION
## 概要

サイドバーのタブ折りたたみ・展開アニメーションが正常に完了した際に、mUpdatingCollapsedStateCanceller Map からエントリが削除されない問題を修正しました。

## 問題

setCollapsed() では、折りたたみ状態の更新をキャンセルするための canceller を mUpdatingCollapsedStateCanceller に登録しています。アニメーションが途中でキャンセルされた場合は onCanceled() 経由で正しく削除されますが、アニメーションが正常に完了した場合には mCollapseExpandAnimationCallback と mCollapseExpandAnimationTimeout は削除されるものの、mUpdatingCollapsedStateCanceller のエントリが残ったままになっていました。

これにより、既に完了済みのアニメーションに対応する不要な canceller が Map に蓄積し、おそらくリソースリークしていました。

## 修正内容

アニメーション完了時のタイムアウトコールバック内で、mCollapseExpandAnimationCallback.delete(tab.id) の直後に mUpdatingCollapsedStateCanceller.delete(tab.id) を追加しました。
