### PR TITLE
perf(sidebar): lazy-create per-tab DOM elements to reduce memory usage

### DIFF
--- a/webextensions/sidebar/components/TreeItemElement.js
+++ b/webextensions/sidebar/components/TreeItemElement.js
@@ -118,16 +118,11 @@ export class TreeItemElement extends HTMLElement {
     this.classList.add(kTAB_CLASS_NAME);
 
     this.insertAdjacentHTML('beforeend', `
-      <span class="native-tab-group-line"></span>
-      <span class="${Constants.kEXTRA_ITEMS_CONTAINER} indent"></span>
       <${kTREE_ITEM_SUBSTANCE_ELEMENT_NAME} draggable="true">
         <span class="${Constants.kBACKGROUND} base"></span>
-        <span class="${Constants.kBACKGROUND}">
-          <span class="${Constants.kBURSTER}"></span>
-        </span>
+        <span class="${Constants.kBACKGROUND}"></span>
         <${kTAB_TWISTY_ELEMENT_NAME}></${kTAB_TWISTY_ELEMENT_NAME}>
         <span class="ui">
-          <span class="${Constants.kEXTRA_ITEMS_CONTAINER} above"></span>
           <span class="caption">
             <${kTAB_FAVICON_ELEMENT_NAME}></${kTAB_FAVICON_ELEMENT_NAME}>
             <${kTAB_SOUND_BUTTON_ELEMENT_NAME}></${kTAB_SOUND_BUTTON_ELEMENT_NAME}>
@@ -135,12 +130,8 @@ export class TreeItemElement extends HTMLElement {
             <${kTAB_COUNTER_ELEMENT_NAME}></${kTAB_COUNTER_ELEMENT_NAME}>
             <${kTAB_CLOSE_BOX_ELEMENT_NAME}></${kTAB_CLOSE_BOX_ELEMENT_NAME}>
           </span>
-          <span class="${Constants.kEXTRA_ITEMS_CONTAINER} below"></span>
-          <span class="${Constants.kEXTRA_ITEMS_CONTAINER} behind"></span>
-          <span class="${Constants.kEXTRA_ITEMS_CONTAINER} front"></span>
         </span>
         <span class="${Constants.kHIGHLIGHTER}"></span>
-        <span class="${Constants.kCONTEXTUAL_IDENTITY_MARKER}"></span>
       </${kTREE_ITEM_SUBSTANCE_ELEMENT_NAME}>
     `.trim().replace(/>\s+</g, '><'));
 
@@ -161,6 +152,11 @@ export class TreeItemElement extends HTMLElement {
     this._endListening();
     this._raw = null;
     this._$TST = null;
+    this._extraItemsContainerIndentRoot = null;
+    this._extraItemsContainerBehindRoot = null;
+    this._extraItemsContainerFrontRoot = null;
+    this._extraItemsContainerAboveRoot = null;
+    this._extraItemsContainerBelowRoot = null;
   }
 
   get initialized() {
@@ -528,7 +524,13 @@ index = ${raw.index}
 
   get extraItemsContainerIndentRoot() {
     if (!this._extraItemsContainerIndentRoot) {
-      this._extraItemsContainerIndentRoot = this.querySelector(`.${Constants.kEXTRA_ITEMS_CONTAINER}.indent`).attachShadow({ mode: 'open' });
+      let container = this.querySelector(`.${Constants.kEXTRA_ITEMS_CONTAINER}.indent`);
+      if (!container) {
+        container = document.createElement('span');
+        container.className = `${Constants.kEXTRA_ITEMS_CONTAINER} indent`;
+        this.insertBefore(container, this.substanceElement);
+      }
+      this._extraItemsContainerIndentRoot = container.attachShadow({ mode: 'open' });
       this._extraItemsContainerIndentRoot.itemById = new Map();
     }
     return this._extraItemsContainerIndentRoot;
@@ -536,7 +538,15 @@ index = ${raw.index}
 
   get extraItemsContainerBehindRoot() {
     if (!this._extraItemsContainerBehindRoot) {
-      this._extraItemsContainerBehindRoot = this.querySelector(`.${Constants.kEXTRA_ITEMS_CONTAINER}.behind`).attachShadow({ mode: 'open' });
+      let container = this.querySelector(`.${Constants.kEXTRA_ITEMS_CONTAINER}.behind`);
+      if (!container) {
+        container = document.createElement('span');
+        container.className = `${Constants.kEXTRA_ITEMS_CONTAINER} behind`;
+        const ui = this.querySelector('.ui');
+        const below = ui.querySelector(`.${Constants.kEXTRA_ITEMS_CONTAINER}.below`);
+        ui.insertBefore(container, below ? below.nextSibling : ui.querySelector('.caption').nextSibling);
+      }
+      this._extraItemsContainerBehindRoot = container.attachShadow({ mode: 'open' });
       this._extraItemsContainerBehindRoot.itemById = new Map();
     }
     return this._extraItemsContainerBehindRoot;
@@ -544,7 +554,13 @@ index = ${raw.index}
 
   get extraItemsContainerFrontRoot() {
     if (!this._extraItemsContainerFrontRoot) {
-      this._extraItemsContainerFrontRoot = this.querySelector(`.${Constants.kEXTRA_ITEMS_CONTAINER}.front`).attachShadow({ mode: 'open' });
+      let container = this.querySelector(`.${Constants.kEXTRA_ITEMS_CONTAINER}.front`);
+      if (!container) {
+        container = document.createElement('span');
+        container.className = `${Constants.kEXTRA_ITEMS_CONTAINER} front`;
+        this.querySelector('.ui').appendChild(container);
+      }
+      this._extraItemsContainerFrontRoot = container.attachShadow({ mode: 'open' });
       this._extraItemsContainerFrontRoot.itemById = new Map();
     }
     return this._extraItemsContainerFrontRoot;
@@ -552,7 +568,14 @@ index = ${raw.index}
 
   get extraItemsContainerAboveRoot() {
     if (!this._extraItemsContainerAboveRoot) {
-      this._extraItemsContainerAboveRoot = this.querySelector(`.${Constants.kEXTRA_ITEMS_CONTAINER}.above`).attachShadow({ mode: 'open' });
+      let container = this.querySelector(`.${Constants.kEXTRA_ITEMS_CONTAINER}.above`);
+      if (!container) {
+        container = document.createElement('span');
+        container.className = `${Constants.kEXTRA_ITEMS_CONTAINER} above`;
+        const ui = this.querySelector('.ui');
+        ui.insertBefore(container, ui.querySelector('.caption'));
+      }
+      this._extraItemsContainerAboveRoot = container.attachShadow({ mode: 'open' });
       this._extraItemsContainerAboveRoot.itemById = new Map();
     }
     return this._extraItemsContainerAboveRoot;
@@ -560,10 +583,42 @@ index = ${raw.index}
 
   get extraItemsContainerBelowRoot() {
     if (!this._extraItemsContainerBelowRoot) {
-      this._extraItemsContainerBelowRoot = this.querySelector(`.${Constants.kEXTRA_ITEMS_CONTAINER}.below`).attachShadow({ mode: 'open' });
+      let container = this.querySelector(`.${Constants.kEXTRA_ITEMS_CONTAINER}.below`);
+      if (!container) {
+        container = document.createElement('span');
+        container.className = `${Constants.kEXTRA_ITEMS_CONTAINER} below`;
+        const ui = this.querySelector('.ui');
+        ui.insertBefore(container, ui.querySelector('.caption').nextSibling);
+      }
+      this._extraItemsContainerBelowRoot = container.attachShadow({ mode: 'open' });
       this._extraItemsContainerBelowRoot.itemById = new Map();
     }
     return this._extraItemsContainerBelowRoot;
+  }
+
+  ensureBurster() {
+    const background = this.querySelector(`.${Constants.kBACKGROUND}:not(.base)`);
+    if (background && !background.querySelector(`.${Constants.kBURSTER}`)) {
+      const burster = document.createElement('span');
+      burster.className = Constants.kBURSTER;
+      background.appendChild(burster);
+    }
+  }
+
+  ensureContextualIdentityMarker() {
+    if (!this.substanceElement?.querySelector(`.${Constants.kCONTEXTUAL_IDENTITY_MARKER}`)) {
+      const marker = document.createElement('span');
+      marker.className = Constants.kCONTEXTUAL_IDENTITY_MARKER;
+      this.substanceElement.appendChild(marker);
+    }
+  }
+
+  ensureNativeTabGroupLine() {
+    if (!this.querySelector('.native-tab-group-line')) {
+      const line = document.createElement('span');
+      line.className = 'native-tab-group-line';
+      this.insertBefore(line, this.firstChild);
+    }
   }
 
   _startListening() {
@@ -748,6 +803,8 @@ index = ${raw.index}
           continue;
         if (!classList.contains(state))
           classList.add(state);
+        if (state.startsWith('contextual-identity-'))
+          this.ensureContextualIdentityMarker();
       }
 
       for (const state of NATIVE_PROPERTIES) {
@@ -802,6 +859,7 @@ index = ${raw.index}
 
     const group = this.$TST.nativeTabGroup || this.$TST.group;
     if (group) {
+      this.ensureNativeTabGroupLine();
       this.style.setProperty('--tab-group-color', `var(--tab-group-color-${group.color})`);
       this.style.setProperty('--tab-group-color-pale', `var(--tab-group-color-${group.color}-pale)`);
       this.style.setProperty('--tab-group-color-invert', `var(--tab-group-color-${group.color}-invert)`);

--- a/webextensions/sidebar/components/TreeItemElement.js
+++ b/webextensions/sidebar/components/TreeItemElement.js
@@ -117,6 +117,34 @@ export class TreeItemElement extends HTMLElement {
     // We preserve this class for backward compatibility with other addons.
     this.classList.add(kTAB_CLASS_NAME);
 
+    /* The DOM structure will be fulfilled as following with delayed creations of elements:
+
+      <span class="native-tab-group-line"></span>
+      <span class="${Constants.kEXTRA_ITEMS_CONTAINER} indent"></span>
+      <${kTREE_ITEM_SUBSTANCE_ELEMENT_NAME} draggable="true">
+        <span class="${Constants.kBACKGROUND} base"></span>
+        <span class="${Constants.kBACKGROUND}">
+          <span class="${Constants.kBURSTER}"></span>
+        </span>
+        <${kTAB_TWISTY_ELEMENT_NAME}></${kTAB_TWISTY_ELEMENT_NAME}>
+        <span class="ui">
+          <span class="${Constants.kEXTRA_ITEMS_CONTAINER} above"></span>
+          <span class="caption">
+            <${kTAB_FAVICON_ELEMENT_NAME}></${kTAB_FAVICON_ELEMENT_NAME}>
+            <${kTAB_SOUND_BUTTON_ELEMENT_NAME}></${kTAB_SOUND_BUTTON_ELEMENT_NAME}>
+            <${kTREE_ITEM_LABEL_ELEMENT_NAME}></${kTREE_ITEM_LABEL_ELEMENT_NAME}>
+            <${kTAB_COUNTER_ELEMENT_NAME}></${kTAB_COUNTER_ELEMENT_NAME}>
+            <${kTAB_CLOSE_BOX_ELEMENT_NAME}></${kTAB_CLOSE_BOX_ELEMENT_NAME}>
+          </span>
+          <span class="${Constants.kEXTRA_ITEMS_CONTAINER} below"></span>
+          <span class="${Constants.kEXTRA_ITEMS_CONTAINER} behind"></span>
+          <span class="${Constants.kEXTRA_ITEMS_CONTAINER} front"></span>
+        </span>
+        <span class="${Constants.kHIGHLIGHTER}"></span>
+        <span class="${Constants.kCONTEXTUAL_IDENTITY_MARKER}"></span>
+      </${kTREE_ITEM_SUBSTANCE_ELEMENT_NAME}>
+    */
+
     this.insertAdjacentHTML('beforeend', `
       <${kTREE_ITEM_SUBSTANCE_ELEMENT_NAME} draggable="true">
         <span class="${Constants.kBACKGROUND} base"></span>

--- a/webextensions/sidebar/sidebar-items.js
+++ b/webextensions/sidebar/sidebar-items.js
@@ -1111,6 +1111,7 @@ BackgroundConnection.onMessage.addListener(async message => {
         }
         else {
           if (lastMessage.reallyChanged) {
+            tab.$TST.element?.ensureBurster();
             tab.$TST.addState(Constants.kTAB_STATE_BURSTING);
             const prevBurstEnd = mDelayedBurstEnd.get(tab.id);
             if (prevBurstEnd)

--- a/webextensions/sidebar/tst-api-frontend.js
+++ b/webextensions/sidebar/tst-api-frontend.js
@@ -512,30 +512,41 @@ function setExtraTabContentsToElement(tabElement, id, params = {}) {
     params = id;
     id = browser.runtime.id;
   }
+  const useBackingField = (id == '*');
   let container;
   switch (String(params.place).toLowerCase()) {
     case 'indent': // for backward compatibility
     case 'tab-indent':
-      container = tabElement.extraItemsContainerIndentRoot;
+      container = useBackingField ?
+        tabElement._extraItemsContainerIndentRoot :
+        tabElement.extraItemsContainerIndentRoot;
       break;
 
     case 'behind': // for backward compatibility
     case 'tab-behind':
-      container = tabElement.extraItemsContainerBehindRoot;
+      container = useBackingField ?
+        tabElement._extraItemsContainerBehindRoot :
+        tabElement.extraItemsContainerBehindRoot;
       break;
 
     case 'front': // for backward compatibility
     case 'tab-front':
     default:
-      container = tabElement.extraItemsContainerFrontRoot;
+      container = useBackingField ?
+        tabElement._extraItemsContainerFrontRoot :
+        tabElement.extraItemsContainerFrontRoot;
       break;
 
     case 'tab-above':
-      container = tabElement.extraItemsContainerAboveRoot;
+      container = useBackingField ?
+        tabElement._extraItemsContainerAboveRoot :
+        tabElement.extraItemsContainerAboveRoot;
       break;
 
     case 'tab-below':
-      container = tabElement.extraItemsContainerBelowRoot;
+      container = useBackingField ?
+        tabElement._extraItemsContainerBelowRoot :
+        tabElement.extraItemsContainerBelowRoot;
       break;
   }
 
@@ -605,11 +616,16 @@ function clearExtraTabContentsIn(tab, id) {
 function clearExtraTabContentsInElement(tabElement, id) {
   if (!id) // the addon id is optional
     id = browser.runtime.id;
-  setExtraTabContentsToElement(tabElement, id, { place: 'tab-indent' });
-  setExtraTabContentsToElement(tabElement, id, { place: 'tab-front' });
-  setExtraTabContentsToElement(tabElement, id, { place: 'tab-behind' });
-  setExtraTabContentsToElement(tabElement, id, { place: 'tab-above' });
-  setExtraTabContentsToElement(tabElement, id, { place: 'tab-below' });
+  if (tabElement._extraItemsContainerIndentRoot)
+    setExtraTabContentsToElement(tabElement, id, { place: 'tab-indent' });
+  if (tabElement._extraItemsContainerFrontRoot)
+    setExtraTabContentsToElement(tabElement, id, { place: 'tab-front' });
+  if (tabElement._extraItemsContainerBehindRoot)
+    setExtraTabContentsToElement(tabElement, id, { place: 'tab-behind' });
+  if (tabElement._extraItemsContainerAboveRoot)
+    setExtraTabContentsToElement(tabElement, id, { place: 'tab-above' });
+  if (tabElement._extraItemsContainerBelowRoot)
+    setExtraTabContentsToElement(tabElement, id, { place: 'tab-below' });
   onExtraContentsAboveChanged(id);
   onExtraContentsBelowChanged(id);
 }
@@ -695,25 +711,25 @@ function collectExtraContentsRoots({ tabs, place }) {
   switch (String(place).toLowerCase()) {
     case 'indent': // for backward compatibility
     case 'tab-indent':
-      return (tabs || Tab.getAllTabs(mTargetWindow)).map(tab => tab.$TST.element.extraItemsContainerIndentRoot);
+      return (tabs || Tab.getAllTabs(mTargetWindow)).map(tab => tab.$TST.element?._extraItemsContainerIndentRoot).filter(root => root);
 
     case 'behind': // for backward compatibility
     case 'tab-behind':
-      return (tabs || Tab.getAllTabs(mTargetWindow)).map(tab => tab.$TST.element.extraItemsContainerBehindRoot);
+      return (tabs || Tab.getAllTabs(mTargetWindow)).map(tab => tab.$TST.element?._extraItemsContainerBehindRoot).filter(root => root);
 
     case 'front': // for backward compatibility
     case 'tab-front':
-      return (tabs || Tab.getAllTabs(mTargetWindow)).map(tab => tab.$TST.element.extraItemsContainerFrontRoot);
+      return (tabs || Tab.getAllTabs(mTargetWindow)).map(tab => tab.$TST.element?._extraItemsContainerFrontRoot).filter(root => root);
 
     case 'tab-above':
       return [
-        ...(tabs || Tab.getAllTabs(mTargetWindow)).map(tab => tab.$TST.element.extraItemsContainerAboveRoot),
+        ...(tabs || Tab.getAllTabs(mTargetWindow)).map(tab => tab.$TST.element?._extraItemsContainerAboveRoot).filter(root => root),
         mDummyTab.extraItemsContainerAboveRoot,
       ];
 
     case 'tab-below':
       return [
-        ...(tabs || Tab.getAllTabs(mTargetWindow)).map(tab => tab.$TST.element.extraItemsContainerBelowRoot),
+        ...(tabs || Tab.getAllTabs(mTargetWindow)).map(tab => tab.$TST.element?._extraItemsContainerBelowRoot).filter(root => root),
         mDummyTab.extraItemsContainerBelowRoot,
       ];
 

--- a/webextensions/sidebar/tst-api-frontend.js
+++ b/webextensions/sidebar/tst-api-frontend.js
@@ -10,6 +10,7 @@ import { DOMUpdater } from '/extlib/dom-updater.js';
 import {
   configs,
   log as internalLogger,
+  mapAndFilter,
 } from '/common/common.js';
 import * as Constants from '/common/constants.js';
 import * as TabsStore from '/common/tabs-store.js';
@@ -711,25 +712,25 @@ function collectExtraContentsRoots({ tabs, place }) {
   switch (String(place).toLowerCase()) {
     case 'indent': // for backward compatibility
     case 'tab-indent':
-      return (tabs || Tab.getAllTabs(mTargetWindow)).map(tab => tab.$TST.element?._extraItemsContainerIndentRoot).filter(root => root);
+      return mapAndFilter(tabs || Tab.getAllTabs(mTargetWindow), tab => tab.$TST.element?._extraItemsContainerIndentRoot || undefined);
 
     case 'behind': // for backward compatibility
     case 'tab-behind':
-      return (tabs || Tab.getAllTabs(mTargetWindow)).map(tab => tab.$TST.element?._extraItemsContainerBehindRoot).filter(root => root);
+      return mapAndFilter(tabs || Tab.getAllTabs(mTargetWindow), tab => tab.$TST.element?._extraItemsContainerBehindRoot || undefined);
 
     case 'front': // for backward compatibility
     case 'tab-front':
-      return (tabs || Tab.getAllTabs(mTargetWindow)).map(tab => tab.$TST.element?._extraItemsContainerFrontRoot).filter(root => root);
+      return mapAndFilter(tabs || Tab.getAllTabs(mTargetWindow), tab => tab.$TST.element?._extraItemsContainerFrontRoot || undefined);
 
     case 'tab-above':
       return [
-        ...(tabs || Tab.getAllTabs(mTargetWindow)).map(tab => tab.$TST.element?._extraItemsContainerAboveRoot).filter(root => root),
+        ...mapAndFilter(tabs || Tab.getAllTabs(mTargetWindow), tab => tab.$TST.element?._extraItemsContainerAboveRoot || undefined),
         mDummyTab.extraItemsContainerAboveRoot,
       ];
 
     case 'tab-below':
       return [
-        ...(tabs || Tab.getAllTabs(mTargetWindow)).map(tab => tab.$TST.element?._extraItemsContainerBelowRoot).filter(root => root),
+        ...mapAndFilter(tabs || Tab.getAllTabs(mTargetWindow), tab => tab.$TST.element?._extraItemsContainerBelowRoot || undefined),
         mDummyTab.extraItemsContainerBelowRoot,
       ];
 


### PR DESCRIPTION
`TreeItemElement.connectedCallback()` の初期HTMLテンプレートから、使用頻度の低い8つのDOM要素を除去し、必要になった時点で初めて生成するようにします。

正直、コードが複雑になってレビューもややこしく、その点については申し訳ないのですが、以下のように、割と効果が高そう（20タブ程度でPSSで25MB程度のメモリ消費量の削減）なので、お手漉きの際にレビューをお願いします。

<img width="1800" height="1800" alt="memory_plot" src="https://github.com/user-attachments/assets/e223773d-63c4-45d1-8294-515d7ba1f8f8" />

条件は以下のような感じです

- Firefox developer edition 148.0b12
- 入っている拡張はTSTとTST Colorize TabsとTST Lindent Lineの3つ
- 拡張のプロセスが使っているメモリを/proc以下から30秒に一度取得
- beforeは数日前のtrunk
- afterはbeforeに対して #3870 と #3872 が加わったもの
- たまにbeforeとafterに同じ操作をしてタブ数を増やしたり減らしたりしていますが、基本的には20タブ程度です
- じわじわとメモリ消費量が上がっているのは操作していない時間帯で、ガクッとメモリ消費量が落ちているのはタブを閉じているのではなくGCが動いた結果のようです

対象の要素:

- **extra-items-container** (indent / above / below / behind / front) — TST APIを通じて外部アドオンが利用する場合のみ必要。lazyなgetterにより、初回アクセス時に動的に `<span>` 要素を生成します。
- **burster** — バックグラウンドタブの読み込み完了時のみ必要。`sidebar-items.js` で `kTAB_STATE_BURSTING` を付与する前に `ensureBurster()` を呼び出します。
- **contextual-identity-marker** — Firefoxのコンテナータブでのみ必要。`_updateTabProperties()` で `contextual-identity-*` 状態を検出した際に `ensureContextualIdentityMarker()` を呼び出します。
- **native-tab-group-line** — ネイティブタブグループに属するタブでのみ必要。`_updateTabProperties()` で `nativeTabGroup` または `group` が存在する場合に `ensureNativeTabGroupLine()` を呼び出します。

highlighter要素は、アクティブタブやホバー状態で即座に必要となるため、テンプレートに残しています。

`tst-api-frontend.js` では、ワイルドカード操作（`id == '*'`）や `collectExtraContentsRoots()` がbacking field（`_extraItemsContainer*Root`）を参照するように変更し、不要なlazy初期化の発火を防止しています。また、`clearExtraTabContentsInElement()`では未初期化のコンテナに対するガードを追加しています。

外部アドオン・コンテナー・タブグループを使用しない100タブの環境で、初期生成から最大800個のDOMノードとそれに伴うShadow DOMルートを削減できます。
