### PR TITLE
fix(eslint): introduce no-restricted-globals to catch undeclared variable bugs

### DIFF
--- a/webextensions/background/background-cache.js
+++ b/webextensions/background/background-cache.js
@@ -623,7 +623,7 @@ function onConfigChange(key) {
           }
           else {
             TabsInternalOperation.clearCache(owner);
-            location.reload();
+            window.location.reload();
           }
         }
       }).catch(ApiTabs.createErrorSuppressor());

--- a/webextensions/background/context-menu.js
+++ b/webextensions/background/context-menu.js
@@ -210,7 +210,7 @@ const mTabSeparator = {
   type:                'separator',
   contexts:            ['tab'],
   viewTypes:           ['sidebar'],
-  documentUrlPatterns: [`moz-extension://${location.host}/*`],
+  documentUrlPatterns: [`moz-extension://${window.location.host}/*`],
   visible:             false,
   lastVisible:         false
 };
@@ -291,7 +291,7 @@ const mBookmarkSeparator = {
   type:                'separator',
   contexts:            ['bookmark'],
   viewTypes:           ['sidebar'],
-  documentUrlPatterns: [`moz-extension://${location.host}/*`],
+  documentUrlPatterns: [`moz-extension://${window.location.host}/*`],
   visible:             false,
   lastVisible:         false
 };

--- a/webextensions/common/bookmark.js
+++ b/webextensions/common/bookmark.js
@@ -316,7 +316,7 @@ export async function bookmarkTab(tab, { parentId, showDialog } = {}) {
     notify({
       title:   browser.i18n.getMessage('bookmark_notification_notPermitted_title'),
       message: browser.i18n.getMessage(`bookmark_notification_notPermitted_message${isLinux() ? '_linux' : ''}`),
-      url:     `moz-extension://${location.host}/options/options.html#bookmarksPermissionSection`
+      url:     `moz-extension://${window.location.host}/options/options.html#bookmarksPermissionSection`
     });
     return null;
   }
