### PR TITLE
fix(common): fix resource leaks in tab cleanup and tracking

### DIFF
--- a/webextensions/common/TreeItem.js
+++ b/webextensions/common/TreeItem.js
@@ -1309,6 +1309,7 @@ export class Tab extends TreeItem {
       TabsStore.tabsByUniqueId.delete(this.uniqueId.id);
 
     TabsStore.removeTabFromIndexes(this.raw);
+    TabsStore.removeVirtualScrollRenderableTab(this.raw);
 
     super.destroy();
   }
@@ -3129,16 +3130,11 @@ export class Tab extends TreeItem {
 
     const promisedTracked = waitUntilTracked(tabId, options);
     mPromisedTrackedTabs.set(key, promisedTracked);
-    return promisedTracked.then(tab => {
-      // Don't clear the last promise, because it is required to process following "waitUntilTracked" callbacks sequentially.
-      //if (mPromisedTrackedTabs.get(key) == promisedTracked)
-      //  mPromisedTrackedTabs.delete(key);
-      return tab;
-    }).catch(_error => {
-      //if (mPromisedTrackedTabs.get(key) == promisedTracked)
-      //  mPromisedTrackedTabs.delete(key);
-      return null;
-    });
+    return promisedTracked
+      .catch(_error => null)
+      .finally(() => {
+        mPromisedTrackedTabs.delete(key);
+      });
   }
 
   static needToWaitMoved(windowId) {

--- a/webextensions/common/tabs-store.js
+++ b/webextensions/common/tabs-store.js
@@ -736,7 +736,7 @@ export function removeBundledActiveTab(tab) {
 function addVirtualScrollRenderableTab(tab) {
   addTabToIndex(tab, virtualScrollRenderableTabsInWindow);
 }
-function removeVirtualScrollRenderableTab(tab) {
+export function removeVirtualScrollRenderableTab(tab) {
   removeTabFromIndex(tab, virtualScrollRenderableTabsInWindow);
 }
 


### PR DESCRIPTION
タブの破棄・追跡処理において、不要になったエントリがコレクションから削除されずに残り続けるリソースリークを修正します。

## 修正内容

### 1. `virtualScrollRenderableTabsInWindow` からの削除漏れ（TreeItem.js）

`Tab.destroy()` の処理で `TabsStore.removeTabFromIndexes()` は呼ばれていましたが、`virtualScrollRenderableTabsInWindow` インデックスからの削除が行われていませんでした。

破棄されたタブが仮想スクロールの描画対象インデックスに残り続けるため、`TabsStore.removeVirtualScrollRenderableTab()` の呼び出しを `destroy()` に追加しています。あわせて、この関数を `tabs-store.js` から export するようにしました。

### 2. `mPromisedTrackedTabs` のエントリ削除漏れ（TreeItem.js）

`Tab.waitUntilTracked()` で使用される `mPromisedTrackedTabs`（Promise キャッシュ用 Map）において、Promise 解決後のエントリ削除がコメントアウトされていました。

コメントには「後続の waitUntilTracked コールバックを逐次処理するために削除しない」とありましたが、Promise が解決済みであれば `.then()` チェーンは即座に実行されるため、キャッシュを維持し続ける必要はないはずです。

修正では `.then().catch()` のチェーンを `.catch().finally()` に置き換え、Promise の成功・失敗にかかわらず `finally()` で確実にエントリを削除するようにしています。これにより、存在しないタブIDに対して `waitUntilTracked()` が呼ばれた場合（タイムアウト後にnullを返すが Tab オブジェクトが生成されず
`destroy()` が呼ばれないケース）でも、エントリが永久に残ることがなくなります。
