### PR TITLE
perf(tree): replace O(n) indexOf lookups with O(1) tab.index in kINSERT_NEAREST

### DIFF
--- a/webextensions/background/tree.js
+++ b/webextensions/background/tree.js
@@ -462,15 +462,17 @@ export function getReferenceTabsForNewChild(child, parent, { insertAt, ignoreTab
         log(`  insert ${child?.id} before firstChild ${insertBefore?.id} (insertAt=kINSERT_TOP)`);
         break;
       case Constants.kINSERT_NEAREST: {
-        const allTabs = Tab.getOtherTabs((child || parent).windowId, ignoreTabs);
-        const index = child ? allTabs.indexOf(child) : -1;
-        log('  insertAt=kINSERT_NEAREST ', { allTabs, index });
-        if (index < allTabs.indexOf(firstChild)) {
+        // Compare tab positions to find the nearest insertion point.
+        // If the child itself is being ignored, treat its position as
+        // unknown (-1) so it falls back to inserting at the top.
+        const index = child ? (ignoreTabs?.includes(child) ? -1 : child.index) : -1;
+        log('  insertAt=kINSERT_NEAREST ', { index });
+        if (index < firstChild.index) {
           insertBefore = firstChild;
           insertAfter  = parent;
           log(`  insert ${child?.id} between parent ${insertAfter?.id} and firstChild ${insertBefore?.id} (insertAt=kINSERT_NEAREST)`);
         }
-        else if (index > allTabs.indexOf(lastDescendant)) {
+        else if (index > lastDescendant.index) {
           insertAfter  = lastDescendant;
           log(`  insert ${child?.id} after lastDescendant ${insertAfter?.id} (insertAt=kINSERT_NEAREST)`);
         }
@@ -479,11 +481,11 @@ export function getReferenceTabsForNewChild(child, parent, { insertAt, ignoreTab
             children = parent.$TST.children;
           if (ignoreTabs)
             children = children.filter(tab => !ignoreTabs.includes(tab));
-          for (const child of children) {
-            if (index > allTabs.indexOf(child))
+          for (const sibling of children) {
+            if (index > sibling.index)
               continue;
-            insertBefore = child;
-            log(`  insert ${child?.id} before nearest following child ${insertBefore?.id} (insertAt=kINSERT_NEAREST)`);
+            insertBefore = sibling;
+            log(`  insert ${child?.id} before nearest following sibling ${insertBefore?.id} (insertAt=kINSERT_NEAREST)`);
             break;
           }
           if (!insertBefore) {


### PR DESCRIPTION
getReferenceTabsForNewChild() の `kINSERT_NEAREST` ケースで、タブの位置比較を allTabs.indexOf() から tab.index の直接比較に置き換えます。これにより、少しだけ高速になります。タブ数が多く、移動するタブ数も多いときに、もしかしたら少し体感できる程度の差になるかもしれません。

## 変更内容

- Tab.getOtherTabs() による(ほぼ)全タブ配列の構築を削除しました
- allTabs.indexOf(tab) （各O(n)）を tab.index のプロパティアクセス（O(1)）に置き換えました
  - ignoreTabs に含まれるタブを除外してもタブ間の相対順序は変わらないため、tab.index の直接比較で同じ結果が得られます
- ループ変数 child が外側のパラメータ child をシャドウイングしていたため、sibling にリネームしました
