### PR TITLE
Improve English phrasing in en locale

### DIFF
--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -224,7 +224,7 @@
   "syncAvailable_notification_message": { "message": "Tabs can be transferred between your devices. Please click here to set an identifiable name to this device." },
   "syncAvailable_notification_message_linux": { "message": "Tabs can be transferred between your devices. Please click the button to set an identifiable name to this device." },
   "sentTabs_notification_title":            { "message": "\u200b" },
-  "sentTabs_notification_message":          { "message": "Tabs is sent to $DEVICE$",
+  "sentTabs_notification_message":          { "message": "Tab is sent to $DEVICE$",
     "placeholders": {
       "DEVICE": { "content": "$1", "example": "Firefox on Device X" }
     }},
@@ -482,7 +482,7 @@
   "config_suppressGroupTabForStructuredTabsFromBookmarks_label": { "message": "Suppress top-level group tab when opened tabs are already organized as a tree" },
 
   "config_sendTabsToDevice_caption": { "message": "Send Tabs to Other Devices with the context menu via Firefox Sync" },
-  "config_syncRequirements_description": { "message": "This feature depends on Firefox Sync, and tabs can be sent only to devices with TST installed. Please activate Firefox Sync with ther browser's options at first, and install TST to other devices also." },
+  "config_syncRequirements_description": { "message": "This feature depends on Firefox Sync, and tabs can be sent only to devices with TST installed. Please activate Firefox Sync with the browser's options at first, and install TST to other devices also." },
   "config_syncDeviceInfo_name_label": { "message": "Name and icon of this device:" },
   "config_syncDeviceInfo_name_description_before": { "message": "TST cannot detect the name of this device you configured for Firefox Sync, due to restrictions of WebExtensions API. Please set an identifiable name for this device manually. (It is recommended to copy " },
   "config_syncDeviceInfo_name_description_link": { "message": "the device name for Firefox Sync" },
@@ -647,7 +647,7 @@
   "config_tabBunchesDetectionTimeout_after": { "message": "msec, and:" },
   "config_autoGroupNewTabsFromBookmarks_label": { "message": "Group tabs under a tab with a title like \"... and more\"" },
   "config_restoreTreeForTabsFromBookmarks_label": { "message": "Restore tree structure" },
-  "config_requireBookmarksPermission_tooltiptext": { "message": "This feature needs a right to access bookmarks. Click here to request an required permission." },
+  "config_requireBookmarksPermission_tooltiptext": { "message": "This feature needs a right to access bookmarks. Click here to request a required permission." },
   "config_requestPermissions_bookmarks_autoGroupNewTabs_before": { "message": "(" },
   "config_requestPermissions_bookmarks_autoGroupNewTabs_after": { "message": "Allow to detect bookmarks corresponding to tabs)" },
   "config_tabsFromSameFolderMinThresholdPercentage_before": { "message": "Treat all new tabs as opened from one bookmark folder, if over " },
@@ -693,7 +693,7 @@
   "config_autoCollapseExpandSubtreeOnSelectExceptActiveTabRemove_label": { "message": "Except focus moving caused by closing of the current tab" },
   "config_unfocusableCollapsedTab_label": { "message": "When a tab under a collapsed tree gets focus, expand its tree automatically" },
   "config_expandNativeTabGroupByMemberTreeExpansion_label": { "message": "When a tree under a collapsed native tab group is expanded, expand the group also" },
-  "config_autoDiscardTabForUnexpectedFocus_label": { "message": "Keep tabs pending (unloaded) when tabs are accidentaly focused and the focus is redirected immediately" },
+  "config_autoDiscardTabForUnexpectedFocus_label": { "message": "Keep tabs pending (unloaded) when tabs are accidentally focused and the focus is redirected immediately" },
   "config_avoidDiscardedTabToBeActivatedIfPossible_label": { "message": "Avoid pending (unloaded) tabs to be activated accidentally on current tab closes or tree collapsing" },
   "config_avoidDiscardedTabToBeActivatedExceptGroupTabs_label": { "message": "Except group tabs" },
 
@@ -774,7 +774,7 @@
   "config_tabDragBehavior_detachSoloTabIfExpanded":      { "message": "Detach Solo Tab if expanded or Entire Tree if collapsed, from the window (but impossible to create bookmark)" },
   "config_tabDragBehavior_bookmarkSoloTabIfExpanded":    { "message": "Create link or bookmark from Solo Tab if expanded or Entire Tree if collapsed (but impossible to detach from the window)" },
   "config_tabDragBehavior_doNothing":                    { "message": "Do nothing" },
-  "config_tabDragBehavior_noteForDragstartOutsideSidebar": { "message": "When a parent tabs is dragged from the browser's native tab bar, it will behave according to the section \"Tree Behavior\" => \"When a parent tab is Closed or Moved\"." },
+  "config_tabDragBehavior_noteForDragstartOutsideSidebar": { "message": "When a parent tab is dragged from the browser's native tab bar, it will behave according to the section \"Tree Behavior\" => \"When a parent tab is Closed or Moved\"." },
   "config_showTabDragBehaviorNotification_label": { "message": "Show notification about what will happen on tabs dropped outside the sidebar, while tab dragging." },
   "config_enlargeDropAreaToCreateNewGroupWithShiftKey_label":       { "message": "Create New Tab Group instead of attaching, by Shift-dragging/dropping tabs onto another tab" },
   "config_enlargeDropAreaToCreateNewGroupWithShiftKey_description": { "message": "(*You still can create New Tab Group by dragging with disabled this option, with dropping tabs onto horizontal head area of another tab.)" },
@@ -870,7 +870,7 @@
   "helper_theme_list_link_uri": { "message": "https://github.com/piroor/treestyletab/wiki/Code-snippets-for-custom-style-rules#restore-old-built-in-themes" },
 
   "config_externaladdonpermissions_label": { "message": "Permissions for API Call from Other Extensions" },
-  "config_externaladdonpermissions_description": { "message": "Extensions allowed here may access detailed tab data or tabs in private windows, <em>through Tree Style Tab's permissions</em>, even if the extension ifself is forbidden by the browser to access them. <em>Please don't give permission for extensions if you cannot trust them.</em>" },
+  "config_externaladdonpermissions_description": { "message": "Extensions allowed here may access detailed tab data or tabs in private windows, <em>through Tree Style Tab's permissions</em>, even if the extension itself is forbidden by the browser to access them. <em>Please don't give permission for extensions if you cannot trust them.</em>" },
   "config_externalAddonPermissions_header_name": { "message": "Extension Name" },
   "config_externalAddonPermissions_header_permissions": { "message": "Allowed Special Operations" },
   "config_externalAddonPermissions_header_incognito": { "message": "Notify Messages from Private Windows" },

--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -256,7 +256,7 @@
       "REST": { "content": "$3", "example": "3" }
     }},
 
