### PR TITLE
fix(tree): skip ignoreTabs children in detachAllChildren processing loop

### DIFF
--- a/webextensions/background/tree.js
+++ b/webextensions/background/tree.js
@@ -751,6 +751,8 @@ export async function detachAllChildren(
   for (const child of children) {
     if (!child)
       continue;
+    if (ignoreTabsSet.has(child))
+      continue;
     const promises = [];
     if (behavior == Constants.kPARENT_TAB_OPERATION_BEHAVIOR_DETACH_ALL_CHILDREN) {
       promises.push(detachTab(child, { ...options, dontSyncParentToOpenerTab }));


### PR DESCRIPTION
## 概要

- `detachAllChildren` 関数では、`ignoreTabs` パラメータから `ignoreTabsSet` を構築し、新しい親タブの解決時に無視すべきタブをスキップしていますが、子タブを実際に処理するメインループでは `ignoreTabsSet` をチェックしていませんでした
- 例えば A → B → C → D というツリー構造がある場合に、A → B → C の部分だけをウィンドウをまたいで移動させようとすると、移動対象のタブが `ignoreTabs` に含まれているにもかかわらず detach/attach/move 操作が実行されてしまい、移動先でツリー構造が壊れる問題がありました

ループの先頭に `ignoreTabsSet.has(child)` のチェックを追加することで、`ignoreTabs` に含まれる子タブをスキップするようにしました
