### PR TITLE
fix: remove redundant delete operator on Map.delete()

### DIFF
--- a/webextensions/background/tab-context-menu.js
+++ b/webextensions/background/tab-context-menu.js
@@ -1858,7 +1858,7 @@ export function onMessageExternal(message, sender) {
     case TSTAPI.kCONTEXT_MENU_REMOVE_ALL:
     case TSTAPI.kFAKE_CONTEXT_MENU_REMOVE_ALL:
     case TSTAPI.kUNREGISTER_SELF: {
-      delete mExtraItems.delete(sender.id);
+      mExtraItems.delete(sender.id);
       return reserveNotifyUpdated();
     }; break;
   }

--- a/webextensions/common/contextual-identities.js
+++ b/webextensions/common/contextual-identities.js
@@ -178,7 +178,7 @@ function onContextualIdentityRemoved(removedInfo) {
     return;
 
   const identity = removedInfo.contextualIdentity;
-  delete mContextualIdentities.delete(identity.cookieStoreId);
+  mContextualIdentities.delete(identity.cookieStoreId);
   onUpdated.dispatch();
 }
 


### PR DESCRIPTION
`Map.prototype.delete()` の戻り値（boolean）に対して `delete` 演算子を適用している箇所を修正しました。