-  "sidebarPositionInvertedNotification_message":   { "message": "TST detected the sidebar position as \"Inverted Side\". Do you want the appearance to be switched to the one matching to the current position?" },
+  "sidebarPositionInvertedNotification_message":   { "message": "TST detected the sidebar position as \"Inverted Side\". Do you want the appearance to be switched to the one matching the current position?" },
   "sidebarPositionInvertedNotification_inverted": { "message": "Apply appearance for Inverted Side" },
   "sidebarPositionInvertedNotification_regular":  { "message": "Keep appearance for Regular Side" },
 
@@ -274,7 +274,7 @@
   "message_startup_description_key": { "message": "\"F1\" key" },
   "message_startup_description_2": { "message": " or click the " },
   "message_startup_description_3": { "message": " button in the toolbar, to activate the sidebar panel." },
-  "message_startup_description_sync_before": { "message": "Tabs can be sent via Firefox Sync only to devices with TST installed. Please activate Firefox Sync with Firefox's options at first, and install TST to other devices also. Moreover," },
+  "message_startup_description_sync_before": { "message": "Tabs can be sent via Firefox Sync only to devices with TST installed. Please activate Firefox Sync in Firefox's options first, and install TST on your other devices as well. Moreover," },
   "message_startup_description_sync_link":   { "message": "the device name should be configured manually" },
   "message_startup_description_sync_after":  { "message": "." },
 
