### PR TITLE
Serialize tree apply during batch restoration and validate cache references

### DIFF
--- a/webextensions/background/background-cache.js
+++ b/webextensions/background/background-cache.js
@@ -245,6 +245,16 @@ async function fixupTabsRestoredFromCache(tabs, permanentStates, cachedTabs) {
   if (remappedCount && remappedCount < tabs.length)
     throw new Error(`fixupTabsRestoredFromCache: not a window restoration, only ${remappedCount} tab(s) are restored (maybe restoration of closed tabs)`);
   MetricsData.add('fixupTabsRestoredFromCache: step 1 done.');
+  // validate parent/child reference integrity in cache
+  for (const cachedTab of cachedTabs) {
+    if (cachedTab.$TST.parentId && !idMap.has(cachedTab.$TST.parentId))
+      throw new Error(`fixupTabsRestoredFromCache: inconsistent cache - unresolvable parent ID: ${cachedTab.$TST.parentId} for tab ${cachedTab.id}`);
+    for (const childId of (cachedTab.$TST.childIds || [])) {
+      if (!idMap.has(childId))
+        throw new Error(`fixupTabsRestoredFromCache: inconsistent cache - unresolvable child ID: ${childId} for tab ${cachedTab.id}`);
+    }
+  }
+  MetricsData.add('fixupTabsRestoredFromCache: step 1.5 done.');
   // step 2: restore information of tabs
   // Do this from bottom to top, to reduce post operations for modified trees.
   // (Attaching a tab to an existing tree will trigger "update" task for

--- a/webextensions/background/tree-structure.js
+++ b/webextensions/background/tree-structure.js
@@ -184,19 +184,30 @@ async function reserveToAttachTabFromRestoredInfo(tab, options = {}) {
     reserveToAttachTabFromRestoredInfo.waiting = null;
     const tasks = reserveToAttachTabFromRestoredInfo.tasks.slice(0);
     reserveToAttachTabFromRestoredInfo.tasks = [];
-    const uniqueIds = tasks.map(task => task.tab.$TST.uniqueId);
     const bulk = tasks.length > 1;
-    const attachedResults = await Promise.all(uniqueIds.map((uniqueId, index) => {
-      const task = tasks[index];
-      return attachTabFromRestoredInfo(task.tab, {
+    // Phase 0: resolve all unique IDs before collecting info
+    await Tab.waitUntilTracked(tasks.map(task => task.tab.id));
+    // Phase 1: collect restored info for all tabs in parallel
+    const restoredInfos = await Promise.all(tasks.map((task, index) =>
+      collectRestoredTabInfo(task.tab, {
         ...task.options,
-        uniqueId,
-        bulk
+        canCollapse: task.options.canCollapse || bulk,
       }).catch(error => {
         console.log(`TreeStructure.reserveToAttachTabFromRestoredInfo: Fatal error on processing task ${index}, ${error}`, stack(error.stack));
         return false;
-      });
-    }));
+      })
+    ));
+    // Phase 2: apply tree structure sequentially
+    const attachedResults = [];
+    for (const info of restoredInfos) {
+      try {
+        attachedResults.push(info ? await applyRestoredTabInfo(info) : false);
+      }
+      catch(error) {
+        console.log(`TreeStructure.reserveToAttachTabFromRestoredInfo: Fatal error applying info, ${error}`, stack(error.stack));
+        attachedResults.push(false);
+      }
+    }
     if (typeof reserveToAttachTabFromRestoredInfo.onDone == 'function')
       reserveToAttachTabFromRestoredInfo.onDone(attachedResults.every(attached => !!attached));
     delete reserveToAttachTabFromRestoredInfo.onDone;
@@ -210,11 +221,11 @@ reserveToAttachTabFromRestoredInfo.tasks   = [];
 reserveToAttachTabFromRestoredInfo.promisedDone = null;
 
 
-async function attachTabFromRestoredInfo(tab, options = {}) {
-  log('attachTabFromRestoredInfo ', tab, options);
+async function collectRestoredTabInfo(tab, options = {}) {
+  log('collectRestoredTabInfo ', tab, options);
   if (tab.$TST.temporaryMetadata.has('treeStructureAlreadyRestoredFromSessionData')) {
     log(' => already restored ', tab.id);
-    return;
+    return null;
   }
 
   let uniqueId, insertBefore, insertAfter, insertAfterLegacy, ancestors, children, states, collapsed /* for backward compatibility */;
@@ -274,24 +285,35 @@ async function attachTabFromRestoredInfo(tab, options = {}) {
       nextOfInsertAfter.pinned)
     insertAfter = null;
 
+  return {
+    tab, insertBefore, insertAfter,
+    ancestors, children,
+    active:           tab.active,
+    maybeRecycledTab,
+    subtreeCollapsed: states.includes(Constants.kTAB_STATE_SUBTREE_COLLAPSED),
+    keepCurrentTree:  options.keepCurrentTree,
+    canCollapse:      options.canCollapse,
+    processChildren:  options.children,
+  };
+}
+
+async function applyRestoredTabInfo(info) {
+  const { tab, insertBefore, insertAfter, ancestors, children,
+    active, maybeRecycledTab, subtreeCollapsed,
+    keepCurrentTree, canCollapse, processChildren } = info;
+
   let attached = false;
-  const active = tab.active;
-  const promises = [];
   for (const ancestor of ancestors) {
     if (!ancestor)
       continue;
     log(' attach to old ancestor: ', tab.id, { child: tab, parent: ancestor });
-    const promisedDone = Tree.attachTabTo(tab, ancestor, {
+    await Tree.attachTabTo(tab, ancestor, {
       insertBefore,
       insertAfter,
       dontExpand:  !active,
       forceExpand: active,
       broadcast:   true
     });
-    if (options.bulk)
-      promises.push(promisedDone);
-    else
-      await promisedDone;
     attached = true;
     break;
   }
@@ -300,20 +322,15 @@ async function attachTabFromRestoredInfo(tab, options = {}) {
     if (opener &&
         configs.syncParentTabAndOpenerTab) {
       log(' attach to opener: ', tab.id, { child: tab, parent: opener });
-      const promisedDone = Tree.attachTabTo(tab, opener, {
+      await Tree.attachTabTo(tab, opener, {
         dontExpand:  !active,
         forceExpand: active,
         broadcast:   true,
         insertAt:    Constants.kINSERT_NEAREST
       });
-      if (options.bulk)
-        promises.push(promisedDone);
-      else
-        await promisedDone;
     }
-    else if (!options.bulk &&
-             (tab.$TST.nearestCompletelyOpenedNormalFollowingTab ||
-              tab.$TST.nearestCompletelyOpenedNormalPrecedingTab)) {
+    else if (tab.$TST.nearestCompletelyOpenedNormalFollowingTab ||
+             tab.$TST.nearestCompletelyOpenedNormalPrecedingTab) {
       log(' attach from position: ', tab.id);
       onTabAttachedFromRestoredInfo.dispatch(tab, {
         toIndex:   tab.index,
@@ -321,7 +338,7 @@ async function attachTabFromRestoredInfo(tab, options = {}) {
       });
     }
   }
-  if (!options.keepCurrentTree &&
+  if (!keepCurrentTree &&
       // the restored tab is a root tab
       ancestors.length == 0 &&
       // but attached to any parent based on its restored position
@@ -332,7 +349,7 @@ async function attachTabFromRestoredInfo(tab, options = {}) {
       broadcast: true
     });
   }
-  if (options.children && !options.bulk) {
+  if (processChildren) {
     let firstInTree = tab.$TST.firstChild || tab;
     let lastInTree  = tab.$TST.lastDescendant || tab;
     for (const child of children) {
@@ -352,22 +369,20 @@ async function attachTabFromRestoredInfo(tab, options = {}) {
     }
   }
 
-  const subtreeCollapsed = states.includes(Constants.kTAB_STATE_SUBTREE_COLLAPSED);
-  log('restore subtree collapsed state: ', tab.id, { current: tab.$TST.subtreeCollapsed, expected: subtreeCollapsed, ...options });
-  if ((options.canCollapse || options.bulk) &&
+  log('restore subtree collapsed state: ', tab.id, { current: tab.$TST.subtreeCollapsed, expected: subtreeCollapsed, canCollapse });
+  if (canCollapse &&
       tab.$TST.subtreeCollapsed != subtreeCollapsed) {
-    const promisedDone = Tree.collapseExpandSubtree(tab, {
+    await Tree.collapseExpandSubtree(tab, {
       broadcast: true,
       collapsed: subtreeCollapsed,
       justNow:   true
     });
-    promises.push(promisedDone);
   }
 
   const updateCollapsedState = () => {
     const shouldBeCollapsed = tab.$TST.ancestors.some(ancestor => ancestor.$TST.collapsed || ancestor.$TST.subtreeCollapsed);
     log('update collapsed state: ', tab.id, { current: tab.$TST.collapsed, expected: shouldBeCollapsed });
-    if ((options.canCollapse || options.bulk) &&
+    if (canCollapse &&
         tab.$TST.collapsed != shouldBeCollapsed) {
       Tree.collapseExpandTabAndSubtree(tab, {
         broadcast: true,
@@ -385,10 +400,7 @@ async function attachTabFromRestoredInfo(tab, options = {}) {
   if (!maybeRecycledTab)
     tab.$TST.temporaryMetadata.set('treeStructureAlreadyRestoredFromSessionData', true);
 
-  if (options.bulk)
-    await Promise.all(promises).then(updateCollapsedState);
-  else
-    updateCollapsedState();
+  updateCollapsedState();
 
   return attached;
 }


### PR DESCRIPTION
複数タブの復元時、並列に行われていた処理の一部を直列化し、ツリー構造が壊れる問題を修正します。

Firefox単体では、複数のタブを復元する際、復元順序は順不同のようですが、TSTでは単にタブが復元されるだけではなく、ツリー構造も復元対象に含まれるので、可能な範囲でツリー構造が復元されたほうが好ましいと考えます。

## ツリー構造の復元処理を直列化 (`tree-structure.js`)

`attachTabFromRestoredInfo` を並列実行していたため親子関係の適用順序が順不同になっていました。

この修正では、処理を2つのフェーズに分離します：

1. **Phase 1 (`collectRestoredTabInfo`)**: 各タブの復元情報を並列に収集します
2. **Phase 2 (`applyRestoredTabInfo`)**: 収集した情報を元にツリー構造を逐次的に適用します

これにより、可能な限りパフォーマンスを維持しつつ、ツリー構造の復元時の競合を防止します。

## キャッシュの参照整合性チェック (`background-cache.js`)

これは予備的な変更で、実際にこちらに起因する問題は手元で数回試した程度では発生していませんが、キャッシュから復元されたタブデータに対して、親子参照の整合性を検証するチェックを追加します。
`parentId` や `childIds` が `idMap` 内に存在しない場合、不整合なキャッシュとして早期にエラーを投げ、フォールバック処理に移行させます。