@@ -331,7 +331,7 @@ export async function bookmarkTab(tab, { parentId, showDialog } = {}) {
     parentId = parent?.id;
   if (showDialog) {
     const windowId = tab.windowId;
-    const inline = location.pathname.startsWith('/sidebar/');
+    const inline = window.location.pathname.startsWith('/sidebar/');
     const inlineClass = inline ? 'inline' : 'dialog';
     const BASE_ID = `dialog-${Date.now()}-${parseInt(Math.random() * 65000)}:`;
     const dialogParams = {
@@ -457,7 +457,7 @@ export async function bookmarkTabs(tabs, { parentId, index, showDialog, title } 
     notify({
       title:   browser.i18n.getMessage('bookmark_notification_notPermitted_title'),
       message: browser.i18n.getMessage('bookmark_notification_notPermitted_message'),
-      url:     `moz-extension://${location.host}/options/options.html#bookmarksPermissionSection`
+      url:     `moz-extension://${window.location.host}/options/options.html#bookmarksPermissionSection`
     });
     return null;
   }
@@ -537,7 +537,7 @@ export async function bookmarkTabs(tabs, { parentId, index, showDialog, title } 
 
   if (showDialog) {
     const windowId = tabs[0].windowId;
-    const inline = location.pathname.startsWith('/sidebar/');
+    const inline = window.location.pathname.startsWith('/sidebar/');
     const inlineClass = inline ? 'inline' : 'dialog';
     const BASE_ID = `dialog-${Date.now()}-${parseInt(Math.random() * 65000)}:`;
     const dialogParams = {

--- a/webextensions/common/constants.js
+++ b/webextensions/common/constants.js
@@ -440,5 +440,5 @@ export const kSYNC_STORAGE_SAFE_QUOTA = 6 * 1024;
 
 export const kSYNC_DATA_TYPE_TABS = 'tabs';
 
-export const IS_BACKGROUND = location.href.startsWith(browser.runtime.getURL('background/background.html'));
-export const IS_SIDEBAR    = location.href.startsWith(browser.runtime.getURL('sidebar/sidebar.html'));
+export const IS_BACKGROUND = window.location.href.startsWith(browser.runtime.getURL('background/background.html'));
+export const IS_SIDEBAR    = window.location.href.startsWith(browser.runtime.getURL('sidebar/sidebar.html'));

--- a/webextensions/common/permissions.js
+++ b/webextensions/common/permissions.js
@@ -53,7 +53,7 @@ for (const permissions of [ALL_URLS, BOOKMARKS, CLIPBOARD_READ, TAB_HIDE]) {
 }
 
 
-const CUSTOM_PANEL_AVAILABLE_URLS_MATCHER = new RegExp(`^((https?|data):|moz-extension://${location.host}/)`);
+const CUSTOM_PANEL_AVAILABLE_URLS_MATCHER = new RegExp(`^((https?|data):|moz-extension://${window.location.host}/)`);
 
 export async function canInjectScriptToTab(tab) {
   if (!tab ||

--- a/webextensions/common/tree-behavior.js
+++ b/webextensions/common/tree-behavior.js
@@ -367,7 +367,7 @@ export function getTreeStructureFromTabs(tabs, { full, keepParentOfRootTabs } = 
   return cleanUpTreeStructureArray(
     tabs.map((tab, index) => {
       const parentId = tab.$TST.parentId;
-      const indexInGivenTabs = parent ? tabIds.indexOf(parentId) : STRUCTURE_NO_PARENT ;
+      const indexInGivenTabs = parentId ? tabIds.indexOf(parentId) : STRUCTURE_NO_PARENT ;
       return indexInGivenTabs >= index ? STRUCTURE_NO_PARENT : indexInGivenTabs ;
     }),
     STRUCTURE_NO_PARENT

--- a/webextensions/common/tst-api.js
+++ b/webextensions/common/tst-api.js
@@ -611,7 +611,7 @@ if (Constants.IS_BACKGROUND) {
         continue;
       mPermissionNotificationForAddon.delete(addonId);
       browser.tabs.create({
-        url: `moz-extension://${location.host}/options/options.html#externalAddonPermissionsGroup`
+        url: `moz-extension://${window.location.host}/options/options.html#externalAddonPermissionsGroup`
       });
       break;
     }

--- a/webextensions/eslint.config.mjs
+++ b/webextensions/eslint.config.mjs
@@ -1,6 +1,7 @@
 import _import from 'eslint-plugin-import';
 import { fixupPluginRules } from '@eslint/compat';
 import babelParser from '@babel/eslint-parser';
+import confusingBrowserGlobals from 'confusing-browser-globals';
 import globals from 'globals';
 import indentInParens from 'eslint-plugin-indent-in-parens';
 import noDeadEventListener from 'webextensions-lib-event-listener-manager';
@@ -23,6 +24,8 @@ const languageOptions = {
 };
 
 const rules = {
+  'no-restricted-globals': ['error', ...confusingBrowserGlobals],
+
   'no-const-assign': 'error',
 
   'prefer-const': ['warn', {

--- a/webextensions/options/init.js
+++ b/webextensions/options/init.js
@@ -53,9 +53,9 @@ const options = new Options(configs, {
 });
 
 document.title = browser.i18n.getMessage('config_title');
-if ((location.hash &&
-     /^#!?$/.test(location.hash)) ||
-    /independent=true/.test(location.search))
+if ((window.location.hash &&
+     /^#!?$/.test(window.location.hash)) ||
+    /independent=true/.test(window.location.search))
   document.body.classList.add('independent');
 
 document.documentElement.classList.toggle('rtl', isRTL());
@@ -615,9 +615,9 @@ window.addEventListener('DOMContentLoaded', async () => {
   }
 
   mShowExpertOptionsTemporarily = !!(
-    location.hash &&
-    !/^#!?$/.test(location.hash) &&
-    document.querySelector(`.expert #${location.hash.replace(/^#!?/, '')}, .expert#${location.hash.replace(/^#!?/, '')}`)
+    window.location.hash &&
+    !/^#!?$/.test(window.location.hash) &&
+    document.querySelector(`.expert #${window.location.hash.replace(/^#!?/, '')}, .expert#${window.location.hash.replace(/^#!?/, '')}`)
   );
 
   try {
@@ -689,8 +689,8 @@ function initDuplicatedTabDetection() {
 }
 
 function initLinks() {
-  document.getElementById('link-optionsPage-top').setAttribute('href', `${location.href.split('#')[0]}#!`);
-  document.getElementById('link-optionsPage').setAttribute('href', `${location.href.split('#')[0]}#!`);
+  document.getElementById('link-optionsPage-top').setAttribute('href', `${window.location.href.split('#')[0]}#!`);
+  document.getElementById('link-optionsPage').setAttribute('href', `${window.location.href.split('#')[0]}#!`);
   document.getElementById('link-startupPage').setAttribute('href', Constants.kSHORTHAND_URIS.startup);
   document.getElementById('link-groupPage').setAttribute('href', Constants.kSHORTHAND_URIS.group);
   document.getElementById('link-tabbarPage').setAttribute('href', Constants.kSHORTHAND_URIS.tabbar);

--- a/webextensions/package-lock.json
+++ b/webextensions/package-lock.json
@@ -18,6 +18,7 @@
         "@eslint/compat": "^1.2.4",
         "@prantlf/jsonlint": "^16.1.0",
         "babel-plugin-module-resolver": "^5.0.0",
+        "confusing-browser-globals": "^1.0.11",
         "eslint": "^9.17.0",
         "eslint-import-resolver-babel-module": "^5.3.2",
         "eslint-plugin-import": "^2.20.1",
@@ -2881,6 +2882,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confusing-browser-globals": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
+      "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "dev": true,
       "license": "MIT"
     },

--- a/webextensions/package.json
+++ b/webextensions/package.json
@@ -14,6 +14,7 @@
     "@eslint/compat": "^1.2.4",
     "@prantlf/jsonlint": "^16.1.0",
     "babel-plugin-module-resolver": "^5.0.0",
+    "confusing-browser-globals": "^1.0.11",
     "eslint": "^9.17.0",
     "eslint-import-resolver-babel-module": "^5.3.2",
     "eslint-plugin-import": "^2.20.1",

--- a/webextensions/resources/module/protocol-handler.js
+++ b/webextensions/resources/module/protocol-handler.js
@@ -7,7 +7,7 @@
 
 import * as Constants from '/common/constants.js';
 
-const uri = decodeURIComponent(location.search.replace(/^\?/, ''));
+const uri = decodeURIComponent(window.location.search.replace(/^\?/, ''));
 const matched = uri?.match(Constants.kSHORTHAND_CUSTOM_URI);
 if (matched) {
   const name = matched[1];
@@ -16,20 +16,20 @@ if (matched) {
   const delimiter = params.toString() ? '?' : '';
   switch (name.toLowerCase()) {
     case 'group':
-      location.href = `${Constants.kSHORTHAND_URIS.group}${delimiter}${params.toString()}${hash}`;
+      window.location.href = `${Constants.kSHORTHAND_URIS.group}${delimiter}${params.toString()}${hash}`;
       break;
 
     case 'startup':
-      location.href = `${Constants.kSHORTHAND_URIS.startup}${hash}`;
+      window.location.href = `${Constants.kSHORTHAND_URIS.startup}${hash}`;
       break;
 
     case 'test-runner':
     case 'testrunner':
-      location.href = `${Constants.kSHORTHAND_URIS.testRunner}${delimiter}${params.toString()}${hash}`;
+      window.location.href = `${Constants.kSHORTHAND_URIS.testRunner}${delimiter}${params.toString()}${hash}`;
       break;
 
     case 'options':
-      location.href = `${Constants.kSHORTHAND_URIS.options}${delimiter}${params.toString()}${hash}`;
+      window.location.href = `${Constants.kSHORTHAND_URIS.options}${delimiter}${params.toString()}${hash}`;
       break;
 
     case 'tabbar':
@@ -40,16 +40,16 @@ if (matched) {
           keys: ['style']
         }).then(configs => {
           params.set('style', configs.style);
-          location.href = `${Constants.kSHORTHAND_URIS.tabbar}?${params.toString()}${hash}`;
+          window.location.href = `${Constants.kSHORTHAND_URIS.tabbar}?${params.toString()}${hash}`;
         });
       }
       else {
-        location.href = `${Constants.kSHORTHAND_URIS.tabbar}${delimiter}${params.toString()}${hash}`;
+        window.location.href = `${Constants.kSHORTHAND_URIS.tabbar}${delimiter}${params.toString()}${hash}`;
       }
       break;
 
     case 'forbidden':
-      location.href = `about:blank?${new URL(location.href).searchParams.get('url') || ''}`;
+      window.location.href = `about:blank?${new URL(window.location.href).searchParams.get('url') || ''}`;
       break;
   }
 }

--- a/webextensions/sidebar/background-connection.js
+++ b/webextensions/sidebar/background-connection.js
@@ -28,14 +28,14 @@ let mHeartbeatTimer = null;
 export function connect() {
   if (mConnectionPort)
     return;
-  const type = /windowId=([1-9][0-9]*)/i.test(location.search) ? 'unknown' : 'sidebar';
+  const type = /windowId=([1-9][0-9]*)/i.test(window.location.search) ? 'unknown' : 'sidebar';
   mConnectionPort = browser.runtime.connect({
     name: `${Constants.kCOMMAND_REQUEST_CONNECT_PREFIX}${TabsStore.getCurrentWindowId()}:${type}`
   });
   mConnectionPort.onMessage.addListener(onConnectionMessage);
   mConnectionPort.onDisconnect.addListener(() => {
     log(`Disconnected accidentally: try to reconnect.`);
-    location.reload();
+    window.location.reload();
   });
   if (mHeartbeatTimer)
     clearInterval(mHeartbeatTimer);

--- a/webextensions/sidebar/sidebar.js
+++ b/webextensions/sidebar/sidebar.js
@@ -95,7 +95,7 @@ document.documentElement.classList.toggle('platform-mac', isMacOS());
 document.documentElement.classList.toggle('rtl', isRTL());
 
 {
-  const url = new URL(location.href);
+  const url = new URL(window.location.href);
 
   mTargetWindow = parseInt(url.searchParams.get('windowId') || 0);
   if (isNaN(mTargetWindow) || mTargetWindow < 1)
@@ -992,7 +992,7 @@ async function onConfigChange(changedKey) {
 
     case 'style':
       log('reload for changed style');
-      location.reload();
+      window.location.reload();
       break;
 
     case 'colorScheme':
@@ -1057,7 +1057,7 @@ async function isSidebarRightSide() {
     const notificationParams = {
       title:   browser.i18n.getMessage('sidebarPositionOptionNotification_title'),
       message: browser.i18n.getMessage('sidebarPositionOptionNotification_message'),
-      url:     `moz-extension://${location.host}/options/options.html#section-appearance`,
+      url:     `moz-extension://${window.location.host}/options/options.html#section-appearance`,
       timeout: configs.sidebarPositionOptionNotificationTimeout,
     };
     configs.sidebarPositionRighsideNotificationShown = true;
@@ -1099,7 +1099,7 @@ function onMessage(message, _sender, _respond) {
 
     case Constants.kCOMMAND_RELOAD:
       log('reload triggered by the reload command');
-      location.reload();
+      window.location.reload();
       return;
 
     case Constants.kCOMMAND_SHOW_DIALOG:

--- a/webextensions/sidebar/tab-context-menu.js
+++ b/webextensions/sidebar/tab-context-menu.js
@@ -132,7 +132,7 @@ async function rebuild() {
           (!item.viewTypes ||
            !item.viewTypes.includes('sidebar') ||
            item.documentUrlPatterns.some(pattern => !/^moz-extension:/.test(pattern)) ||
-           !matchesToPattern(location.href, item.documentUrlPatterns)) &&
+           !matchesToPattern(window.location.href, item.documentUrlPatterns)) &&
           mContextTab &&
           !matchesToPattern(mContextTab.url, item.documentUrlPatterns))
         continue;
@@ -679,7 +679,7 @@ async function onContextMenu(event) {
           notify({
             title:   browser.i18n.getMessage('bookmarkContext_notification_notPermitted_title'),
             message: browser.i18n.getMessage(`bookmarkContext_notification_notPermitted_message${isLinux() ? '_linux' : ''}`),
-            url:     `moz-extension://${location.host}/options/options.html#bookmarksPermissionGranted_context`
+            url:     `moz-extension://${window.location.host}/options/options.html#bookmarksPermissionGranted_context`
           });
         else
           console.error(error);

--- a/webextensions/tests/runner.js
+++ b/webextensions/tests/runner.js
@@ -43,7 +43,7 @@ async function run() {
 
   // you can run specific tests with URL parameter like:
   // ...runner.html?testMoveAttachedTabBeforeHiddenTab,/^testMove.+/,...
-  for (const part of (location.search || '').replace(/^\?/, '').split(/,/)) {
+  for (const part of (window.location.search || '').replace(/^\?/, '').split(/,/)) {
     const trimmedPart = part.trim();
     if (!trimmedPart.trim())
       continue;
@@ -86,7 +86,7 @@ async function restoreConfigs(values) {
 
 async function runAll() {
   const testCases = [];
-  if (/benchmark=true/.test(location.search)) {
+  if (/benchmark=true/.test(window.location.search)) {
     testCases.push(TestDOMUpdater);
   }
   else {

--- a/webextensions/tests/test-new-tab.js
+++ b/webextensions/tests/test-new-tab.js
@@ -161,13 +161,13 @@ export async function testReopenedWithPositionByAnotherAddonImmediatelyWhileCrea
           // This must be an already loaded URL, othwrwise tabs.executeScript()
           // is called for about:blank page and this test fails with "missing
           // host permission" error.
-          url:   `${location.origin}/resources/ui-color.css`,
+          url:   `${window.location.origin}/resources/ui-color.css`,
           index: 2
         });
         if (browser.scripting)
           await browser.scripting.executeScript({ // Manifest V3
             target: { tabId: reopenedTab.id },
-            func:   function() { return location.href; },
+            func:   function() { return window.location.href; },
           });
         else
           await browser.tabs.executeScript(reopenedTab.id, {


### PR DESCRIPTION
ブラウザグローバル変数と紛らわしい名前の未定義変数が、`no-undef` をすり抜けてしまう問題に対処します。

ESLintの `no-restricted-globals` ルールと `confusing-browser-globals` パッケージを導入し、`event`, `name`, `status`, `parent`, `location` などの紛らわしいブラウザグローバルをlocal変数的に使用した場合にエラーを出すようにしました。

## 実際に見つかったバグ

`common/tree-behavior.js` の `getTreeStructureFromTabs()` において、宣言されていない変数 `parent` が使われていました。
これはブラウザ環境では `window.parent`（常にtruthy）に解決されるため、エラーにならず動作し続けていました。
これはおそらく、直前の行で宣言されている `parentId` を参照すべきです。
