### PR TITLE
optimize tab restore for Ctrl-Shift-T

### DIFF
--- a/webextensions/background/api-tabs-listener.js
+++ b/webextensions/background/api-tabs-listener.js
@@ -41,6 +41,7 @@ import * as TabsStore from '/common/tabs-store.js';
 import * as TabsUpdate from '/common/tabs-update.js';
 import * as TreeBehavior from '/common/tree-behavior.js';
 import * as TSTAPI from '/common/tst-api.js';
+import * as UniqueId from '/common/unique-id.js';
 
 import MetricsData from '/common/MetricsData.js';
 import { Tab, TabGroup } from '/common/TreeItem.js';
@@ -539,40 +540,49 @@ async function onNewTabTracked(tab, info) {
       win.duplicatingTabsCount--;
 
     if (restored && info.trigger !== 'tabs.onAttached') {
-      win.restoredCount = win.restoredCount || 0;
-      win.restoredCount++;
-      if (!win.promisedAllTabsRestored) {
-        log(`onNewTabTracked(${dumpTab(tab)}): Maybe starting to restore window`);
-        win.promisedAllTabsRestored = (new Promise((resolve, _aReject) => {
-          let lastCount = win.restoredCount;
-          const timer = setInterval(() => {
-            if (lastCount != win.restoredCount) {
-              lastCount = win.restoredCount;
-              return;
-            }
-            clearTimeout(timer);
-            win.promisedAllTabsRestored = null;
-            win.restoredCount   = 0;
-            log('All tabs are restored');
-            resolve(lastCount);
-          }, 200);
-        })).then(async lastCount => {
-          await Tab.onWindowRestoring.dispatch({
-            windowId:      tab.windowId,
-            restoredCount: lastCount,
-          });
-          metric.add('Tab.onWindowRestoring proceeded');
-          return lastCount;
-        });
-      }
       SidebarConnection.sendMessage({
         type:     Constants.kCOMMAND_NOTIFY_TAB_RESTORING,
         tabId:    tab.id,
         windowId: tab.windowId
       });
-      await win.promisedAllTabsRestored;
-      log(`onNewTabTracked(${dumpTab(tab)}): continued for restored tab`);
-      metric.add('win.promisedAllTabsRestored resolved');
+
+      if (UniqueId.isRestorationComplete()) {
+        // Ctrl-Shift-T: skip the gate and proceed immediately
+        log(`onNewTabTracked(${dumpTab(tab)}): post-startup restored tab, skipping gate`);
+        metric.add('post-startup restore (no gate)');
+      }
+      else {
+        // Session restoration at startup: wait for all tabs
+        win.restoredCount = win.restoredCount || 0;
+        win.restoredCount++;
+        if (!win.promisedAllTabsRestored) {
+          log(`onNewTabTracked(${dumpTab(tab)}): Maybe starting to restore window`);
+          win.promisedAllTabsRestored = (new Promise((resolve, _aReject) => {
+            let lastCount = win.restoredCount;
+            const timer = setInterval(() => {
+              if (lastCount != win.restoredCount) {
+                lastCount = win.restoredCount;
+                return;
+              }
+              clearTimeout(timer);
+              win.promisedAllTabsRestored = null;
+              win.restoredCount   = 0;
+              log('All tabs are restored');
+              resolve(lastCount);
+            }, 200);
+          })).then(async lastCount => {
+            await Tab.onWindowRestoring.dispatch({
+              windowId:      tab.windowId,
+              restoredCount: lastCount,
+            });
+            metric.add('Tab.onWindowRestoring proceeded');
+            return lastCount;
+          });
+        }
+        await win.promisedAllTabsRestored;
+        log(`onNewTabTracked(${dumpTab(tab)}): continued for restored tab`);
+        metric.add('win.promisedAllTabsRestored resolved');
+      }
     }
     if (!TabsStore.ensureLivingItem(tab)) {
       log(`onNewTabTracked(${dumpTab(tab)}):  => aborted`);
@@ -682,7 +692,9 @@ async function onNewTabTracked(tab, info) {
         info.trigger !== 'tabs.onAttached') {
       tab.$TST.addState(Constants.kTAB_STATE_RESTORED);
       Tab.onRestored.dispatch(tab);
-      checkRecycledTab(win.id);
+      if (!UniqueId.isRestorationComplete()) {
+        checkRecycledTab(win.id);
+      }
     }
 
     onCompleted(uniqueId);

--- a/webextensions/common/unique-id.js
+++ b/webextensions/common/unique-id.js
@@ -164,6 +164,10 @@ export function completeRestoration() {
   mReadyToDetectDuplicatedTab = true;
 }
 
+export function isRestorationComplete() {
+  return mReadyToDetectDuplicatedTab;
+}
+
 export async function request(tabOrId, options = {}) {
   log('requested for ', tabOrId?.id || tabOrId);
   if (typeof options != 'object')

--- a/webextensions/sidebar/scroll.js
+++ b/webextensions/sidebar/scroll.js
@@ -91,11 +91,6 @@ export function clearItemRectCache() {
   mCachedItemRects.clear();
 }
 
-let mCachedRenderableTreeItems = null;
-
-export function clearRenderableTreeItemsCache() {
-  mCachedRenderableTreeItems = null;
-}
 
 let mScrollingInternallyCount = 0;
 
@@ -119,17 +114,14 @@ export function init(scrollPosition) {
   TSTAPI.onMessageExternal.addListener(onMessageExternal);
   SidebarItems.onNormalTabsChanged.addListener(_tab => {
     clearItemRectCache();
-    clearRenderableTreeItemsCache();
     reserveToRenderVirtualScrollViewport({ trigger: 'tabsChanged' });
   });
   Tab.onNativeGroupModified.addListener(_tab => {
     clearItemRectCache();
-    clearRenderableTreeItemsCache();
     reserveToRenderVirtualScrollViewport({ trigger: 'tabsChanged' });
   });
   Tab.onSplitViewModified.addListener(_tab => {
     clearItemRectCache();
-    clearRenderableTreeItemsCache();
     reserveToRenderVirtualScrollViewport({ trigger: 'tabsChanged' });
   });
   Size.onUpdated.addListener(() => {
@@ -250,20 +242,15 @@ export function getRenderableTreeItems(windowId = null) {
   if (!windowId) {
     windowId = TabsStore.getCurrentWindowId();
   }
-  if (mCachedRenderableTreeItems) {
-    return mapAndFilter(mCachedRenderableTreeItems, item => TreeItem.get(item) || undefined);
-  }
 
   if (TabsStore.nativelyGroupedTabsInWindow.get(windowId).size == 0) {
     log('getRenderableTreeItems: no native tab group');
-    const items = TabsStore.queryAll({
+    return TabsStore.queryAll({
       windowId,
       tabs:         TabsStore.getTabsMap(TabsStore.virtualScrollRenderableTabsInWindow, windowId),
       skipMatching: true,
       ordered:      true,
     }).filter(splitViewHiddenTabFilter);
-    mCachedRenderableTreeItems = items.map(item => ({ id: item.id, type: item.type }));
-    return items;
   }
 
   const mixedItems = TreeItem.sort([
@@ -289,10 +276,8 @@ export function getRenderableTreeItems(windowId = null) {
     ).flat(),
   ]);
   log('getRenderableTreeItems: mixedItems = ', mixedItems);
-
-  mCachedRenderableTreeItems = mixedItems.map(item => ({ id: item.id, type: item.type }));
   return mixedItems;
-};
+}
 
 renderVirtualScrollViewport.triggers = new Set();
 
@@ -312,18 +297,17 @@ function renderVirtualScrollViewport(scrollPosition = undefined) {
 
   const outOfScreenPages = configs.outOfScreenTabsRenderingPages;
   const staticRendering  = outOfScreenPages < 0;
-  const skipRefreshItems = staticRendering && triggers.size == 1 && triggers.has('scroll');
+  const scrollOnly       = triggers.size == 1 && triggers.has('scroll');
+  const skipRefreshItems = staticRendering && scrollOnly;
 
   const itemSize           = Size.getRenderedTabHeight();
-  const renderableItems   = skipRefreshItems && mLastRenderableItems || getRenderableTreeItems(windowId);
-  const disappearingItems = skipRefreshItems && mLastDisappearingItems || renderableItems.filter(item => item.$TST.removing || item.$TST.states.has(Constants.kTAB_STATE_COLLAPSING));
+  const renderableItems   = scrollOnly && mLastRenderableItems || getRenderableTreeItems(windowId);
+  const disappearingItems = scrollOnly && mLastDisappearingItems || renderableItems.filter(item => item.$TST.removing || item.$TST.states.has(Constants.kTAB_STATE_COLLAPSING));
   const totalRenderableItemsSize = Size.getTabMarginBlockStart() + (itemSize * (renderableItems.length - disappearingItems.length)) + Size.getTabMarginBlockEnd();
   const viewPortSize = Size.getNormalTabsViewPortSize();
 
-  if (staticRendering) {
-    mLastRenderableItems = renderableItems;
-    mLastDisappearingItems = disappearingItems;
-  }
+  mLastRenderableItems = renderableItems;
+  mLastDisappearingItems = disappearingItems;
 
   // For underflow case, we need to unset min-height to put the "new tab"
   // button next to the last tab immediately.
@@ -1350,7 +1334,7 @@ async function onBackgroundMessage(message) {
       await Tab.waitUntilTracked(message.tabId);
       if (message.maybeMoved)
         await SidebarItems.waitUntilNewTabIsMoved(message.tabId);
-      clearRenderableTreeItemsCache();
+
       const item = Tab.get(message.tabId);
       if (!item) // it can be closed while waiting
         break;
@@ -1388,12 +1372,12 @@ async function onBackgroundMessage(message) {
     }; break;
 
     case Constants.kCOMMAND_NOTIFY_TAB_PINNED:
-      clearRenderableTreeItemsCache();
+
       break;
 
     case Constants.kCOMMAND_NOTIFY_TAB_UNPINNED:
       await Tab.waitUntilTracked(message.tabId);
-      clearRenderableTreeItemsCache();
+
       reserveToScrollToItem(Tab.get(message.tabId));
       break;
 
@@ -1430,11 +1414,14 @@ async function onBackgroundMessage(message) {
       const item = Tab.get(message.tabId);
       if (!item) // it can be closed while waiting
         break;
-      clearRenderableTreeItemsCache();
+
       if (!reReserveScrollingForItem(item) &&
           item.active)
         reserveToScrollToItem(item);
     }; break;
+
+    case Constants.kCOMMAND_SYNC_TABS_ORDER:
+      break;
   }
 }
 
@@ -1505,7 +1492,6 @@ CollapseExpand.onUpdating.addListener((item, options) => {
   if (!configs.scrollToExpandedTree)
     return;
   if (!item.pinned) {
-    clearRenderableTreeItemsCache();
     reserveToRenderVirtualScrollViewport({ trigger: 'collapseExpand' });
   }
   if (options.last)
@@ -1519,7 +1505,6 @@ CollapseExpand.onUpdated.addListener((item, options) => {
   if (!configs.scrollToExpandedTree)
     return;
   if (!item.pinned) {
-    clearRenderableTreeItemsCache();
     reserveToRenderVirtualScrollViewport({ trigger: 'collapseExpand' });
   }
   if (options.last)

--- a/webextensions/sidebar/sidebar-items.js
+++ b/webextensions/sidebar/sidebar-items.js
@@ -213,6 +213,8 @@ async function syncTabsOrder() {
     tab.reindexedBy = `syncTabsOrder (${tab.index})`;
     tab.$TST.invalidateCache();
   }
+
+  onNormalTabsChanged.dispatch();
 }
 
 function getItemElementId(item) {

--- a/webextensions/sidebar/sidebar.js
+++ b/webextensions/sidebar/sidebar.js
@@ -732,7 +732,6 @@ updateTabbarLayout.lastSizes = {};
 
 function updateTabbarLayout({ reason, reasons, timeout, justNow } = {}) {
   Scroll.clearItemRectCache();
-  Scroll.clearRenderableTreeItemsCache();
   if (reason && !reasons)
     reasons = reason;
   if (reserveToUpdateTabbarLayout.reasons) {


### PR DESCRIPTION
Ctrl-Shift-T によるタブ復元を高速化しました。

Ctrl-Shift-T で直前に閉じたタブを復元する際、TST はブラウザ起動時のセッション復元と同じコードパスを通っていました。このため、1タブが復元されるだけでも、`restoreWindowFromEffectiveWindowCache`が走っていました。
unique-id.js に isRestorationComplete() を追加し、既存の mReadyToDetectDuplicatedTab フラグを公開しました。このフラグは起動時のセッション復元完了後に true になるため、api-tabs-listener.js が Ctrl-Shift-T のようなタブの復元で`restoreWindowFromEffectiveWindowCache`を確実にスキップできるようになります。
セッション復元を行わなかった場合にはこの高速化の恩恵は受けられない、ということになりますが、他にいい方法が思いつきませんでした…。

また、mCachedRenderableTreeItems を削除しました。高速化したことで、C-w, C-S-Tを急いで実行すると、復元されたタブツリーの表示が壊れる（並び順がおかしくなる）という問題が出てきました。
原因を調べてみると、mCachedRenderableTreeItemsの情報がおかしくなってしまうみたいでした。backgroundのツリー情報は正しいままなので、適切なタイミングで再レンダリングを行うという手段も考えられましたが、そもそも、mCachedRenderableTreeItemsは現状ではスクロール時にしか使われていないこと、スクロール時はmLastRenderableItemsを使ってキャッシュすれば同等の性能を達成できることから、削除してしまうのがベストだと判断しました。
