### PR TITLE
chore(build): add Knip for unused export detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PACKAGE_NAME = treestyletab
 
-.PHONY: all xpi install_hook update_extlib lint format fix_locale_errors
+.PHONY: all xpi install_hook update_extlib lint format knip fix_locale_errors
 
 all: xpi
 
@@ -18,6 +18,9 @@ lint:
 	cd webextensions && $(MAKE) $@
 
 format:
+	cd webextensions && $(MAKE) $@
+
+knip:
 	cd webextensions && $(MAKE) $@
 
 fix_locale_errors:

--- a/webextensions/Makefile
+++ b/webextensions/Makefile
@@ -4,7 +4,7 @@ NPM_BIN_DIR := $(NPM_MOD_DIR)/.bin
 EXTERNAL_LIB_DIR := $(CURDIR)/extlib
 TOOLS_DIR := $(CURDIR)/tools
 
-.PHONY: xpi install_dependency lint format init_extlib update_extlib install_extlib fix_locale_errors
+.PHONY: xpi install_dependency lint format knip init_extlib update_extlib install_extlib fix_locale_errors
 
 all: xpi
 
@@ -17,6 +17,10 @@ lint: install_dependency
 
 format: install_dependency
 	"$(NPM_BIN_DIR)/eslint" . --report-unused-disable-directives --fix
+
+# Find unused exports and dependencies across the project (https://knip.dev/)
+knip: install_dependency
+	"$(NPM_BIN_DIR)/knip"
 
 xpi: init_extlib install_extlib lint
 	rm -f ./*.xpi

--- a/webextensions/knip.json
+++ b/webextensions/knip.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://unpkg.com/knip@latest/schema.json",
+  "entry": [
+    "background/index.js",
+    "sidebar/index.js",
+    "common/handle-accel-key.js",
+    "options/init.js",
+    "tests/runner.js"
+  ],
+  "project": [
+    "background/**/*.js",
+    "sidebar/**/*.js",
+    "common/**/*.js",
+    "options/**/*.js",
+    "tests/**/*.js"
+  ]
+}

--- a/webextensions/tsconfig.json
+++ b/webextensions/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "/common/*": ["./common/*"],
+      "/background/*": ["./background/*"],
+      "/sidebar/*": ["./sidebar/*"],
+      "/options/*": ["./options/*"],
+      "/extlib/*": ["./extlib/*"],
+      "/resources/*": ["./resources/*"],
+      "/tests/*": ["./tests/*"]
+    }
+  }
+}


### PR DESCRIPTION
## 概要

プロジェクト内の未使用のexportや依存関係を検出するために、静的解析ツール [Knip](https://knip.dev/) の導入を提案します。

## 変更内容

- `webextensions/knip.json` を追加し、エントリポイント（background, sidebar, options, tests）とプロジェクトのglob パターンを設定しています
- `webextensions/tsconfig.json` を追加し、WebExtension の絶対パスによるimport（`/common/*` 等）を解決できるようにしています
- `make knip`（または `npm run knip`）で実行できるようにしています

## 使い方

リポジトリルートまたは `webextensions/` ディレクトリで以下のコマンドを実行します。

```bash
  make knip
  # または
  cd webextensions && npm run knip
```

## 補足

- TST API として外部アドオンに公開している定数など、browser.runtime.sendMessage() 経由でのみ使われるものは誤検出される可能性があります
