### PR TITLE
fix(session): use tab offsets when restoring saved tree structures

### DIFF
--- a/webextensions/background/tree-structure.js
+++ b/webextensions/background/tree-structure.js
@@ -10,7 +10,6 @@ import EventListenerManager from '/extlib/EventListenerManager.js';
 import {
   log as internalLogger,
   dumpTab,
-  toLines,
   configs,
   wait,
   stack,
@@ -85,6 +84,25 @@ async function saveTreeStructure(windowId) {
   ).catch(ApiTabs.createErrorSuppressor());
 }
 
+function findStructureOffset(uniqueIds, structure) {
+  if (!structure.length)
+    return 0;
+  if (structure.length > uniqueIds.length)
+    return -1;
+
+  const offset = uniqueIds.indexOf(structure[0].id);
+  if (offset < 0 ||
+      offset + structure.length > uniqueIds.length)
+    return -1;
+
+  for (let index = 1; index < structure.length; index++) {
+    if (uniqueIds[offset + index] != structure[index].id)
+      return -1;
+  }
+
+  return offset;
+}
+
 export async function loadTreeStructure(windows, restoredFromCacheResults) {
   log('loadTreeStructure ', restoredFromCacheResults);
   MetricsData.add('loadTreeStructure: start');
@@ -106,8 +124,7 @@ export async function loadTreeStructure(windows, restoredFromCacheResults) {
         uniqueIds = uniqueIds.map(id => id.id);
         let tabsOffset;
         if (structure[0].id) {
-          const structureSignature = toLines(structure, item => item.id);
-          tabsOffset = uniqueIds.join('\n').indexOf(structureSignature);
+          tabsOffset = findStructureOffset(uniqueIds, structure);
           windowStateCompletelyApplied = tabsOffset > -1;
         }
         else {
@@ -115,7 +132,7 @@ export async function loadTreeStructure(windows, restoredFromCacheResults) {
           windowStateCompletelyApplied = structure.length == tabs.length;
         }
         if (tabsOffset > -1) {
-          const structureRestoreTabs = tabs.slice(tabsOffset);
+          const structureRestoreTabs = tabs.slice(tabsOffset, tabsOffset + structure.length);
           await Tree.applyTreeStructureToTabs(structureRestoreTabs, structure);
           for (const tab of structureRestoreTabs) {
             tab.$TST.temporaryMetadata.set('treeStructureAlreadyRestoredFromSessionData', true);


### PR DESCRIPTION
## 概要

セッション復元時に保存済みツリー構造を現在のタブ列へ適用する位置の計算を修正します。

従来は、保存済み構造のタブ ID 列と現在のタブ ID 列を改行区切り文字列に変換し、String#indexOf() の結果を tabs.slice() の開始位置として使っていました。しかし String#indexOf() が返すのは文字列中の文字位置であり、タブ配列中の index ではありません。

この変更では、保存済み構造の先頭 ID を現在のタブ ID 配列から探し、その位置から保存済み構造の ID 列が連続一致するかを確認する findStructureOffset() を導入しました。これを用いることで、元のコードの意図していたと思われるタブ位置を計算することができます。

## 変更内容

- 文字列化した ID 列でのマッチングを廃止
- findStructureOffset() でタブ配列上の offset を直接計算
- 復元済み metadata を付与する対象を、保存済み構造と対応するタブ範囲に限定