@@ -482,7 +482,7 @@
   "config_suppressGroupTabForStructuredTabsFromBookmarks_label": { "message": "Suppress top-level group tab when opened tabs are already organized as a tree" },
 
   "config_sendTabsToDevice_caption": { "message": "Send Tabs to Other Devices with the context menu via Firefox Sync" },
-  "config_syncRequirements_description": { "message": "This feature depends on Firefox Sync, and tabs can be sent only to devices with TST installed. Please activate Firefox Sync with the browser's options at first, and install TST to other devices also." },
+  "config_syncRequirements_description": { "message": "This feature depends on Firefox Sync, and tabs can be sent only to devices with TST installed. Please activate Firefox Sync in the browser's options first, and install TST on your other devices as well." },
   "config_syncDeviceInfo_name_label": { "message": "Name and icon of this device:" },
   "config_syncDeviceInfo_name_description_before": { "message": "TST cannot detect the name of this device you configured for Firefox Sync, due to restrictions of WebExtensions API. Please set an identifiable name for this device manually. (It is recommended to copy " },
   "config_syncDeviceInfo_name_description_link": { "message": "the device name for Firefox Sync" },
@@ -647,7 +647,7 @@
   "config_tabBunchesDetectionTimeout_after": { "message": "msec, and:" },
   "config_autoGroupNewTabsFromBookmarks_label": { "message": "Group tabs under a tab with a title like \"... and more\"" },
   "config_restoreTreeForTabsFromBookmarks_label": { "message": "Restore tree structure" },
-  "config_requireBookmarksPermission_tooltiptext": { "message": "This feature needs a right to access bookmarks. Click here to request a required permission." },
+  "config_requireBookmarksPermission_tooltiptext": { "message": "This feature needs permission to access bookmarks. Click here to request the required permission." },
   "config_requestPermissions_bookmarks_autoGroupNewTabs_before": { "message": "(" },
   "config_requestPermissions_bookmarks_autoGroupNewTabs_after": { "message": "Allow to detect bookmarks corresponding to tabs)" },
   "config_tabsFromSameFolderMinThresholdPercentage_before": { "message": "Treat all new tabs as opened from one bookmark folder, if over " },


### PR DESCRIPTION
Follow-up to #3941. That PR fixes outright typos; this one is purely about English phrasing, so it is separate and entirely optional — please feel free to close it if you prefer the current wording.

| Key | Before | After |
|---|---|---|
| `sidebarPositionInvertedNotification_message` | "the one **matching to** the current position" | "the one matching the current position" |
| `message_startup_description_sync_before` | "activate Firefox Sync **with** Firefox's options **at first**, and install TST **to** other devices **also**" | "activate Firefox Sync in Firefox's options first, and install TST on your other devices as well" |
| `config_syncRequirements_description` | same phrasing as above, with "the browser's options" | same correction as above |
| `config_requireBookmarksPermission_tooltiptext` | "This feature needs **a right to** access bookmarks. Click here to request **a** required permission." | "This feature needs permission to access bookmarks. Click here to request the required permission." |

Notes on the individual changes:

- **"matching to"** — "matching" takes a direct object in English; the preposition is not used here.
- **"at first"** — this means "initially, but not later" (as in "at first I thought…"). For "before anything else", English uses "first".
- **"install TST to other devices"** — software is installed *on* a device.
- **"needs a right to access"** — grammatical, but "right" is a legal term in English. For browser permissions the idiomatic word is "permission", which also matches the wording used elsewhere in the locale.

### Verification

- The file parses as JSON and the key count is unchanged (813).
- The key set is identical to `trunk`, so no translation is orphaned. No other locale files are touched.
- Only these four `message` values differ from #3941.

Since GitHub cannot base a cross-fork PR on another fork's branch, this PR is stacked on #3941 and its diff currently shows both commits. Once #3941 is merged this will reduce to the four changes above on its own — happy to rebase at any point, or to squash both into a single PR if you would rather review them together.
