### PR TITLE
perf(sidebar): avoid redundant per-tab resize and config listeners in TreeItemElement

### DIFF
--- a/webextensions/sidebar/components/TreeItemElement.js
+++ b/webextensions/sidebar/components/TreeItemElement.js
@@ -77,7 +77,6 @@ export class TreeItemElement extends HTMLElement {
     this.__onMouseOver = null;
     this.__onMouseEnter = null;
     this.__onMouseLeave = null;
-    this.__onWindowResize = null;
     this.__onConfigChange = null;
     this._extraItemsContainerIndentRoot = null;
     this._extraItemsContainerBehindRoot = null;
@@ -574,7 +573,6 @@ index = ${raw.index}
     this.substanceElement?.addEventListener('mouseenter', this.__onMouseEnter);
     this.addEventListener('mouseleave', this.__onMouseLeave = this._onMouseLeave.bind(this));
     this.substanceElement?.addEventListener('mouseleave', this.__onMouseLeave);
-    window.addEventListener('resize', this.__onWindowResize = this._onWindowResize.bind(this));
     configs.$addObserver(this.__onConfigChange = this._onConfigChange.bind(this));
   }
 
@@ -589,8 +587,6 @@ index = ${raw.index}
     this.removeEventListener('mouseleave', this.__onMouseLeave);
     this.substanceElement?.removeEventListener('mouseleave', this.__onMouseLeave);
     this.__onMouseLeave = null;
-    window.removeEventListener('resize', this.__onWindowResize);
-    this.__onWindowResize = null;
     configs.$removeObserver(this.__onConfigChange);
     this.__onConfigChange = null;
   }
@@ -629,8 +625,10 @@ index = ${raw.index}
     this.dispatchEvent(tabSubstanceLeaveEvent);
   }
 
-  _onWindowResize(_event) {
-    this.invalidateTooltip();
+  static onWindowResize() {
+    for (const element of document.querySelectorAll(kTREE_ITEM_ELEMENT_NAME)) {
+      element.invalidateTooltip();
+    }
   }
 
   _onConfigChange(changedKey) {
@@ -863,3 +861,5 @@ index = ${raw.index}
     }
   }
 }
+
+window.addEventListener('resize', TreeItemElement.onWindowResize);

--- a/webextensions/sidebar/components/TreeItemElement.js
+++ b/webextensions/sidebar/components/TreeItemElement.js
@@ -77,7 +77,6 @@ export class TreeItemElement extends HTMLElement {
     this.__onMouseOver = null;
     this.__onMouseEnter = null;
     this.__onMouseLeave = null;
-    this.__onConfigChange = null;
     this._extraItemsContainerIndentRoot = null;
     this._extraItemsContainerBehindRoot = null;
     this._extraItemsContainerFrontRoot = null;
@@ -573,7 +572,6 @@ index = ${raw.index}
     this.substanceElement?.addEventListener('mouseenter', this.__onMouseEnter);
     this.addEventListener('mouseleave', this.__onMouseLeave = this._onMouseLeave.bind(this));
     this.substanceElement?.addEventListener('mouseleave', this.__onMouseLeave);
-    configs.$addObserver(this.__onConfigChange = this._onConfigChange.bind(this));
   }
 
   _endListening() {
@@ -587,8 +585,6 @@ index = ${raw.index}
     this.removeEventListener('mouseleave', this.__onMouseLeave);
     this.substanceElement?.removeEventListener('mouseleave', this.__onMouseLeave);
     this.__onMouseLeave = null;
-    configs.$removeObserver(this.__onConfigChange);
-    this.__onConfigChange = null;
   }
 
   _onMouseOver(_event) {
@@ -631,14 +627,18 @@ index = ${raw.index}
     }
   }
 
-  _onConfigChange(changedKey) {
+  static onConfigChange(changedKey) {
     switch (changedKey) {
       case 'showCollapsedDescendantsByTooltip':
-        this.invalidateTooltip();
+        for (const element of document.querySelectorAll(kTREE_ITEM_ELEMENT_NAME)) {
+          element.invalidateTooltip();
+        }
         break;
 
       case 'labelOverflowStyle':
-        this.updateOverflow();
+        for (const element of document.querySelectorAll(kTREE_ITEM_ELEMENT_NAME)) {
+          element.updateOverflow();
+        }
         break;
     }
   }
@@ -863,3 +863,4 @@ index = ${raw.index}
 }
 
 window.addEventListener('resize', TreeItemElement.onWindowResize);
+configs.$addObserver(TreeItemElement.onConfigChange);


### PR DESCRIPTION
TreeItemElement の各インスタンスが個別に登録していた window の resize リスナーと configs のオブザーバーを、クラスレベルの静的メソッド＋単一リスナーに統合することで、イベントリスナのインスタンス数を削減します。

- `_onWindowResize` と `_onConfigChange` をインスタンスメソッドから静的メソッドに変更し、document.querySelectorAll で全要素に対して処理を行うようにしました
- インスタンスごとの `_startListening` / `_endListening` でのリスナー登録・解除を削除しました
- モジュールスコープで window.addEventListener と configs.$addObserver を一度だけ呼び出すようにしました
