### PR TITLE
refactor(TreeItem): use Promise.race for waitUntilTracked

### DIFF
--- a/webextensions/common/TreeItem.js
+++ b/webextensions/common/TreeItem.js
@@ -3872,8 +3872,12 @@ export class Tab extends TreeItem {
 }
 
 
-function waitForTabEvent(tabId, stack, signal) {
+function waitForTabTracking(tabId, stackTrace, signal) {
   return new Promise(resolve => {
+    const timeout = setTimeout(() => {
+      log(`Tab.waitUntilTracked for ${tabId} is timed out (in ${TabsStore.getCurrentWindowId() || 'bg'})\n${stackTrace}`);
+      resolve(null);
+    }, configs.maximumDelayUntilTabIsTracked); // Tabs.moveTabs() between windows may take much time
     function onTracked(tab) {
       if (tab?.id === tabId)
         resolve(tab);
@@ -3882,53 +3886,46 @@ function waitForTabEvent(tabId, stack, signal) {
       if (tab?.id !== tabId)
         return;
       const scope = TabsStore.getCurrentWindowId() || 'bg';
-      log(`Tab.waitUntilTracked: ${tabId} is destroyed while waiting (in ${scope})\n${stack}`);
+      log(`Tab.waitUntilTracked: ${tabId} is destroyed while waiting (in ${scope})\n${stackTrace}`);
       resolve(null);
     }
     function onRemoved(removedTabId, _removeInfo) {
       if (removedTabId !== tabId)
         return;
       const scope = TabsStore.getCurrentWindowId() || 'bg';
-      log(`Tab.waitUntilTracked: ${tabId} is removed while waiting (in ${scope})\n${stack}`);
+      log(`Tab.waitUntilTracked: ${tabId} is removed while waiting (in ${scope})\n${stackTrace}`);
       resolve(null);
-    }
-    function removeListeners() {
-      Tab.onTracked.removeListener(onTracked);
-      TreeItem.onElementBound.removeListener(onTracked);
-      Tab.onDestroyed.removeListener(onDestroyed);
-      browser.tabs.onRemoved.removeListener(onRemoved);
     }
     Tab.onTracked.addListener(onTracked);
     TreeItem.onElementBound.addListener(onTracked);
     Tab.onDestroyed.addListener(onDestroyed);
     browser.tabs.onRemoved.addListener(onRemoved);
-    signal.addEventListener('abort', removeListeners, { once: true });
+    signal.addEventListener('abort', () => {
+      clearTimeout(timeout);
+      Tab.onTracked.removeListener(onTracked);
+      TreeItem.onElementBound.removeListener(onTracked);
+      Tab.onDestroyed.removeListener(onDestroyed);
+      browser.tabs.onRemoved.removeListener(onRemoved);
+    }, { once: true });
   });
 }
 
-function waitForTimeout(tabId, stack, signal) {
-  return new Promise(resolve => {
-    const timeout = setTimeout(() => {
-      log(`Tab.waitUntilTracked for ${tabId} is timed out (in ${TabsStore.getCurrentWindowId() || 'bg'})\n${stack}`);
-      resolve(null);
-    }, configs.maximumDelayUntilTabIsTracked); // Tabs.moveTabs() between windows may take much time
-    signal.addEventListener('abort', clearTimeout.bind(null, timeout), { once: true });
-  });
-}
-
+// Returns null to make waitUntilTracked fail immediately if the Firefox
+// tab no longer exists (e.g. already closed before tracking completes).
+// If the tab still exists, returns a never-resolving promise to drop out
+// of the race and let waitForTabTracking handle it.
 async function checkTabExistence(tabId, signal) {
   const tab = await browser.tabs.get(tabId).catch(_error => null);
-  if (signal.aborted)
+  if (signal.aborted || tab)
     return new Promise(() => {});
-  if (!tab) {
-    log('waitUntilTracked was called for unexisting tab');
-    return null;
-  }
-  if (Tab.get(tabId))
-    return tab;
-  return new Promise(() => {});
+  log('waitUntilTracked was called for unexisting tab');
+  return null;
 }
 
+// Waits until the tab with the given ID is internally tracked by TST.
+// Returns null without the tab being tracked if:
+//   - the Firefox tab no longer exists (already closed or never created)
+//   - the waiting time exceeds configs.maximumDelayUntilTabIsTracked
 async function waitUntilTracked(tabId, options = {}) {
   if (!tabId)
     return null;
@@ -3943,8 +3940,7 @@ async function waitUntilTracked(tabId, options = {}) {
   const signal = controller.signal;
   try {
     return await Promise.race([
-      waitForTabEvent(tabId, stackTrace, signal),
-      waitForTimeout(tabId, stackTrace, signal),
+      waitForTabTracking(tabId, stackTrace, signal),
       checkTabExistence(tabId, signal),
     ]);
   }

--- a/webextensions/common/TreeItem.js
+++ b/webextensions/common/TreeItem.js
@@ -3872,132 +3872,85 @@ export class Tab extends TreeItem {
 }
 
 
-const mWaitingTasks = new Map();
-
-function destroyWaitingTabTask(task) {
-  const tasks = mWaitingTasks.get(task.tabId);
-  if (tasks)
-    tasks.delete(task);
-
-  if (task.timeout)
-    clearTimeout(task.timeout);
-
-  const resolve     = task.resolve;
-  const formattedStack = stack(task.stack);
-
-  task.tabId       = undefined;
-  task.resolve     = undefined;
-  task.timeout     = undefined;
-  task.stack       = undefined;
-
-  return { resolve, stack: formattedStack };
+function waitForTabEvent(tabId, stack, signal) {
+  return new Promise(resolve => {
+    function onTracked(tab) {
+      if (tab?.id === tabId)
+        resolve(tab);
+    }
+    function onDestroyed(tab) {
+      if (tab?.id !== tabId)
+        return;
+      const scope = TabsStore.getCurrentWindowId() || 'bg';
+      log(`Tab.waitUntilTracked: ${tabId} is destroyed while waiting (in ${scope})\n${stack}`);
+      resolve(null);
+    }
+    function onRemoved(removedTabId, _removeInfo) {
+      if (removedTabId !== tabId)
+        return;
+      const scope = TabsStore.getCurrentWindowId() || 'bg';
+      log(`Tab.waitUntilTracked: ${tabId} is removed while waiting (in ${scope})\n${stack}`);
+      resolve(null);
+    }
+    function removeListeners() {
+      Tab.onTracked.removeListener(onTracked);
+      TreeItem.onElementBound.removeListener(onTracked);
+      Tab.onDestroyed.removeListener(onDestroyed);
+      browser.tabs.onRemoved.removeListener(onRemoved);
+    }
+    Tab.onTracked.addListener(onTracked);
+    TreeItem.onElementBound.addListener(onTracked);
+    Tab.onDestroyed.addListener(onDestroyed);
+    browser.tabs.onRemoved.addListener(onRemoved);
+    signal.addEventListener('abort', removeListeners, { once: true });
+  });
 }
 
-function onWaitingTabTracked(tab) {
-  if (!tab)
-    return;
-
-  const tasks = mWaitingTasks.get(tab.id);
-  if (!tasks)
-    return;
-
-  mWaitingTasks.delete(tab.id);
-
-  for (const task of tasks) {
-    tasks.delete(task);
-    const { resolve } = destroyWaitingTabTask(task);
-    if (!resolve)
-      continue;
-    resolve(tab);
-  }
+function waitForTimeout(tabId, stack, signal) {
+  return new Promise(resolve => {
+    const timeout = setTimeout(() => {
+      log(`Tab.waitUntilTracked for ${tabId} is timed out (in ${TabsStore.getCurrentWindowId() || 'bg'})\n${stack}`);
+      resolve(null);
+    }, configs.maximumDelayUntilTabIsTracked); // Tabs.moveTabs() between windows may take much time
+    signal.addEventListener('abort', clearTimeout.bind(null, timeout), { once: true });
+  });
 }
-TreeItem.onElementBound.addListener(onWaitingTabTracked);
-Tab.onTracked.addListener(onWaitingTabTracked);
 
-function onWaitingTabDestroyed(tab) {
-  if (!tab)
-    return;
-
-  const tasks = mWaitingTasks.get(tab.id);
-  if (!tasks)
-    return;
-
-  mWaitingTasks.delete(tab.id);
-
-  const scope = TabsStore.getCurrentWindowId() || 'bg';
-  for (const task of tasks) {
-    tasks.delete(task);
-    const { resolve, stack } = destroyWaitingTabTask(task);
-    if (!resolve)
-      continue;
-
-    log(`Tab.waitUntilTracked: ${tab.id} is destroyed while waiting (in ${scope})\n${stack}`);
-    resolve(null);
-  }
-}
-Tab.onDestroyed.addListener(onWaitingTabDestroyed);
-
-function onWaitingTabRemoved(removedTabId, _removeInfo) {
-  const tasks = mWaitingTasks.get(removedTabId);
-  if (!tasks)
-    return;
-
-  mWaitingTasks.delete(removedTabId);
-
-  const scope = TabsStore.getCurrentWindowId() || 'bg';
-  for (const task of tasks) {
-    tasks.delete(task);
-    const { resolve, stack } = destroyWaitingTabTask(task);
-    if (!resolve)
-      continue;
-
-    log(`Tab.waitUntilTracked: ${removedTabId} is removed while waiting (in ${scope})\n${stack}`);
-    resolve(null);
-  }
-}
-browser.tabs.onRemoved.addListener(onWaitingTabRemoved);
-
-async function waitUntilTracked(tabId, options = {}) {
-  if (!tabId) {
+async function checkTabExistence(tabId, signal) {
+  const tab = await browser.tabs.get(tabId).catch(_error => null);
+  if (signal.aborted)
+    return new Promise(() => {});
+  if (!tab) {
+    log('waitUntilTracked was called for unexisting tab');
     return null;
   }
+  if (Tab.get(tabId))
+    return tab;
+  return new Promise(() => {});
+}
+
+async function waitUntilTracked(tabId, options = {}) {
+  if (!tabId)
+    return null;
   const stackTrace = stack();
   const tab = Tab.get(tabId);
   if (tab) {
-    onWaitingTabTracked(tab);
     if (options.element)
       return tab.$TST.promisedElement;
     return tab;
   }
-  const tasks = mWaitingTasks.get(tabId) || new Set();
-  const task = {
-    tabId,
-    stack: stackTrace,
-  };
-  tasks.add(task);
-  mWaitingTasks.set(tabId, tasks);
-  return new Promise((resolve, _reject) => {
-    task.resolve = resolve;
-    task.timeout = setTimeout(() => {
-      const { resolve } = destroyWaitingTabTask(task);
-      if (resolve) {
-        log(`Tab.waitUntilTracked for ${tabId} is timed out (in ${TabsStore.getCurrentWindowId() || 'bg'})\b${stackTrace}`);
-        resolve(null);
-      }
-    }, configs.maximumDelayUntilTabIsTracked); // Tabs.moveTabs() between windows may take much time
-    browser.tabs.get(tabId).catch(_error => null).then(tab => {
-      if (tab) {
-        if (Tab.get(tabId))
-          onWaitingTabTracked(tab);
-        return;
-      }
-      const { resolve } = destroyWaitingTabTask(task);
-      if (resolve) {
-        log('waitUntilTracked was called for nonexistent tab');
-        resolve(null);
-      }
-    });
-  }).then(destroyWaitingTabTask.bind(null, task));
+  const controller = new AbortController();
+  const signal = controller.signal;
+  try {
+    return await Promise.race([
+      waitForTabEvent(tabId, stackTrace, signal),
+      waitForTimeout(tabId, stackTrace, signal),
+      checkTabExistence(tabId, signal),
+    ]);
+  }
+  finally {
+    controller.abort();
+  }
 }
 
 Tab.broadcastTooltipText.enabled = false;


### PR DESCRIPTION
waitUntilTrackedは、渡されたtabがtrackされるまで（timeoutつきで）待ちたいだけの関数ですが、tabがなんらかの事情でなくなってしまった場合のことを考慮すると意外と実装が複雑になります。

従来の実装では、mWaitingTasks という共有 `Map<tabId, Set<task>>` でタスクを管理し、グローバルに登録された onWaitingTabTracked / onWaitingTabDestroyed / onWaitingTabRemoved リスナーがそれを参照・更新していました。

新しい実装では、Promise.raceとAbortControllerを導入することで、mWaitingTasksなしで同等の機能を実現します。

- waitUntilTracked: Promise.race で下記2つを競合させ、finally ブロックで AbortController.abort() により確実にクリーンアップします
- waitForTabTracking(tabId, stackTrace, signal): タブのトラッキング完了・破棄・削除・タイムアウトを一つの Promise にまとめ、AbortSignal でリスナーを一括解除します
- checkTabExistence(tabId, signal): Firefox 側でタブが既に存在しない場合に即座に null を返します（存在する場合は永久に resolve しない Promise を返して race から脱落します）

checkTabExistenceが「何らかの理由でタブがなくなった場合」に対応するPromiseで、他のすべてはwaitForTabTrackingが担当します。

動作は特に変わらず、メリットはコード量の削減と可読性の向上です。
