### PR TITLE
fix: correct typos in variable names and comments

### DIFF
--- a/webextensions/background/api-tabs-listener.js
+++ b/webextensions/background/api-tabs-listener.js
@@ -209,7 +209,7 @@ async function onActivated(activeInfo) {
       return;
     }
 
-    const onActivatedReuslt = Tab.onActivated.dispatch(newActiveTab, {
+    const onActivatedResult = Tab.onActivated.dispatch(newActiveTab, {
       ...activeInfo,
       oldActiveTabs,
       byActiveTabRemove,
@@ -219,8 +219,8 @@ async function onActivated(activeInfo) {
       silently
     });
     // don't do await if not needed, to process things synchronously
-    if (onActivatedReuslt instanceof Promise)
-      await onActivatedReuslt;
+    if (onActivatedResult instanceof Promise)
+      await onActivatedResult;
 
     SidebarConnection.sendMessage({
       type:     Constants.kCOMMAND_NOTIFY_TAB_ACTIVATED,
@@ -410,7 +410,7 @@ async function onNewTabTracked(tab, info) {
   tab.$possibleInitialUrl = tab.title;
 
   // We need to track new tab after getting old active tab. Otherwise, this
-  // operation updates the latest active tab in the window amd it becomes
+  // operation updates the latest active tab in the window and it becomes
   // impossible to know which tab was previously active.
   tab = Tab.track(tab);
   metric.add('tracked');
@@ -907,10 +907,10 @@ async function onRemoved(tabId, removeInfo) {
       toBeRemoved: true
     });
 
-    const onRemovedReuslt = Tab.onRemoved.dispatch(oldTab, removeInfo);
+    const onRemovedResult = Tab.onRemoved.dispatch(oldTab, removeInfo);
     // don't do await if not needed, to process things synchronously
-    if (onRemovedReuslt instanceof Promise)
-      await onRemovedReuslt;
+    if (onRemovedResult instanceof Promise)
+      await onRemovedResult;
 
     SidebarConnection.sendMessage({
       type:            Constants.kCOMMAND_NOTIFY_TAB_REMOVED,

--- a/webextensions/common/TreeItem.js
+++ b/webextensions/common/TreeItem.js
@@ -1588,13 +1588,13 @@ export class Tab extends TreeItem {
       const url = this.raw.$possibleInitialUrl;
       try {
         const possibleBookmarks = await Promise.all([
-          this._safeSearchBookmstksWithUrl(`http://${url}`),
-          this._safeSearchBookmstksWithUrl(`http://www.${url}`),
-          this._safeSearchBookmstksWithUrl(`https://${url}`),
-          this._safeSearchBookmstksWithUrl(`https://www.${url}`),
-          this._safeSearchBookmstksWithUrl(`ftp://${url}`),
-          this._safeSearchBookmstksWithUrl(`moz-extension://${url}`),
-          this._safeSearchBookmstksWithUrl(url), // about:* and so on
+          this._safeSearchBookmarksWithUrl(`http://${url}`),
+          this._safeSearchBookmarksWithUrl(`http://www.${url}`),
+          this._safeSearchBookmarksWithUrl(`https://${url}`),
+          this._safeSearchBookmarksWithUrl(`https://www.${url}`),
+          this._safeSearchBookmarksWithUrl(`ftp://${url}`),
+          this._safeSearchBookmarksWithUrl(`moz-extension://${url}`),
+          this._safeSearchBookmarksWithUrl(url), // about:* and so on
         ]);
         log(`promisedPossibleOpenerBookmarks for tab ${this.id} (${url}): `, possibleBookmarks);
         const result = possibleBookmarks.flat();
@@ -1610,12 +1610,12 @@ export class Tab extends TreeItem {
       }
     });
   }
-  async _safeSearchBookmstksWithUrl(url) {
+  async _safeSearchBookmarksWithUrl(url) {
     try {
       return await browser.bookmarks.search({ url });
     }
     catch(error) {
-      log(`_searchBookmstksWithUrl failed: tab ${this.id} (${url}): `, error);
+      log(`_searchBookmarksWithUrl failed: tab ${this.id} (${url}): `, error);
       try {
         // bookmarks.search() does not accept "moz-extension:" URL
         // via a query with "url" on Firefox 105 and later - it raises an error as

--- a/webextensions/common/tst-api.js
+++ b/webextensions/common/tst-api.js
@@ -409,8 +409,8 @@ async function notifyPermissionRequest(addon, requestedPermissions) {
   mPermissionNotificationForAddon.set(addon.id, id);
 }
 
-function setPermissions(addon, permisssions) {
-  addon.grantedPermissions = permisssions;
+function setPermissions(addon, permissions) {
+  addon.grantedPermissions = permissions;
   const cachedPermissions = JSON.parse(JSON.stringify(configs.grantedExternalAddonPermissions));
   cachedPermissions[addon.id] = Array.from(addon.grantedPermissions);
   configs.grantedExternalAddonPermissions = cachedPermissions;

--- a/webextensions/sidebar/sidebar-items.js
+++ b/webextensions/sidebar/sidebar-items.js
@@ -500,14 +500,14 @@ configs.$addObserver(async changedKey => {
 // Mechanism to override "index" of newly opened tabs by TST's detection logic
 
 const mMovedNewTabResolvers = new Map();
-const mPromsiedMovedNewTabs = new Map();
+const mPromisedMovedNewTabs = new Map();
 const mAlreadyMovedNewTabs = new Set();
 
 export async function waitUntilNewTabIsMoved(tabId) {
   if (mAlreadyMovedNewTabs.has(tabId))
     return true;
-  if (mPromsiedMovedNewTabs.has(tabId))
-    return mPromsiedMovedNewTabs.get(tabId);
+  if (mPromisedMovedNewTabs.has(tabId))
+    return mPromisedMovedNewTabs.get(tabId);
   const timer = setTimeout(() => {
     if (mMovedNewTabResolvers.has(tabId))
       mMovedNewTabResolvers.get(tabId)();
@@ -516,11 +516,11 @@ export async function waitUntilNewTabIsMoved(tabId) {
     mMovedNewTabResolvers.set(tabId, resolve);
   }).then(newIndex => {
     mMovedNewTabResolvers.delete(tabId);
-    mPromsiedMovedNewTabs.delete(tabId);
+    mPromisedMovedNewTabs.delete(tabId);
     clearTimeout(timer);
     return newIndex;
   });
-  mPromsiedMovedNewTabs.set(tabId, promise);
+  mPromisedMovedNewTabs.set(tabId, promise);
   return promise;
 }
 


### PR DESCRIPTION
コード内の変数名・関数名・コメントに含まれるタイポを修正しました。
